### PR TITLE
Constructor typing

### DIFF
--- a/bin/smoke_runner.rb
+++ b/bin/smoke_runner.rb
@@ -93,9 +93,13 @@ ARGV.each do |arg|
 
   unless lines.empty?
     lines.each do |line|
-      puts Rainbow("  🤦‍♀️ Unexpected error found: #{line}").red
+      if line =~ /:\d+:\d+:/
+        puts Rainbow("  🤦‍♀️ Unexpected error found: #{line}").red
+        failed = true
+      else
+        puts Rainbow("  🤦 Unexpected error found, but ignored: #{line}").yellow
+      end
     end
-    failed = true
   end
 end
 

--- a/lib/steep/interface.rb
+++ b/lib/steep/interface.rb
@@ -232,14 +232,19 @@ module Steep
     class Method
       attr_reader :super_method
       attr_reader :types
+      attr_reader :attributes
 
-      def initialize(types:, super_method:)
+      def initialize(types:, super_method:, attributes:)
         @types = types
         @super_method = super_method
+        @attributes = attributes
       end
 
       def ==(other)
-        other.is_a?(Method) && other.types == types && other.super_method == super_method
+        other.is_a?(Method) &&
+          other.types == types &&
+          other.super_method == super_method &&
+          other.attributes == attributes
       end
 
       def closed?

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -123,11 +123,14 @@ class_member: instance_method_member { result = val[0] }
             | include_member { result = val[0] }
             | extend_member { result = val[0] }
 
-instance_method_member: DEF method_name COLON method_type_union { result = Signature::Members::InstanceMethod.new(name: val[1], types: val[3]) }
-class_method_member: DEF SELF DOT method_name COLON method_type_union { result = Signature::Members::ModuleMethod.new(name: val[3], types: val[5]) }
-class_instance_method_member: DEF SELFQ DOT method_name COLON method_type_union { result = Signature::Members::ModuleInstanceMethod.new(name: val[3], types: val[5]) }
+instance_method_member: DEF constructor_method method_name COLON method_type_union { result = Signature::Members::InstanceMethod.new(name: val[2], types: val[4], constructor: val[1]) }
+class_method_member: DEF constructor_method SELF DOT method_name COLON method_type_union { result = Signature::Members::ModuleMethod.new(name: val[4], types: val[6], constructor: val[1]) }
+class_instance_method_member: DEF constructor_method SELFQ DOT method_name COLON method_type_union { result = Signature::Members::ModuleInstanceMethod.new(name: val[4], types: val[6], constructor: val[1]) }
 include_member: INCLUDE type { result = Signature::Members::Include.new(name: val[1]) }
 extend_member: EXTEND type { result = Signature::Members::Extend.new(name: val[1]) }
+
+constructor_method: { result = false }
+                  | LPAREN CONSTRUCTOR RPAREN { result = true }
 
 super_opt: { result = nil }
          | LTCOLON type { result = val[1] }

--- a/lib/steep/signature/class.rb
+++ b/lib/steep/signature/class.rb
@@ -327,6 +327,11 @@ module Steep
                                                     params.map {|x| Types::Var.new(name: x) })
 
         validate_mixins(assignability, interface)
+
+        # FIXME: There is no check for initializer compatibility
+        if interface.methods.values.any? {|method| method.attributes.include?(:constructor) }
+          assignability.errors << Signature::Errors::ConstructorNoCheck.new(signature: self)
+        end
       end
 
       def is_class?
@@ -419,7 +424,8 @@ module Steep
         end
 
         interface = assignability.resolve_interface(TypeName::Instance.new(name: name),
-                                                    params.map {|x| Types::Var.new(name: x) })
+                                                    params.map {|x| Types::Var.new(name: x) },
+                                                    constructor: true)
 
         interface.methods.each_key do |method_name|
           method = interface.methods[method_name]
@@ -429,6 +435,11 @@ module Steep
         end
 
         validate_mixins(assignability, interface)
+
+        # FIXME: There is no check for initializer compatibility
+        if interface.methods.values.any? {|method| method.attributes.include?(:constructor) }
+          assignability.errors << Signature::Errors::ConstructorNoCheck.new(signature: self)
+        end
       end
 
       def is_class?

--- a/lib/steep/signature/class.rb
+++ b/lib/steep/signature/class.rb
@@ -9,13 +9,16 @@ module Steep
         # @dynamic types
         attr_reader :types
 
-        def initialize(name:, types:)
+        attr_reader :constructor
+
+        def initialize(name:, types:, constructor:)
           @name = name
           @types = types
+          @constructor = constructor
         end
 
         def ==(other)
-          other.is_a?(self.class) && other.name == name && other.types == types
+          other.is_a?(self.class) && other.name == name && other.types == types && other.constructor == constructor
         end
       end
 
@@ -26,14 +29,16 @@ module Steep
         attr_reader :name
         # @dynamic types
         attr_reader :types
+        attr_reader :constructor
 
-        def initialize(name:, types:)
+        def initialize(name:, types:, constructor:)
           @name = name
           @types = types
+          @constructor = constructor
         end
 
         def ==(other)
-          other.is_a?(self.class) && other.name == name && other.types == types
+          other.is_a?(self.class) && other.name == name && other.types == types && other.constructor == constructor
         end
       end
 
@@ -44,14 +49,16 @@ module Steep
         attr_reader :name
         # @dynamic types
         attr_reader :types
+        attr_reader :constructor
 
-        def initialize(name:, types:)
+        def initialize(name:, types:, constructor:)
           @name = name
           @types = types
+          @constructor = constructor
         end
 
         def ==(other)
-          other.is_a?(self.class) && other.name == name && other.types == types
+          other.is_a?(self.class) && other.name == name && other.types == types && other.constructor == constructor
         end
       end
 

--- a/lib/steep/signature/class.rb
+++ b/lib/steep/signature/class.rb
@@ -127,7 +127,7 @@ module Steep
         methods
       end
 
-      def module_methods(assignability:, klass:, instance:, params:)
+      def module_methods(assignability:, klass:, instance:, params:, constructor:)
         methods = super
 
         members.each do |member|
@@ -137,7 +137,8 @@ module Steep
             merge_methods(methods, module_signature.module_methods(assignability: assignability,
                                                                    klass: klass,
                                                                    instance: instance,
-                                                                   params: module_signature.type_application_hash(member.name.params)))
+                                                                   params: module_signature.type_application_hash(member.name.params),
+                                                                   constructor: constructor))
           when Members::Extend
             module_signature = assignability.lookup_included_signature(member.name)
             merge_methods(methods, module_signature.instance_methods(assignability: assignability,
@@ -157,7 +158,7 @@ module Steep
           end
         end
 
-        if is_class?
+        if is_class? && constructor
           instance_methods = instance_methods(assignability: assignability, klass: klass, instance: instance, params: params)
           new_method = if instance_methods[:initialize]
                          types = instance_methods[:initialize].types.map do |method_type|
@@ -280,7 +281,7 @@ module Steep
         {}
       end
 
-      def module_methods(assignability:, klass:, instance:, params:)
+      def module_methods(assignability:, klass:, instance:, params:, constructor:)
         {}
       end
 
@@ -354,7 +355,7 @@ module Steep
         end
       end
 
-      def module_methods(assignability:, klass:, instance:, params:)
+      def module_methods(assignability:, klass:, instance:, params:, constructor:)
         signature = assignability.lookup_class_signature(Types::Name.instance(name: :Class))
         class_methods = signature.instance_methods(assignability: assignability,
                                                    klass: klass,
@@ -371,7 +372,11 @@ module Steep
             type.substitute(klass: klass, instance: instance, params: hash)
           end
 
-          class_methods.merge!(signature.module_methods(assignability: assignability, klass: klass, instance: instance, params: super_class_params))
+          class_methods.merge!(signature.module_methods(assignability: assignability,
+                                                        klass: klass,
+                                                        instance: instance,
+                                                        params: super_class_params,
+                                                        constructor: constructor))
         end
       end
 

--- a/lib/steep/signature/errors.rb
+++ b/lib/steep/signature/errors.rb
@@ -94,6 +94,12 @@ module Steep
           io.puts "UnexpectedTypeNameKind: signature=#{signature.name}, type=#{type}, kind=#{expected_kind}"
         end
       end
+
+      class ConstructorNoCheck < Base
+        def puts(io)
+          io.puts "ConstructorNoCheck: signature=#{signature.name}"
+        end
+      end
     end
   end
 end

--- a/lib/steep/signature/interface.rb
+++ b/lib/steep/signature/interface.rb
@@ -37,7 +37,7 @@ module Steep
                                types = method.map {|method_type|
                                  method_type.substitute(klass: klass, instance: instance, params: map)
                                }
-                               Steep::Interface::Method.new(types: types, super_method: nil)
+                               Steep::Interface::Method.new(types: types, super_method: nil, attributes: [])
                              })
       end
 

--- a/lib/steep/type_assignability.rb
+++ b/lib/steep/type_assignability.rb
@@ -229,7 +229,7 @@ module Steep
         signatures[name.name].to_interface(klass: klass, instance: instance, params: params)
       when TypeName::Instance
         methods = signatures[name.name].instance_methods(assignability: self, klass: klass, instance: instance, params: params)
-        Interface.new(name: name, params: params, methods: methods)
+        Interface.new(name: name, params: params, methods: methods.reject {|key, _| key == :initialize })
       when TypeName::Module
         methods = signatures[name.name].module_methods(assignability: self, klass: klass, instance: instance, params: params, constructor: constructor)
         Interface.new(name: name, params: params, methods: methods)

--- a/lib/steep/type_assignability.rb
+++ b/lib/steep/type_assignability.rb
@@ -216,7 +216,7 @@ module Steep
       test(src: dest.return_type, dest: src.return_type, known_pairs: known_pairs)
     end
 
-    def resolve_interface(name, params, klass: nil, instance: nil)
+    def resolve_interface(name, params, klass: nil, instance: nil, constructor: nil)
       klass ||= Types::Name.module(name: name.name, params: params)
       instance ||= Types::Name.instance(name: name.name, params: params)
 
@@ -227,7 +227,7 @@ module Steep
         methods = signatures[name.name].instance_methods(assignability: self, klass: klass, instance: instance, params: params)
         Interface.new(name: name, params: params, methods: methods)
       when TypeName::Module
-        methods = signatures[name.name].module_methods(assignability: self, klass: klass, instance: instance, params: params)
+        methods = signatures[name.name].module_methods(assignability: self, klass: klass, instance: instance, params: params, constructor: constructor)
         Interface.new(name: name, params: params, methods: methods)
       else
         raise "Unexpected type name: #{name.inspect}"
@@ -284,7 +284,8 @@ module Steep
         }
         method = methods[name]
       when Types::Name
-        interface = resolve_interface(type.name, type.params)
+        constructor = type.name.is_a?(TypeName::Module) && type.name.constructor
+        interface = resolve_interface(type.name, type.params, constructor: constructor)
         method = interface.methods[name]
       else
         raise "Unexpected type: #{type}"

--- a/lib/steep/type_assignability.rb
+++ b/lib/steep/type_assignability.rb
@@ -140,7 +140,7 @@ module Steep
             assigning_pairs << [src.rest, dest_type.last]
           end
         end
-      when src.required.size + src.optional.size >= dest.required.size + dest.optional.size && !src.rest
+      when src.required.size + src.optional.size >= dest.required.size + dest.optional.size
         while src_flat.size > 0
           src_type = src_flat.shift
           dest_type = dest_flat.shift
@@ -148,7 +148,11 @@ module Steep
           if dest_type
             assigning_pairs << [src_type.last, dest_type.last]
           else
-            break
+            if src_type.first == :required
+              return false
+            else
+              break
+            end
           end
         end
       else

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -89,7 +89,7 @@ module Steep
       end
 
       if (type = annotations.lookup_method_type(method_name))
-        Interface::Method.new(types: [type], super_method: entry&.super_method)
+        Interface::Method.new(types: [type], super_method: entry&.super_method, attributes: [])
       else
         entry
       end
@@ -113,14 +113,7 @@ module Steep
       end
 
       # FIXME: reading signature directory does not look good...
-      constructor_method = if annotations.implement_module
-                             signature = assignability.signatures[annotations.implement_module]
-                             signature&.members&.find do |member|
-                               if member.is_a?(Signature::Members::InstanceMethod) || member.is_a?(Signature::Members::ModuleMethod) || member.is_a?(Signature::Members::ModuleInstanceMethod)
-                                 member.name == method_name
-                               end
-                             end&.constructor
-                           end
+      constructor_method = entry&.attributes&.include?(:constructor)
 
       method_context = MethodContext.new(
         name: method_name,

--- a/lib/steep/type_name.rb
+++ b/lib/steep/type_name.rb
@@ -50,6 +50,16 @@ module Steep
       def ==(other)
         other.is_a?(self.class) && other.name == name && other.constructor == constructor
       end
+
+      NOTHING = Object.new
+
+      def updated(constructor: NOTHING)
+        if NOTHING == constructor
+          constructor = self.constructor
+        end
+
+        self.class.new(name: name, constructor: constructor)
+      end
     end
 
     class Instance < Base; end

--- a/lib/steep/type_name.rb
+++ b/lib/steep/type_name.rb
@@ -27,8 +27,28 @@ module Steep
     class Interface < Base; end
 
     class Module < Base
+      attr_reader :constructor
+
       def to_s
-        "#{name}.module"
+        k = case constructor
+            when nil
+              ""
+            when true
+              " constructor"
+            when false
+              " noconstructor"
+            end
+
+        "#{name}.module#{k}"
+      end
+
+      def initialize(name:, constructor:)
+        super(name: name)
+        @constructor = constructor
+      end
+
+      def ==(other)
+        other.is_a?(self.class) && other.name == name && other.constructor == constructor
       end
     end
 

--- a/lib/steep/types/name.rb
+++ b/lib/steep/types/name.rb
@@ -21,8 +21,8 @@ module Steep
         self.new(name: TypeName::Interface.new(name: name), params: params)
       end
 
-      def self.module(name:, params: [])
-        self.new(name: TypeName::Module.new(name: name), params: params)
+      def self.module(name:, params: [], constructor: nil)
+        self.new(name: TypeName::Module.new(name: name, constructor: constructor), params: params)
       end
 
       def self.instance(name:, params: [])

--- a/smoke/class/a.rbi
+++ b/smoke/class/a.rbi
@@ -7,3 +7,8 @@ end
 class B
   def name: -> String
 end
+
+class C
+  def (constructor) foo: -> instance
+  def bar: -> instance
+end

--- a/smoke/class/a.rbi
+++ b/smoke/class/a.rbi
@@ -12,3 +12,13 @@ class C
   def (constructor) foo: -> instance
   def bar: -> instance
 end
+
+class D
+  def initialize: (String) -> any
+  def foo: -> any
+end
+
+class E
+  def initialize: () -> any
+  def foo: -> any
+end

--- a/smoke/class/d.rb
+++ b/smoke/class/d.rb
@@ -1,0 +1,9 @@
+# @type const A: A.class
+# @type const B: A.class constructor
+# @type const C: A.class noconstructor
+
+# !expects NoMethodError: type=A.module, method=new
+a = A.new
+b = B.new
+# !expects NoMethodError: type=A.module noconstructor, method=new
+c = C.new

--- a/smoke/class/e.rb
+++ b/smoke/class/e.rb
@@ -1,0 +1,12 @@
+class C
+  # @implements C
+
+  def foo
+    self.class.new
+  end
+
+  def bar
+    # !expects NoMethodError: type=C.module noconstructor, method=new
+    self.class.new
+  end
+end

--- a/smoke/class/f.rb
+++ b/smoke/class/f.rb
@@ -1,0 +1,8 @@
+# @type var e: E
+# @type var d: D
+
+e = nil
+d = nil
+
+e = d
+d = e

--- a/smoke/initialize/a.rb
+++ b/smoke/initialize/a.rb
@@ -1,0 +1,12 @@
+class A
+  # @implements A
+
+  def initialize()
+    
+  end
+
+  def foo()
+    # !expects NoMethodError: type=A, method=initialize
+    initialize()
+  end
+end

--- a/smoke/initialize/a.rbi
+++ b/smoke/initialize/a.rbi
@@ -1,0 +1,3 @@
+class A
+  def initialize: () -> any
+end

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -24,7 +24,6 @@ class Module
 end
 
 class Class<'instance> <: Module
-  def new: -> 'instance
   def allocate: -> 'instance
   def tap: { (any) -> any } -> any
   def class: -> any

--- a/test/signature_class_test.rb
+++ b/test/signature_class_test.rb
@@ -224,4 +224,39 @@ end
 
     assert_equal [:Pathname], methods.keys
   end
+
+  def test_interface_with_constructor
+    assignability = new_assignability(<<-SRC)
+class BasicObject
+end
+
+class Object <: BasicObject
+end
+
+class A
+  def (constructor) foo: (BasicObject) -> any
+end
+
+class B <: A
+  def foo: (any) -> any
+end
+    SRC
+
+    a_methods = assignability.signatures[:A].instance_methods(assignability: assignability,
+                                                            klass: Types::Name.module(name: :A),
+                                                            instance: Types::Name.instance(name: :A),
+                                                            params: [])
+
+    assert_equal [:foo], a_methods.keys
+    assert_equal [:constructor], a_methods[:foo].attributes
+
+
+    b_methods = assignability.signatures[:B].instance_methods(assignability: assignability,
+                                                              klass: Types::Name.module(name: :B),
+                                                              instance: Types::Name.instance(name: :B),
+                                                              params: [])
+
+    assert_equal [:foo], b_methods.keys
+    assert_equal [:constructor], b_methods[:foo].attributes
+  end
 end

--- a/test/signature_class_test.rb
+++ b/test/signature_class_test.rb
@@ -259,4 +259,45 @@ end
     assert_equal [:foo], b_methods.keys
     assert_equal [:constructor], b_methods[:foo].attributes
   end
+
+  def test_instance_new_override_without_constructor
+    assignability = new_assignability(<<-SRC)
+class BasicObject
+end
+
+class Object <: BasicObject
+end
+
+class A
+  def initialize: () -> any
+end
+
+class B <: A
+  def initialize: (any) -> any
+end
+    SRC
+
+    assert_empty assignability.errors
+  end
+
+  def test_instance_new_override_with_constructor
+    assignability = new_assignability(<<-SRC)
+class BasicObject
+end
+
+class Object <: BasicObject
+end
+
+class A
+  def initialize: () -> any
+  def (constructor) makeCopy: () -> instance
+end
+
+class B <: A
+  def initialize: (any) -> any
+end
+    SRC
+
+    refute_empty assignability.errors
+  end
 end

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -17,21 +17,43 @@ class C<'a> <: Object
   def class: () -> class
   def self.g: () -> C
   def self?.h: () -> C.class
+  def (constructor) foobar: -> any
+  def constructor: -> any
 end
     EOS
 
     assert_instance_of Steep::Signature::Class, klass
     assert_equal :C, klass.name
-    assert_equal 6, klass.members.size
+    assert_equal 8, klass.members.size
     assert_equal Steep::Types::Name.instance(name: :Object), klass.super_class
     assert_equal [:a], klass.params
 
     assert_equal Steep::Signature::Members::Include.new(name: Steep::Types::Name.instance(name: :M1)), klass.members[0]
     assert_equal Steep::Signature::Members::Extend.new(name: Steep::Types::Name.instance(name: :M2)), klass.members[1]
-    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :itself, types: [parse_method_type("() -> instance")]), klass.members[2]
-    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :class, types: [parse_method_type("() -> class")]), klass.members[3]
-    assert_equal Steep::Signature::Members::ModuleMethod.new(name: :g, types: [parse_method_type("() -> C")]), klass.members[4]
-    assert_equal Steep::Signature::Members::ModuleInstanceMethod.new(name: :h, types: [parse_method_type("() -> C.class")]), klass.members[5]
+    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :itself,
+                                                               types: [parse_method_type("() -> instance")],
+                                                               constructor: false),
+                 klass.members[2]
+    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :class,
+                                                               types: [parse_method_type("() -> class")],
+                                                               constructor: false),
+                 klass.members[3]
+    assert_equal Steep::Signature::Members::ModuleMethod.new(name: :g,
+                                                             types: [parse_method_type("() -> C")],
+                                                             constructor: false),
+                 klass.members[4]
+    assert_equal Steep::Signature::Members::ModuleInstanceMethod.new(name: :h,
+                                                                     types: [parse_method_type("() -> C.class")],
+                                                                     constructor: false),
+                 klass.members[5]
+    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :foobar,
+                                                               types: [parse_method_type("() -> any")],
+                                                               constructor: true),
+                 klass.members[6]
+    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :constructor,
+                                                               types: [parse_method_type("() -> any")],
+                                                               constructor: false),
+                 klass.members[7]
   end
 
   def test_parsing_module
@@ -55,10 +77,14 @@ end
 
     assert_equal Steep::Signature::Members::Include.new(name: Steep::Types::Name.instance(name: :M1)), mod.members[0]
     assert_equal Steep::Signature::Members::Extend.new(name: Steep::Types::Name.instance(name: :M2)), mod.members[1]
-    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :itself, types: [parse_method_type("() -> instance")]), mod.members[2]
-    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :class, types: [parse_method_type("() -> class")]), mod.members[3]
-    assert_equal Steep::Signature::Members::ModuleMethod.new(name: :g, types: [parse_method_type("() -> C")]), mod.members[4]
-    assert_equal Steep::Signature::Members::ModuleInstanceMethod.new(name: :h, types: [parse_method_type("() -> C.class")]), mod.members[5]
+    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :itself, types: [parse_method_type("() -> instance")], constructor: false),
+                 mod.members[2]
+    assert_equal Steep::Signature::Members::InstanceMethod.new(name: :class, types: [parse_method_type("() -> class")], constructor: false),
+                 mod.members[3]
+    assert_equal Steep::Signature::Members::ModuleMethod.new(name: :g, types: [parse_method_type("() -> C")], constructor: false),
+                 mod.members[4]
+    assert_equal Steep::Signature::Members::ModuleInstanceMethod.new(name: :h, types: [parse_method_type("() -> C.class")], constructor: false),
+                 mod.members[5]
   end
 
   def test_parsing_module2
@@ -127,7 +153,8 @@ end
       members: [
         Steep::Signature::Members::InstanceMethod.new(
           name: :Pathname,
-          types: [parse_method_type("(String) -> Pathname")]
+          types: [parse_method_type("(String) -> Pathname")],
+          constructor: false
         )
       ]), signature
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,9 +21,9 @@ module TestHelper
     Steep::Parser.parse_method(string)
   end
 
-  def parse_single_method(string, super_method: nil)
+  def parse_single_method(string, super_method: nil, attributes: [])
     type = Steep::Parser.parse_method(string)
-    Steep::Interface::Method.new(types: [type], super_method: super_method)
+    Steep::Interface::Method.new(types: [type], super_method: super_method, attributes: attributes)
   end
 end
 

--- a/test/type_assignability_test.rb
+++ b/test/type_assignability_test.rb
@@ -578,4 +578,37 @@ end
       dest: T::Name.instance(name: :B, params: [T::Name.instance(name: :String)])
     )
   end
+
+  def test_initialize_compatibility
+    assignability = Steep::TypeAssignability.new do |a|
+      parse_signature(<<-SRC) do |sig|
+class BasicObject
+end
+
+class Object <: BasicObject
+end
+
+class A
+  def initialize: () -> any
+end
+
+class B <: A
+  def initialize: (any) -> any
+end
+SRC
+        a.add_signature sig
+      end
+    end
+
+    assert_empty assignability.errors
+
+    a = assignability.resolve_interface(Steep::TypeName::Instance.new(name: :A), [])
+    assert_empty a.methods
+
+    b = assignability.resolve_interface(Steep::TypeName::Instance.new(name: :B), [])
+    assert_empty b.methods
+
+    assert assignability.test(src: T::Name.instance(name: :A), dest: T::Name.instance(name: :B))
+    assert assignability.test(src: T::Name.instance(name: :B), dest: T::Name.instance(name: :A))
+  end
 end

--- a/test/type_parsing_test.rb
+++ b/test/type_parsing_test.rb
@@ -15,12 +15,30 @@ class TypeParsingTest < Minitest::Test
 
   def test_class
     type = parse_method_type("() -> Foo.class").return_type
-    assert_equal Steep::Types::Name.new(name: Steep::TypeName::Module.new(name: :Foo), params: []), type
+    assert_equal Steep::Types::Name.new(name: Steep::TypeName::Module.new(name: :Foo, constructor: nil),
+                                        params: []),
+                 type
   end
 
   def test_module
     type = parse_method_type("() -> Foo.module").return_type
-    assert_equal Steep::Types::Name.new(name: Steep::TypeName::Module.new(name: :Foo), params: []), type
+    assert_equal Steep::Types::Name.new(name: Steep::TypeName::Module.new(name: :Foo, constructor: nil),
+                                        params: []),
+                 type
+  end
+
+  def test_module_constructor
+    type = parse_method_type("() -> Foo.module constructor").return_type
+    assert_equal Steep::Types::Name.new(name: Steep::TypeName::Module.new(name: :Foo, constructor: true),
+                                        params: []),
+                 type
+  end
+
+  def test_module_noconstructor
+    type = parse_method_type("() -> Foo.module constructor").return_type
+    assert_equal Steep::Types::Name.new(name: Steep::TypeName::Module.new(name: :Foo, constructor: true),
+                                        params: []),
+                 type
   end
 
   def test_type_var


### PR DESCRIPTION
In Ruby, object instantiation is done by a normal method call to `new`. This prevents subtyping relations from holding between any two classes which do not have compatible `initialize` types.

The following is an example: `B.class` is not a subtype of `A.class`, and `B` is not a subtype of `A` because of `Object#class`.

```
class A
  def initialize: (Integer) -> any
end

class B <: A
  def initialize: (String) -> any
end
```

Clearly, this does not match with the intuition of most Rubyists.

To fix this issue, we would like to introduce an idea of *constructor*.

* Class types can be attributed with `constructor` or `noconstructor` keywords
  * `constructor` class types have `.new` method
  * `noconstructor` class types do not have `.new` method
* Method definitions can be attributed with `(constructor)` keyword
  * In `(constructor)` methods, `self.class` nodes have `T.class constructor` type
  * In non `(constructor)` methods, `self.class` nodes have `T.class noconstructor` type

## Example

```
class A
  def (constructor) foo: -> instance
  def bar: -> instance
end
```

```rb
class A
  # @implements A

  def foo
    self.class.new
  end

  def bar
    self.class.new   # type error: A.class noconstructor does not have #new method
  end
end
```

# ToDo

* [x] Type parsing
* [x] Implement `(constructor)` typing
* [x] Hide `initialize` from instance type
* [ ] <s>Implement `initialize` method type compatibility validation if the class has `(constructor)` methods</s> (Skip)
