### PR TITLE
Auto implements

### DIFF
--- a/lib/steep/ast/annotation.rb
+++ b/lib/steep/ast/annotation.rb
@@ -49,20 +49,37 @@ module Steep
       class IvarType < Named; end
 
       class Implements
-        attr_reader :location
-        attr_reader :module_name
-        attr_reader :module_args
+        class Module
+          attr_reader :name
+          attr_reader :args
 
-        def initialize(module_name:, module_args:, location:)
+          def initialize(name:, args:)
+            @name = name
+            @args = args
+          end
+
+          def ==(other)
+            other.is_a?(Module) && other.name == name && other.args == args
+          end
+
+          alias eql? ==
+
+          def hash
+            self.class.hash ^ name.hash ^ args.hash
+          end
+        end
+
+        attr_reader :location
+        attr_reader :name
+
+        def initialize(name:, location:)
           @location = location
-          @module_name = module_name
-          @module_args = module_args
+          @name = name
         end
 
         def ==(other)
           other.is_a?(Implements) &&
-            other.module_name == module_name &&
-            other.module_args == module_args &&
+            other.name == name &&
             other.location == location
         end
       end

--- a/lib/steep/ast/signature/env.rb
+++ b/lib/steep/ast/signature/env.rb
@@ -78,6 +78,14 @@ module Steep
           classes.key?(name)
         end
 
+        def class_name?(name, current_module: nil)
+          classes.key?(current_module ? current_module + name : name.absolute!)
+        end
+
+        def module_name?(name, current_module: nil)
+          modules.key?(current_module ? current_module + name : name.absolute!)
+        end
+
         def each(&block)
           if block_given?
             classes.each_value(&block)

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -75,7 +75,8 @@ module Steep
               module_context: TypeConstruction::ModuleContext.new(
                 instance_type: nil,
                 module_type: nil,
-                const_types: annotations.const_types
+                const_types: annotations.const_types,
+                implement_name: nil
               ),
               method_context: nil,
               typing: typing,

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -64,7 +64,7 @@ module Steep
             location: type.location
           )
         when AST::Types::Intersection
-          AST::Types::Union.new(
+          AST::Types::Intersection.new(
             types: type.types.map {|ty| absolute_type(ty, current: current) },
             location: type.location
           )

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -416,13 +416,11 @@ annotation: AT_TYPE VAR subject COLON type {
               loc = val.first.location + val.last.location
               result = AST::Annotation::IvarType.new(name: val[2].value, type: val[4], location: loc)
             }
-          | AT_IMPLEMENTS module_name {
-              loc = val.first.location + val.last.location
-              result = AST::Annotation::Implements.new(module_name: val[1].value, location: loc, module_args: [])
-            }
-          | AT_IMPLEMENTS module_name LT type_seq GT {
-              loc = val.first.location + val.last.location
-              result = AST::Annotation::Implements.new(module_name: val[1].value, location: loc, module_args: val[3])
+          | AT_IMPLEMENTS module_name type_params {
+              loc = val[0].location + (val[2]&.location || val[1].location)
+              args = val[2]&.variables || []
+              name = AST::Annotation::Implements::Module.new(name: val[1].value, args: args)
+              result = AST::Annotation::Implements.new(name: name, location: loc)
             }
           | AT_DYNAMIC method_name {
               loc = val.first.location + val.last.location

--- a/smoke/class/g.rb
+++ b/smoke/class/g.rb
@@ -1,0 +1,8 @@
+# !expects MethodDefinitionMissing: module=::B, method=name
+class B
+end
+
+# !expects MethodDefinitionMissing: module=::B, method=name
+class C
+  # @implements ::B
+end

--- a/smoke/module/a.rbi
+++ b/smoke/module/a.rbi
@@ -5,3 +5,7 @@ end
 module A : _Each<Integer>
   def count: () -> Integer
 end
+
+module X
+  def foo: () -> Integer
+end

--- a/smoke/module/d.rb
+++ b/smoke/module/d.rb
@@ -1,0 +1,5 @@
+# If there is a same name module definition, it automatically implements.
+
+# !expects MethodDefinitionMissing: module=::X, method=foo
+module X
+end

--- a/smoke/module/e.rb
+++ b/smoke/module/e.rb
@@ -1,0 +1,13 @@
+# If module has a @implements annotation, it wins
+
+module X
+  # @implements A
+
+  def count
+    3
+  end
+
+  def foo
+    "3"
+  end
+end

--- a/test/annotation_parsing_test.rb
+++ b/test/annotation_parsing_test.rb
@@ -93,15 +93,15 @@ class AnnotationParsingTest < Minitest::Test
   def test_implements
     annot = parse_annotation("@implements String")
     assert_instance_of Steep::AST::Annotation::Implements, annot
-    assert_equal ModuleName.parse(:String), annot.module_name
-    assert_empty annot.module_args
+    assert_equal ModuleName.parse(:String), annot.name.name
+    assert_empty annot.name.args
   end
 
   def test_implement2
-    annot = parse_annotation("@implements Array<String>")
+    annot = parse_annotation("@implements Array<'a>")
     assert_instance_of Steep::AST::Annotation::Implements, annot
-    assert_equal ModuleName.parse(:Array), annot.module_name
-    assert_equal [Steep::AST::Types::Name.new_instance(name: :String)], annot.module_args
+    assert_equal ModuleName.parse(:Array), annot.name.name
+    assert_equal [:a], annot.name.args
   end
 
   def test_ivar_type

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1026,7 +1026,7 @@ string = poly.try { "string" }
   def test_module_self
     source = parse_ruby(<<-EOF)
 module Foo
-  # @implements Foo<String>
+  # @implements Foo<'a>
   
   block_given?
 end


### PR DESCRIPTION
Currently, when you want to type check your Ruby programs, you need `@implements` annotations to all of your classes/modules. This patch is to decrease the efforts you need to start type checking. 🎉 

1. When your program contains a module or a class, and
2. If the module/class does not have `@implements` annotation, and
3. If  a signature which has the same name exists, then
4. It inserts `@implements` annotation automatically

Not implemented yet:

* Support for nested modules/classes
* Support for parametrized signatures
