### PR TITLE
Remove duplicated range of regexp

### DIFF
--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -594,7 +594,7 @@ def next_token
     new_token(:UIDENT, input.matched.to_sym)
   when input.scan(/_\w+/)
     new_token(:INTERFACE_NAME, input.matched.to_sym)
-  when input.scan(/@[\w_]+/)
+  when input.scan(/@\w+/)
     new_token(:IVAR_NAME, input.matched.to_sym)
   when input.scan(/\w+/)
     new_token(:IDENT, input.matched.to_sym)


### PR DESCRIPTION
`\w` contains `_`. So Onigumo warns.

```bash
$ RUBYOPT= ruby -w -e "/[\w_]/" 2>&1
-e:1: warning: character class has duplicated range: /[\w_]/
-e:1: warning: possibly useless use of a literal in void context
```

This change removes the `_`.