### PR TITLE
Support Ruby 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note that Steep is not released yet (pre-released). Add `--pre` for `gem install
 
 ### Requirements
 
-Steep requires Ruby 2.4.
+Steep requires Ruby 2.5.
 
 ## Usage
 

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
   
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I guess steep support only Ruby 2.5, because steep uses `yield_self`, and it's tested only Ruby 2.5 on Travis CI.