### PR TITLE
Add support error handling sytnax (`begin - rescue - end`)

### DIFF
--- a/smoke/ensure/a.rb
+++ b/smoke/ensure/a.rb
@@ -1,0 +1,22 @@
+# @type var a: Integer
+# @type var b: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::String
+a = begin
+      'foo'
+    ensure
+      # !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::Symbol
+      b = :foo
+      1
+    end
+
+# @type method foo: (String) -> String
+
+# !expects MethodBodyTypeMismatch: method=foo, expected=::String, actual=::Integer
+def foo(a)
+  10
+ensure
+  # !expects ArgumentTypeMismatch: expected=::Integer, actual=::String
+  1 + '1'
+  a
+end

--- a/smoke/kwbegin/a.rb
+++ b/smoke/kwbegin/a.rb
@@ -1,0 +1,8 @@
+# @type var a: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::String
+a = begin
+  # @type var x: String
+  x = '1'
+  x
+end

--- a/smoke/rescue/a.rb
+++ b/smoke/rescue/a.rb
@@ -1,0 +1,62 @@
+# @type var a: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Integer)
+a = begin
+      'foo'
+    rescue
+      1
+    end
+
+# @type var b: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Integer)
+b = 'foo' rescue 1
+
+# @type var c: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Symbol | ::Integer)
+c = begin
+      'foo'
+    rescue RuntimeError
+      :sym
+    rescue StandardError
+      1
+    end
+
+# @type var d: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::String
+d = begin
+      1
+    else
+      'foo'
+    end
+
+# @type var e: Integer
+
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Symbol | ::Integer | ::Array<::Integer>)
+e = begin
+      'foo'
+    rescue RuntimeError
+      :sym
+    rescue StandardError
+      1
+    else
+      [1]
+    end
+
+# @type method foo: (String) -> String
+
+# !expects MethodBodyTypeMismatch: method=foo, expected=::String, actual=(::Integer | ::String)
+def foo(a)
+  10
+rescue
+  'foo'
+end
+
+# when empty
+begin
+rescue
+else
+ensure
+end


### PR DESCRIPTION
This pull-request makes Steep to support `begin - rescue - end` syntax.


