### PR TITLE
Fix method typing check

### DIFF
--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -214,9 +214,60 @@ module Steep
       end
     end
 
-    class MethodParameterTypeMismatch < Base
+    class MethodArityMismatch < Base
       def to_s
-        "#{location_to_str}: MethodParameterTypeMismatch: method=#{node.children[0]}"
+        "#{location_to_str}: MethodArityMismatch: method=#{node.children[0]}"
+      end
+    end
+
+    class IncompatibleMethodTypeAnnotation < Base
+      attr_reader :interface_method
+      attr_reader :annotation_method
+      attr_reader :result
+
+      include ResultPrinter
+
+      def initialize(node:, interface_method:, annotation_method:, result:)
+        super(node: node)
+        @interface_method = interface_method
+        @annotation_method = annotation_method
+        @result = result
+      end
+
+      def to_s
+        "#{location_to_str}: IncompatibleMethodTypeAnnotation: interface_method=#{interface_method.type_name}.#{interface_method.name}, annotation_method=#{annotation_method.name}"
+      end
+    end
+
+    class MethodDefinitionWithOverloading < Base
+      attr_reader :method
+
+      def initialize(node:, method:)
+        super(node: node)
+        @method = method
+      end
+
+      def to_s
+        "#{location_to_str}: MethodDefinitionWithOverloading: method=#{method.name}, types=#{method.types.join(" | ")}"
+      end
+    end
+
+    class MethodReturnTypeAnnotationMismatch < Base
+      attr_reader :method_type
+      attr_reader :annotation_type
+      attr_reader :result
+
+      include ResultPrinter
+
+      def initialize(node:, method_type:, annotation_type:, result:)
+        super(node: node)
+        @method_type = method_type
+        @annotation_type = annotation_type
+        @result = result
+      end
+
+      def to_s
+        "#{location_to_str}: MethodReturnTypeAnnotationMismatch: method_type=#{method_type.return_type}, annotation_type=#{annotation_type}"
       end
     end
 

--- a/lib/steep/interface/instantiated.rb
+++ b/lib/steep/interface/instantiated.rb
@@ -54,6 +54,23 @@ module Steep
           end
         end
       end
+
+      def select_method_type(&block)
+        self.class.new(
+          type: type,
+          methods: methods.each.with_object({}) do |(name, method), methods|
+            methods[name] = Method.new(
+              type_name: method.type_name,
+              name: method.name,
+              types: method.types.select(&block),
+              super_method: method.super_method,
+              attributes: method.attributes
+            )
+          end.reject do |_, method|
+            method.types.empty?
+          end
+        )
+      end
     end
   end
 end

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -208,6 +208,19 @@ module Steep
         )
       end
 
+      def each_type(&block)
+        if block_given?
+          params.each_type(&block)
+          self.block&.tap do
+            self.block.params.each_type(&block)
+            yield(self.block.return_type)
+          end
+          yield(return_type)
+        else
+          enum_for :each_type
+        end
+      end
+
       def instantiate(s)
         self.class.new(
           type_params: [],

--- a/smoke/class/a.rb
+++ b/smoke/class/a.rb
@@ -8,7 +8,7 @@ class A
   end
 
   # A#bar is defined but the implementation is incompatible.
-  # !expects MethodParameterTypeMismatch: method=bar
+  # !expects MethodArityMismatch: method=bar
   def bar(y)
     y
   end

--- a/smoke/method/a.rb
+++ b/smoke/method/a.rb
@@ -15,7 +15,7 @@ end
 
 # @type method bar: (Integer) -> String
 
-# !expects MethodParameterTypeMismatch: method=bar
+# !expects MethodArityMismatch: method=bar
 def bar(x, y)
   # @type var z: String
 

--- a/smoke/method/a.rbi
+++ b/smoke/method/a.rbi
@@ -1,0 +1,4 @@
+class X
+  def foo: (String) -> Integer
+         | (Integer) -> String
+end

--- a/smoke/method/b.rb
+++ b/smoke/method/b.rb
@@ -1,0 +1,29 @@
+class A
+  # @implements X
+
+  # !expects*@+2 MethodDefinitionWithOverloading: method=foo, types=
+  # !expects MethodBodyTypeMismatch: method=foo, expected=(::Integer | ::String), actual=::Symbol
+  def foo(x)
+    :foobar
+  end
+end
+
+class B
+  # @implements X
+
+  # @type method foo: (::String | ::Integer) -> any
+  def foo(x)
+    3
+  end
+end
+
+class C
+  # @implements X
+
+  # @type method foo: (Symbol) -> Symbol
+
+  # !expects IncompatibleMethodTypeAnnotation: interface_method=::X.foo, annotation_method=foo
+  def foo(x)
+    :foo
+  end
+end


### PR DESCRIPTION
It now checks:

* If signature's method type is overloaded
* If annotation is compatible with signature's definition
