### PR TITLE
Branch sensitive typing

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -66,6 +66,7 @@ require "steep/drivers/utils/validator"
 require "steep/drivers/utils/each_signature"
 require "steep/drivers/check"
 require "steep/drivers/validate"
+require "steep/drivers/annotations"
 
 module Steep
   def self.logger

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -61,6 +61,7 @@ require "steep/type_construction"
 require "steep/type_inference/send_args"
 require "steep/type_inference/block_params"
 require "steep/type_inference/constant_env"
+require "steep/type_inference/type_env"
 
 require "steep/drivers/utils/validator"
 require "steep/drivers/utils/each_signature"

--- a/lib/steep/ast/annotation.rb
+++ b/lib/steep/ast/annotation.rb
@@ -23,6 +23,7 @@ module Steep
       class Typed
         attr_reader :type
         attr_reader :annotation
+        attr_reader :location
 
         def initialize(type:, location: nil)
           @type = type

--- a/lib/steep/ast/types/helper.rb
+++ b/lib/steep/ast/types/helper.rb
@@ -4,12 +4,12 @@ module Steep
       module Helper
         module ChildrenLevel
           def level_of_children(children)
-            children.map(&:level).inject() do |a, b|
+            children.map(&:level).sort {|a, b| b.size <=> a.size }.inject() do |a, b|
               a.zip(b).map do |(x, y)|
                 if x && y
                   x + y
                 else
-                  x || y || 0
+                  x || y
                 end
               end
             end || []

--- a/lib/steep/ast/types/intersection.rb
+++ b/lib/steep/ast/types/intersection.rb
@@ -29,7 +29,11 @@ module Steep
               type
             end
           end.compact.uniq.yield_self do |tys|
-            new(types: tys.sort_by(&:hash), location: location)
+            if tys.size == 1
+              tys.first
+            else
+              new(types: tys.sort_by(&:hash), location: location)
+            end
           end
         end
 

--- a/lib/steep/ast/types/union.rb
+++ b/lib/steep/ast/types/union.rb
@@ -29,7 +29,11 @@ module Steep
               type
             end
           end.compact.uniq.yield_self do |tys|
-            new(types: tys.sort_by(&:hash), location: location)
+            if tys.length == 1
+              tys.first
+            else
+              new(types: tys.sort_by(&:hash), location: location)
+            end
           end
         end
 

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -16,7 +16,7 @@ module Steep
     end
 
     def self.available_commands
-      [:check, :validate]
+      [:check, :validate, :annotations]
     end
 
     def setup_global_options
@@ -91,6 +91,11 @@ module Steep
       Drivers::Validate.new(signature_dirs: signature_dirs, stdout: stdout, stderr: stderr).tap do |validate|
         validate.verbose = verbose
       end.run
+    end
+
+    def process_annotations
+      source_paths = argv.map {|file| Pathname(file) }
+      Drivers::Annotations.new(source_paths: source_paths, stdout: stdout, stderr: stderr).run
     end
   end
 end

--- a/lib/steep/drivers/annotations.rb
+++ b/lib/steep/drivers/annotations.rb
@@ -1,0 +1,32 @@
+module Steep
+  module Drivers
+    class Annotations
+      attr_reader :source_paths
+      attr_reader :stdout
+      attr_reader :stderr
+      attr_reader :labeling
+
+      include Utils::EachSignature
+
+      def initialize(source_paths:, stdout:, stderr:)
+        @source_paths = source_paths
+        @stdout = stdout
+        @stderr = stderr
+
+        @labeling = ASTUtils::Labeling.new
+      end
+
+      def run
+        each_ruby_source(source_paths, false) do |source|
+          source.each_annotation.sort_by {|node, _| [node.loc.expression.begin_pos, node.loc.expression.end_pos] }.each do |node, annotations|
+            loc = node.loc
+            stdout.puts "#{source.path}:#{loc.line}:#{loc.column}:#{node.type}:\t#{node.loc.expression.source.lines.first}"
+            annotations.each do |annotation|
+              stdout.puts "  #{annotation.location.source}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -65,24 +65,29 @@ module Steep
 
             pp annotations if verbose
 
+            const_env = TypeInference::ConstantEnv.new(builder: check.builder, current_namespace: nil)
+            type_env = TypeInference::TypeEnv.build(annotations: annotations,
+                                                    subtyping: check,
+                                                    const_env: const_env,
+                                                    signatures: check.builder.signatures)
+
             construction = TypeConstruction.new(
               checker: check,
               annotations: annotations,
               source: source,
-              var_types: {},
               self_type: nil,
               block_context: nil,
               module_context: TypeConstruction::ModuleContext.new(
                 instance_type: nil,
                 module_type: nil,
-                const_types: annotations.const_types,
                 implement_name: nil,
                 current_namespace: nil,
-                const_env: TypeInference::ConstantEnv.new(builder: check.builder, current_namespace: nil)
+                const_env: const_env
               ),
               method_context: nil,
               typing: typing,
-              break_context: nil
+              break_context: nil,
+              type_env: type_env
               )
             construction.synthesize(source.node)
           end

--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -411,5 +411,22 @@ module Steep
         "#{location_to_str}: UnsatisfiableConstraint: method_type=#{method_type}, constraint=#{sub_type} <: '#{var} <: #{super_type}"
       end
     end
+
+    class IncompatibleAnnotation < Base
+      attr_reader :var_name
+      attr_reader :result
+
+      def initialize(node:, var_name:, result:)
+        super(node: node)
+        @var_name = var_name
+        @result = result
+      end
+
+      include ResultPrinter
+
+      def to_s
+        "#{location_to_str}: IncompatibleAnnotation: var_name=#{var_name}, #{result.relation}"
+      end
+    end
   end
 end

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -248,5 +248,16 @@ module Steep
     def annotations(block:)
       AST::Annotation::Collection.new(annotations: mapping[block.__id__] || [])
     end
+
+    def each_annotation
+      if block_given?
+        mapping.each_key do |id|
+          node = ObjectSpace._id2ref(id)
+          yield node, mapping[id]
+        end
+      else
+        enum_for :each_annotation
+      end
+    end
   end
 end

--- a/lib/steep/subtyping/result.rb
+++ b/lib/steep/subtyping/result.rb
@@ -96,6 +96,7 @@ module Steep
           end
         end
 
+        attr_reader :relation
         attr_reader :error
         attr_reader :trace
 

--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -1,0 +1,219 @@
+module Steep
+  module TypeInference
+    class TypeEnv
+      attr_reader :subtyping
+      attr_reader :lvar_types
+      attr_reader :const_types
+      attr_reader :gvar_types
+      attr_reader :ivar_types
+      attr_reader :const_env
+
+      def initialize(subtyping:, const_env:)
+        @subtyping = subtyping
+        @lvar_types = {}
+        @const_types = {}
+        @gvar_types = {}
+        @ivar_types = {}
+        @const_env = const_env
+      end
+
+      def initialize_copy(other)
+        @subtyping = other.subtyping
+        @lvar_types = other.lvar_types.dup
+        @const_types = other.const_types.dup
+        @gvar_types = other.gvar_types.dup
+        @ivar_types = other.ivar_types.dup
+        @const_env = other.const_env
+      end
+
+      def self.build(annotations:, signatures:, subtyping:, const_env:)
+        new(subtyping: subtyping, const_env: const_env).tap do |env|
+          annotations.var_types.each do |name, annot|
+            env.set(lvar: name, type: annot.type)
+          end
+          annotations.ivar_types.each do |name, type|
+            env.set(ivar: name, type: type)
+          end
+          annotations.const_types.each do |name, type|
+            env.set(const: name, type: type)
+          end
+          signatures.globals.each do |name, annot|
+            type = subtyping.builder.absolute_type(annot.type, current: nil)
+            env.set(gvar: name, type: type)
+          end
+        end
+      end
+
+      def with_annotations(lvar_types: {}, ivar_types: {}, const_types: {}, gvar_types: {}, &block)
+        dup.tap do |env|
+          merge!(original_env: env.lvar_types, override_env: lvar_types, &block)
+          merge!(original_env: env.ivar_types, override_env: ivar_types, &block)
+          merge!(original_env: env.gvar_types, override_env: gvar_types, &block)
+
+          const_types.each do |name, annotated_type|
+            original_type = self.const_types[name] || const_env.lookup(name)
+            if original_type
+              assert_annotation name, original_type: original_type, annotated_type: annotated_type, &block
+            end
+            env.const_types[name] = annotated_type
+          end
+        end
+      end
+
+      def join!(envs)
+        lvars = {}
+
+        envs.each do |env|
+          env.lvar_types.each do |name, type|
+            unless lvar_types.key?(name)
+              lvars[name] = [] unless lvars[name]
+              lvars[name] << type
+            end
+          end
+        end
+
+        lvars.each do |name, types|
+          if types.size == 1
+            set(lvar: name, type: types.first)
+          else
+            set(lvar: name, type: AST::Types::Union.build(types: types))
+          end
+        end
+      end
+
+      # @type method assert: (const: ModuleName) { () -> void } -> AST::Type
+      #                    | (gvar: Symbol) { () -> void } -> AST::Type
+      #                    | (ivar: Symbol) { () -> void } -> AST::Type
+      #                    | (lvar: Symbol | LabeledName) { () -> void } -> AST::Type
+      def get(lvar: nil, const: nil, gvar: nil, ivar: nil)
+        case
+        when lvar
+          lvar_name(lvar).yield_self do |name|
+            lvar_types[name] or raise
+          end
+        when const
+          if const_types.key?(const)
+            const_types[const]
+          else
+            const_env.lookup(const).yield_self do |type|
+              if type
+                type
+              else
+                yield
+                AST::Types::Any.new
+              end
+            end
+          end
+        else
+          lookup_dictionary(ivar: ivar, gvar: gvar) do |var_name, dictionary|
+            if dictionary.key?(var_name)
+              dictionary[var_name]
+            else
+              yield
+              AST::Types::Any.new
+            end
+          end
+        end
+      end
+
+      def set(lvar: nil, const: nil, gvar: nil, ivar: nil, type:)
+        case
+        when lvar
+          lvar_name(lvar).yield_self do |name|
+            lvar_types[name] = type
+          end
+        when const
+          const_types[const] = type
+        else
+          lookup_dictionary(ivar: ivar, gvar: gvar) do |var_name, dictionary|
+            dictionary[var_name] = type
+          end
+        end
+      end
+
+      # @type method assign: (const: ModuleName, type: AST::Type) { (Subtyping::Result::Failure | nil) -> void } -> AST::Type
+      #                    | (gvar: Symbol, type: AST::Type) { (Subtyping::Result::Failure | nil) -> void } -> AST::Type
+      #                    | (ivar: Symbol, type: AST::Type) { (Subtyping::Result::Failure | nil) -> void } -> AST::Type
+      #                    | (lvar: Symbol | LabeledName, type: AST::Type) { (Subtyping::Result::Failure) -> void } -> AST::Type
+      def assign(lvar: nil, const: nil, gvar: nil, ivar: nil, type:, &block)
+        case
+        when lvar
+          yield_self do
+            name = lvar_name(lvar)
+            var_type = lvar_types[name]
+            if var_type
+              assert_assign(var_type: var_type, lhs_type: type, &block)
+            else
+              lvar_types[name] = type
+            end
+          end
+        when const
+          yield_self do
+            const_type = const_types[const] || const_env.lookup(const)
+            if const_type
+              assert_assign(var_type: const_type, lhs_type: type, &block)
+            else
+              yield nil
+              AST::Types::Any.new
+            end
+          end
+        else
+          lookup_dictionary(ivar: ivar, gvar: gvar) do |var_name, dictionary|
+            if dictionary.key?(var_name)
+              assert_assign(var_type: dictionary[var_name], lhs_type: type, &block)
+            else
+              yield nil
+              AST::Types::Any.new
+            end
+          end
+        end
+      end
+
+      def lookup_dictionary(ivar:, gvar:)
+        case
+        when ivar
+          yield ivar, ivar_types
+        when gvar
+          yield gvar, gvar_types
+        end
+      end
+
+      def lvar_name(lvar)
+        case lvar
+        when Symbol
+          lvar
+        when ASTUtils::Labeling::LabeledName
+          lvar.name
+        end
+      end
+
+      def assert_assign(var_type:, lhs_type:)
+        relation = Subtyping::Relation.new(sub_type: lhs_type, super_type: var_type)
+        constraints = Subtyping::Constraints.new(unknowns: Set.new)
+
+        subtyping.check(relation, constraints: constraints).else do |result|
+          yield result
+        end
+
+        var_type
+      end
+
+      def merge!(original_env:, override_env:, &block)
+        original_env.merge!(override_env) do |name, original_type, override_type|
+          assert_annotation name, annotated_type: override_type, original_type: original_type, &block
+        end
+      end
+
+      def assert_annotation(name, annotated_type:, original_type:)
+        relation = Subtyping::Relation.new(sub_type: annotated_type, super_type: original_type)
+        constraints = Subtyping::Constraints.new(unknowns: Set.new)
+
+        subtyping.check(relation, constraints: constraints).else do |result|
+          yield name, result
+        end
+
+        annotated_type
+      end
+    end
+  end
+end

--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -73,11 +73,7 @@ module Steep
         end
 
         lvars.each do |name, types|
-          if types.size == 1
-            set(lvar: name, type: types.first)
-          else
-            set(lvar: name, type: AST::Types::Union.build(types: types))
-          end
+          set(lvar: name, type: AST::Types::Union.build(types: types))
         end
       end
 

--- a/smoke/rescue/a.rb
+++ b/smoke/rescue/a.rb
@@ -34,7 +34,7 @@ d = begin
 
 # @type var e: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Symbol | ::Integer | ::Array<::Integer>)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Symbol | ::Integer | ::Array<::Integer>)
 e = begin
       'foo'
     rescue RuntimeError

--- a/test/constraints_test.rb
+++ b/test/constraints_test.rb
@@ -134,10 +134,12 @@ end
                  constraints.eliminate_variable(AST::Types::Var.new(name: :a), to: AST::Types::Any.new)
 
     assert_equal AST::Types::Any.new,
-                 constraints.eliminate_variable(AST::Types::Union.build(types: [AST::Types::Var.new(name: :a)]),
+                 constraints.eliminate_variable(AST::Types::Union.build(types: [AST::Types::Var.new(name: :a),
+                                                                                AST::Types::Var.new(name: :b)]),
                                                 to: AST::Types::Top.new)
     assert_equal AST::Types::Any.new,
-                 constraints.eliminate_variable(AST::Types::Intersection.build(types: [AST::Types::Var.new(name: :a)]),
+                 constraints.eliminate_variable(AST::Types::Intersection.build(types: [AST::Types::Var.new(name: :a),
+                                                                                       AST::Types::Var.new(name: :b)]),
                                                 to: AST::Types::Bot.new)
     assert_equal AST::Types::Name.new(name: "::String", args: [AST::Types::Any.new]),
                  constraints.eliminate_variable(AST::Types::Name.new(name: "::String", args: [AST::Types::Var.new(name: :a)]),

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -659,8 +659,6 @@ end
     assert_equal AST::Types::Name.new_instance(name: :"::String"), result.constraints.lower_bound(:x)
     assert_instance_of AST::Types::Top, result.constraints.upper_bound(:x)
 
-    puts result.constraints
-
     variance = Subtyping::VariableVariance.new(contravariants: Set.new([:x]),
                                                covariants: Set.new([:x]))
     s = result.constraints.solution(checker, variance: variance, variables: Set.new([:x]))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -293,8 +293,12 @@ class String
   def +: (String) -> String
 end
 
-class Integer
+class Numeric
+  def +: (Numeric) -> Numeric
   def to_int: -> Integer
+end
+
+class Integer <: Numeric
 end
 
 class Range<'a>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,28 @@ module TestHelper
   def parse_ruby(string)
     Steep::Source.parse(string, path: Pathname("test.rb"))
   end
+
+  def dig(node, *indexes)
+    if indexes.size == 1
+      node.children[indexes.first]
+    else
+      dig(node.children[indexes.first], *indexes.drop(1))
+    end
+  end
+
+  def lvar_in(node, name)
+    if (node.type == :lvar || node.type == :lvasgn) && node.children[0].name == name
+      return node
+    else
+      node.children.each do |child|
+        if child.is_a?(AST::Node)
+          lvar = lvar_in(child, name)
+          return lvar if lvar
+        end
+      end
+      nil
+    end
+  end
 end
 
 module TypeErrorAssertions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -313,6 +313,7 @@ end
 class String
   def to_str: -> String
   def +: (String) -> String
+  def size: -> Integer
 end
 
 class Numeric

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -270,3 +270,99 @@ module ASTAssertion
     yield name: annot.name, type: annot.type if block_given?
   end
 end
+
+module SubtypingHelper
+  BUILTIN = <<-EOS
+class BasicObject
+end
+
+class Object <: BasicObject
+  def class: -> module
+  def tap: { (instance) -> any } -> instance
+end
+
+class Class<'a>
+end
+
+class Module
+  def block_given?: -> any
+end
+
+class String
+  def to_str: -> String
+  def +: (String) -> String
+end
+
+class Integer
+  def to_int: -> Integer
+end
+
+class Range<'a>
+  def begin: -> 'a
+  def end: -> 'a
+end
+
+class Regexp
+end
+
+class Array<'a>
+  def []: (Integer) -> 'a
+  def []=: (Integer, 'a) -> 'a
+  def <<: ('a) -> self
+  def each: { ('a) -> any } -> self
+  def zip: <'b> (Array<'b>) -> Array<'a | 'b>
+  def each_with_object: <'b> ('b) { ('a, 'b) -> any } -> 'b
+end
+  EOS
+
+  DEFAULT_SIGS = <<-EOS
+interface _A
+  def +: (_A) -> _A
+end
+
+interface _B
+end
+
+interface _C
+  def f: () -> _A
+  def g: (_A, ?_B) -> _B
+  def h: (a: _A, ?b: _B) -> _C
+end
+
+interface _D
+  def foo: () -> any
+end
+
+interface _X
+  def f: () { (_A) -> _D } -> _C 
+end
+
+interface _Kernel
+  def foo: (_A) -> _B
+         | (_C) -> _D
+end
+
+interface _PolyMethod
+  def snd: <'a>(any, 'a) -> 'a
+  def try: <'a> { (any) -> 'a } -> 'a
+end
+
+module Foo<'a>
+end
+  EOS
+
+  def new_subtyping_checker(sigs = DEFAULT_SIGS)
+    signatures = Steep::AST::Signature::Env.new.tap do |env|
+      parse_signature(BUILTIN).each do |sig|
+        env.add sig
+      end
+
+      parse_signature(sigs).each do |sig|
+        env.add sig
+      end
+    end
+
+    builder = Steep::Interface::Builder.new(signatures: signatures)
+    Steep::Subtyping::Check.new(builder: builder)
+  end
+end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -16,100 +16,7 @@ class TypeConstructionTest < Minitest::Test
 
   include TestHelper
   include TypeErrorAssertions
-
-  BUILTIN = <<-EOS
-class BasicObject
-end
-
-class Object <: BasicObject
-  def class: -> module
-  def tap: { (instance) -> any } -> instance
-end
-
-class Class<'a>
-end
-
-class Module
-  def block_given?: -> any
-end
-
-class String
-  def to_str: -> String
-  def +: (String) -> String
-end
-
-class Integer
-  def to_int: -> Integer
-end
-
-class Range<'a>
-  def begin: -> 'a
-  def end: -> 'a
-end
-
-class Regexp
-end
-
-class Array<'a>
-  def []: (Integer) -> 'a
-  def []=: (Integer, 'a) -> 'a
-  def <<: ('a) -> self
-  def each: { ('a) -> any } -> self
-  def zip: <'b> (Array<'b>) -> Array<'a | 'b>
-  def each_with_object: <'b> ('b) { ('a, 'b) -> any } -> 'b
-end
-  EOS
-
-  DEFAULT_SIGS = <<-EOS
-interface _A
-  def +: (_A) -> _A
-end
-
-interface _B
-end
-
-interface _C
-  def f: () -> _A
-  def g: (_A, ?_B) -> _B
-  def h: (a: _A, ?b: _B) -> _C
-end
-
-interface _D
-  def foo: () -> any
-end
-
-interface _X
-  def f: () { (_A) -> _D } -> _C 
-end
-
-interface _Kernel
-  def foo: (_A) -> _B
-         | (_C) -> _D
-end
-
-interface _PolyMethod
-  def snd: <'a>(any, 'a) -> 'a
-  def try: <'a> { (any) -> 'a } -> 'a
-end
-
-module Foo<'a>
-end
-  EOS
-
-  def checker(sigs = DEFAULT_SIGS)
-    signatures = Signature::Env.new.tap do |env|
-      parse_signature(BUILTIN).each do |sig|
-        env.add sig
-      end
-
-      parse_signature(sigs).each do |sig|
-        env.add sig
-      end
-    end
-
-    builder = Interface::Builder.new(signatures: signatures)
-    Subtyping::Check.new(builder: builder)
-  end
+  include SubtypingHelper
 
   def test_lvar_with_annotation
     source = parse_ruby(<<-EOF)
@@ -119,7 +26,7 @@ x = nil
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -147,7 +54,7 @@ z = x
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -180,7 +87,7 @@ z = x
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -207,7 +114,7 @@ z = x
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -234,7 +141,7 @@ x.f
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -263,7 +170,7 @@ x.g(y)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -292,7 +199,7 @@ x.g(y)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -323,7 +230,7 @@ x.no_such_method
     typing = Typing.new
     annotations = source.annotations(block: source.node)
 
-    construction = TypeConstruction.new(checker: checker(),
+    construction = TypeConstruction.new(checker: new_subtyping_checker(),
                                         source: source,
                                         annotations: annotations,
                                         var_types: {},
@@ -348,7 +255,7 @@ x.no_such_method
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -379,7 +286,7 @@ a.g()
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -413,7 +320,7 @@ a.g(nil, nil, nil)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -449,7 +356,7 @@ x.h(a: a, b: b)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -476,7 +383,7 @@ x.h()
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -509,7 +416,7 @@ x.h(a: nil, b: nil, c: nil)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -543,7 +450,7 @@ x.h(a: y)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -575,7 +482,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -603,7 +510,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -633,7 +540,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -669,7 +576,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -709,7 +616,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -742,7 +649,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -774,7 +681,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -806,7 +713,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -841,7 +748,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -874,7 +781,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -903,7 +810,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -931,7 +838,7 @@ hello = Hello
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
 
@@ -967,7 +874,7 @@ Hello::World = ""
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
 
@@ -1005,7 +912,7 @@ x = String
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
 
@@ -1044,7 +951,7 @@ x = X
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 X: Module
     EOF
 
@@ -1093,7 +1000,7 @@ d = k.foo(c)
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1125,7 +1032,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1164,7 +1071,7 @@ string = poly.snd(1, "a")
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1192,7 +1099,7 @@ string = poly.try { "string" }
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1214,7 +1121,7 @@ string = poly.try { "string" }
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1245,7 +1152,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1268,7 +1175,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<EOF)
+    checker = new_subtyping_checker(<<EOF)
 class Person
 end
 EOF
@@ -1302,7 +1209,7 @@ EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<EOF)
+    checker = new_subtyping_checker(<<EOF)
 class Address
 end
 EOF
@@ -1330,7 +1237,7 @@ EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<EOF)
+    checker = new_subtyping_checker(<<EOF)
 class Steep::ModuleName
 end
 EOF
@@ -1372,7 +1279,7 @@ EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<EOF)
+    checker = new_subtyping_checker(<<EOF)
 module Steep
 end
 EOF
@@ -1414,7 +1321,7 @@ EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<EOF)
+    checker = new_subtyping_checker(<<EOF)
 module Rails
 end
 EOF
@@ -1442,7 +1349,7 @@ EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<EOF)
+    checker = new_subtyping_checker(<<EOF)
 module Steep::Printable
 end
 EOF
@@ -1485,7 +1392,7 @@ EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def foo: (String) -> Integer
 end
@@ -1527,7 +1434,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def foo: (String) -> Integer
          | (Object) -> Integer
@@ -1577,7 +1484,7 @@ RUBY
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def foo: (String) -> Integer
 end
@@ -1628,7 +1535,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def foo: (String) -> Integer
 end
@@ -1671,7 +1578,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A::String
   def aaaaa: -> any
 end
@@ -1718,7 +1625,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def foobar: -> any
 end
@@ -1757,7 +1664,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
 end
 
@@ -1794,7 +1701,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
 end
 
@@ -1828,7 +1735,7 @@ a, @b = 1, 2
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1865,7 +1772,7 @@ a, @b = x
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1899,7 +1806,7 @@ a, @b = 3
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1931,7 +1838,7 @@ a += 3
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1962,7 +1869,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -1992,7 +1899,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2025,7 +1932,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2053,7 +1960,7 @@ end while true
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2081,7 +1988,7 @@ a = 2..."a"
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2112,7 +2019,7 @@ a = /#{a + 3}/
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2142,7 +2049,7 @@ a = $1
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2173,7 +2080,7 @@ a ||= a + "foo"
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2204,7 +2111,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2232,7 +2139,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2263,7 +2170,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2291,7 +2198,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2318,7 +2225,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2350,7 +2257,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2378,7 +2285,7 @@ x = $HOGE
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 $HOGE: Integer
     EOF
 
@@ -2409,7 +2316,7 @@ x = $HOGE
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 $HOGE: Integer
     EOF
 
@@ -2439,7 +2346,7 @@ x = $HOGE
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2470,7 +2377,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def foo: -> String
   @foo: String
@@ -2503,7 +2410,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   @foo: String
 end
@@ -2537,7 +2444,7 @@ b = [*a]
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2567,7 +2474,7 @@ b = [*1...3]
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2597,7 +2504,7 @@ b = [*a]
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker()
+    checker = new_subtyping_checker()
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2627,7 +2534,7 @@ a.gen(*["1"])
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class A
   def initialize: () -> any
   def gen: (*Integer) -> String
@@ -2677,7 +2584,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class Hoge
   def foo: (self) -> void
 end
@@ -2731,7 +2638,7 @@ end
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker(<<-EOF)
+    checker = new_subtyping_checker(<<-EOF)
 class Hoge
   def foo: () { () -> void } -> any
 end
@@ -2779,7 +2686,7 @@ b = a.zip(["foo"])
 EOF
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker("")
+    checker = new_subtyping_checker("")
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
@@ -2808,7 +2715,7 @@ end
 EOF
     typing = Typing.new
     annotations = source.annotations(block: source.node)
-    checker = checker("")
+    checker = new_subtyping_checker("")
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -13,6 +13,7 @@ class TypeConstructionTest < Minitest::Test
   Signature = Steep::AST::Signature
   TypeInference = Steep::TypeInference
   ConstantEnv = Steep::TypeInference::ConstantEnv
+  TypeEnv = Steep::TypeInference::TypeEnv
 
   include TestHelper
   include TypeErrorAssertions
@@ -27,11 +28,16 @@ x = nil
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         typing: typing,
@@ -55,11 +61,16 @@ z = x
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         typing: typing,
                                         block_context: nil,
@@ -88,11 +99,16 @@ z = x
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -115,11 +131,16 @@ z = x
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -142,11 +163,16 @@ x.f
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -171,11 +197,16 @@ x.g(y)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -200,11 +231,16 @@ x.g(y)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -229,11 +265,17 @@ x.no_such_method
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
+    checker = new_subtyping_checker
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
-    construction = TypeConstruction.new(checker: new_subtyping_checker(),
+    construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -256,11 +298,16 @@ x.no_such_method
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         typing: typing,
@@ -287,11 +334,16 @@ a.g()
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -321,11 +373,16 @@ a.g(nil, nil, nil)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -357,11 +414,16 @@ x.h(a: a, b: b)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -384,11 +446,16 @@ x.h()
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -417,11 +484,16 @@ x.h(a: nil, b: nil, c: nil)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -451,11 +523,16 @@ x.h(a: y)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -483,11 +560,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -511,11 +593,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -526,8 +613,7 @@ end
 
     def_body = source.node.children[2]
     assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: def_body)
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :y)
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: def_body.children[1])
   end
 
   def test_def_param_error
@@ -535,17 +621,24 @@ end
 def foo(x, y = x)
   # @type var x: _A
   # @type var y: _C
+  x
+  y
 end
     EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -562,8 +655,11 @@ end
       assert_equal :y, error.node.children[0].name
     end
 
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_C), typing.type_of_variable(name: :y)
+    x = dig(source.node, 2, 0)
+    y = dig(source.node, 2, 1)
+
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: x)
+    assert_equal Types::Name.new_interface(name: :_C), typing.type_of(node: y)
   end
 
   def test_def_kw_param_error
@@ -571,17 +667,24 @@ end
 def foo(x:, y: x)
   # @type var x: _A
   # @type var y: _C
+  x
+  y
 end
     EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -598,8 +701,11 @@ end
       assert_equal :y, error.node.children[0].name
     end
 
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_C), typing.type_of_variable(name: :y)
+    x = dig(source.node, 2, 0)
+    y = dig(source.node, 2, 1)
+
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: x)
+    assert_equal Types::Name.new_interface(name: :_C), typing.type_of(node: y)
   end
 
   def test_block
@@ -611,17 +717,27 @@ b = a.f do |x|
   # @type var x: _A
   # @type var y: _B
   y = nil
+  x
+  y
 end
+
+a
+b
     EOF
 
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -630,10 +746,15 @@ end
                                         break_context: nil)
     construction.synthesize(source.node)
 
-    assert_equal Types::Name.new_interface(name: :_X), typing.type_of_variable(name: :a)
-    assert_equal Types::Name.new_interface(name: :_C), typing.type_of_variable(name: :b)
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_B), typing.type_of_variable(name: :y)
+    a = dig(source.node, 2)
+    b = dig(source.node, 3)
+    x = dig(source.node, 1, 1, 2, 1)
+    y = dig(source.node, 1, 1, 2, 2)
+
+    assert_equal Types::Name.new_interface(name: :_X), typing.type_of(node: a)
+    assert_equal Types::Name.new_interface(name: :_C), typing.type_of(node: b)
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: x)
+    assert_equal Types::Name.new_interface(name: :_B), typing.type_of(node: y)
   end
 
   def test_block_shadow
@@ -650,11 +771,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -663,9 +789,11 @@ end
                                         break_context: nil)
     construction.synthesize(source.node)
 
-    assert_any typing.var_typing do |var, type| var.name == :a && type.is_a?(Types::Name) && type.name == TypeName::Interface.new(name: :_A) end
-    assert_any typing.var_typing do |var, type| var.name == :a && type.is_a?(Types::Name) && type.name == TypeName::Interface.new(name: :_X) end
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :b)
+    block_body = dig(source.node, 1, 2)
+
+    assert_equal Types::Name.new_interface(name: :_X), typing.type_of(node: lvar_in(source.node, :a))
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: lvar_in(block_body, :a))
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: lvar_in(block_body, :b))
   end
 
   def test_block_param_type
@@ -675,6 +803,7 @@ x = nil
 
 x.f do |a|
   # @type var d: _D
+  a
   d = nil
 end
     EOF
@@ -682,11 +811,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -695,9 +829,9 @@ end
                                         break_context: nil)
     construction.synthesize(source.node)
 
-    assert_equal Types::Name.new_interface(name: :_X), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :a)
-    assert_equal Types::Name.new_interface(name: :_D), typing.type_of_variable(name: :d)
+    assert_equal Types::Name.new_interface(name: :_X), typing.type_of(node: lvar_in(source.node, :x))
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: lvar_in(source.node, :a))
+    assert_equal Types::Name.new_interface(name: :_D), typing.type_of(node: lvar_in(source.node, :d))
     assert_empty typing.errors
   end
 
@@ -714,11 +848,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -727,8 +866,8 @@ end
                                         break_context: nil)
     construction.synthesize(source.node)
 
-    assert_equal Types::Name.new_interface(name: :_X), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :a)
+    assert_equal Types::Name.new_interface(name: :_X), typing.type_of(node: lvar_in(source.node, :x))
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: lvar_in(source.node, :a))
 
     assert_equal 1, typing.errors.size
     assert_block_type_mismatch typing.errors[0], expected: Types::Name.new_interface(name: :_D), actual: Types::Name.new_interface(name: :_A)
@@ -749,11 +888,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -762,8 +906,8 @@ end
                                         break_context: nil)
     construction.synthesize(source.node)
 
-    assert_equal Types::Name.new_interface(name: :_X), typing.type_of_variable(name: :x)
-    assert_equal Types::Name.new_interface(name: :_A), typing.type_of_variable(name: :a)
+    assert_equal Types::Name.new_interface(name: :_X), typing.type_of(node: lvar_in(source.node, :x))
+    assert_equal Types::Name.new_interface(name: :_A), typing.type_of(node: lvar_in(source.node, :a))
 
     assert_equal 1, typing.errors.size
     assert_break_type_mismatch typing.errors[0], expected: Types::Name.new_interface(name: :_C), actual: Types::Name.new_interface(name: :_A)
@@ -782,11 +926,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -811,11 +960,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -839,22 +993,24 @@ hello = Hello
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
-
-    env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
-      const_env: env
+      const_env: const_env
     )
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -875,13 +1031,17 @@ Hello::World = ""
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
 
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
       const_env: env
@@ -890,7 +1050,7 @@ Hello::World = ""
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -902,6 +1062,8 @@ Hello::World = ""
     assert_any typing.errors do |error|
       error.is_a?(Steep::Errors::IncompatibleAssignment)
     end
+
+    assert_equal Types::Name.new_instance(name: "::Integer"), typing.type_of(node: source.node)
   end
 
   def test_constant_signature
@@ -913,13 +1075,17 @@ x = String
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
 
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
       const_env: env
@@ -928,7 +1094,7 @@ x = String
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -954,22 +1120,24 @@ x = X
     checker = new_subtyping_checker(<<-EOF)
 X: Module
     EOF
-
-    env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
-      const_env: env
+      const_env: const_env
     )
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -1001,11 +1169,16 @@ d = k.foo(c)
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -1033,11 +1206,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -1072,11 +1250,16 @@ string = poly.snd(1, "a")
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -1100,11 +1283,16 @@ string = poly.try { "string" }
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -1122,11 +1310,16 @@ string = poly.try { "string" }
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -1153,11 +1346,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1179,11 +1377,16 @@ end
 class Person
 end
 EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1213,11 +1416,16 @@ EOF
 class Address
 end
 EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1241,14 +1449,18 @@ EOF
 class Steep::ModuleName
 end
 EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: Types::Name.new_instance(name: "::Steep"),
       module_type: Types::Name.new_module(name: "::Steep"),
-      const_types: {},
       implement_name: nil,
       current_namespace: Steep::ModuleName.parse("::Steep"),
-      const_env: nil
+      const_env: const_env
     )
 
     module_name_class_node = source.node.children[1]
@@ -1256,7 +1468,7 @@ EOF
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1283,11 +1495,16 @@ EOF
 module Steep
 end
 EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1325,11 +1542,16 @@ EOF
 module Rails
 end
 EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1353,14 +1575,18 @@ EOF
 module Steep::Printable
 end
 EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: Types::Name.new_instance(name: "::Steep"),
       module_type: Types::Name.new_class(name: "::Steep", constructor: false),
-      const_types: {},
       implement_name: nil,
       current_namespace: Steep::ModuleName.parse("::Steep"),
-      const_env: nil
+      const_env: const_env
     )
 
     module_node = source.node.children.last
@@ -1368,7 +1594,7 @@ EOF
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1397,11 +1623,16 @@ class A
   def foo: (String) -> Integer
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1423,9 +1654,9 @@ end
 
     assert_equal Types::Name.new_instance(name: "::A"), for_method.self_type
     assert_nil for_method.block_context
-    assert_equal [:x], for_method.var_types.keys.map(&:name)
+    assert_equal [:x], for_method.type_env.lvar_types.keys
     assert_equal Types::Name.new_instance(name: "::String"),
-                 for_method.var_types.find {|name, _| name.name == :x }.last
+                 for_method.type_env.lvar_types[:x]
   end
 
   def test_new_method_constructor_union
@@ -1440,11 +1671,16 @@ class A
          | (Object) -> Integer
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1466,7 +1702,7 @@ end
 
     assert_equal Types::Name.new_instance(name: "::A"), for_method.self_type
     assert_nil for_method.block_context
-    assert_empty for_method.var_types
+    assert_empty for_method.type_env.lvar_types
 
     assert_equal 1, typing.errors.size
     assert_instance_of Steep::Errors::MethodDefinitionWithOverloading, typing.errors.first
@@ -1489,11 +1725,16 @@ class A
   def foo: (String) -> Integer
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1515,8 +1756,8 @@ end
 
     assert_equal Types::Name.new_instance(name: "::A"), for_method.self_type
     assert_nil for_method.block_context
-    assert_equal [:x], for_method.var_types.keys.map(&:name)
-    assert_equal Types::Name.new_instance(name: "::String"), for_method.var_types.find {|name, _| name.name == :x }.last
+    assert_equal [:x], for_method.type_env.lvar_types.keys
+    assert_equal Types::Name.new_instance(name: "::String"), for_method.type_env.lvar_types[:x]
 
     assert_equal 1, typing.errors.size
     assert_instance_of Steep::Errors::MethodReturnTypeAnnotationMismatch, typing.errors.first
@@ -1540,11 +1781,16 @@ class A
   def foo: (String) -> Integer
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1583,11 +1829,16 @@ class A::String
   def aaaaa: -> any
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1634,11 +1885,16 @@ class A::String
   def aaaaa: -> any
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1672,11 +1928,16 @@ class A::String
   def foo: -> any
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1709,11 +1970,16 @@ class A::String
   def foo: -> any
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1736,12 +2002,16 @@ a, @b = 1, 2
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1773,12 +2043,16 @@ a, @b = x
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1807,12 +2081,16 @@ a, @b = 3
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1839,12 +2117,16 @@ a += 3
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1870,12 +2152,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: nil,
                                         block_context: nil,
                                         method_context: nil,
@@ -1900,12 +2186,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -1933,12 +2223,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -1961,12 +2255,16 @@ end while true
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -1989,12 +2287,16 @@ a = 2..."a"
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2020,12 +2322,16 @@ a = /#{a + 3}/
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2050,12 +2356,16 @@ a = $1
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2081,12 +2391,16 @@ a ||= a + "foo"
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2112,12 +2426,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2140,12 +2458,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2171,12 +2493,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2199,12 +2525,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2226,12 +2556,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2258,12 +2592,16 @@ end
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2288,12 +2626,16 @@ x = $HOGE
     checker = new_subtyping_checker(<<-EOF)
 $HOGE: Integer
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2319,12 +2661,16 @@ x = $HOGE
     checker = new_subtyping_checker(<<-EOF)
 $HOGE: Integer
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2347,12 +2693,16 @@ x = $HOGE
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2383,12 +2733,16 @@ class A
   @foo: String
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2415,12 +2769,16 @@ class A
   @foo: String
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2445,12 +2803,16 @@ b = [*a]
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2475,12 +2837,16 @@ b = [*1...3]
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2505,12 +2871,16 @@ b = [*a]
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker()
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2540,22 +2910,24 @@ class A
   def gen: (*Integer) -> String
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
-    env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
-      const_env: env
+      const_env: const_env
     )
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2589,22 +2961,24 @@ class Hoge
   def foo: (self) -> void
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
-    env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
-      const_env: env
+      const_env: const_env
     )
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2643,22 +3017,24 @@ class Hoge
   def foo: () { () -> void } -> any
 end
     EOF
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
-    env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
     module_context = TypeConstruction::ModuleContext.new(
       instance_type: nil,
       module_type: nil,
-      const_types: annotations.const_types,
       implement_name: nil,
       current_namespace: nil,
-      const_env: env
+      const_env: const_env
     )
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        ivar_types: annotations.ivar_types,
-                                        var_types: {},
+                                        type_env: type_env,
                                         self_type: Types::Name.new_instance(name: "::Object"),
                                         block_context: nil,
                                         method_context: nil,
@@ -2687,11 +3063,16 @@ EOF
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker("")
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,
@@ -2716,11 +3097,16 @@ EOF
     typing = Typing.new
     annotations = source.annotations(block: source.node)
     checker = new_subtyping_checker("")
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
 
     construction = TypeConstruction.new(checker: checker,
                                         source: source,
                                         annotations: annotations,
-                                        var_types: {},
+                                        type_env: type_env,
                                         block_context: nil,
                                         self_type: nil,
                                         method_context: nil,

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -2098,7 +2098,7 @@ a ||= a + "foo"
 
     assert_equal 1, typing.errors.size
     assert_any typing.errors do |error|
-      error.is_a?(Steep::Errors::NoMethod)
+      error.is_a?(Steep::Errors::ArgumentTypeMismatch)
     end
   end
 

--- a/test/type_env_test.rb
+++ b/test/type_env_test.rb
@@ -1,0 +1,474 @@
+require_relative "test_helper"
+
+class TypeEnvTest < Minitest::Test
+  include Steep
+
+  include TestHelper
+  include SubtypingHelper
+
+  def test_ivar_without_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    # If no annotation is given to ivar, assign yields the block with nil and returns `any`
+    yield_self do
+      ivar_type = type_env.assign(ivar: :"@x",
+                                  type: AST::Types::Name.new_instance(name: "::String")) {|error| assert_nil error }
+      assert_instance_of AST::Types::Any, ivar_type
+    end
+
+    # If no annotation is given to ivar, get yields the block and returns `any`
+    yield_self do
+      ivar_type = type_env.get(ivar: :"@x") {|error| assert_nil error }
+      assert_instance_of AST::Types::Any, ivar_type
+    end
+  end
+
+  def test_ivar_with_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    type_env.set(ivar: :"@x", type: AST::Types::Name.new_instance(name: "::Numeric"))
+
+    # If annotation is given, get returns the type
+    yield_self do
+      ivar_type = type_env.get(ivar: :"@x")
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), ivar_type
+    end
+
+    # If annotation is given and assigned type is compatible with that, assign returns annotated type, no yield
+    yield_self do
+      ivar_type = type_env.assign(ivar: :"@x",
+                                  type: AST::Types::Name.new_instance(name: "::Integer")) do |_|
+        raise
+      end
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), ivar_type
+    end
+
+    # If annotation is given and assigned type is incompatible with that, assign returns annotated type and yield an failure result
+    yield_self do
+      ivar_type = type_env.assign(ivar: :"@x",
+                                  type: AST::Types::Name.new_instance(name: "::String")) do |error|
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), ivar_type
+    end
+  end
+
+  def test_gvar_without_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    # If no annotation is given to ivar, assign yields the block with nil and returns `any`
+    yield_self do
+      type = type_env.assign(gvar: :"$x",
+                                  type: AST::Types::Name.new_instance(name: "::String")) {|error| assert_nil error }
+      assert_instance_of AST::Types::Any, type
+    end
+
+    # If no annotation is given to ivar, get yields the block and returns `any`
+    yield_self do
+      type = type_env.get(gvar: :"$x") {|error| assert_nil error }
+      assert_instance_of AST::Types::Any, type
+    end
+  end
+
+  def test_gvar_with_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    type_env.set(gvar: :"$x", type: AST::Types::Name.new_instance(name: "::Numeric"))
+
+    # If annotation is given, get returns the type
+    yield_self do
+      type = type_env.get(gvar: :"$x")
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), type
+    end
+
+    # If annotation is given and assigned type is compatible with that, assign returns annotated type, no yield
+    yield_self do
+      type = type_env.assign(gvar: :"$x",
+                                  type: AST::Types::Name.new_instance(name: "::Integer")) do |_|
+        raise
+      end
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), type
+    end
+
+    # If annotation is given and assigned type is incompatible with that, assign returns annotated type and yield an failure result
+    yield_self do
+      type = type_env.assign(gvar: :"$x",
+                                  type: AST::Types::Name.new_instance(name: "::String")) do |error|
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), type
+    end
+  end
+
+  def test_const_without_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    # When constant type is known from const env
+
+    yield_self do
+      type = type_env.get(const: ModuleName.parse("Regexp"))
+      assert_equal AST::Types::Name.new_class(name: "::Regexp", constructor: true), type
+    end
+
+    yield_self do
+      type = type_env.assign(const: ModuleName.parse("Regexp"),
+                             type: AST::Types::Name.new_instance(name: "::String")) do |error|
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+      assert_equal AST::Types::Name.new_class(name: "::Regexp", constructor: true), type
+    end
+
+    yield_self do
+      type = type_env.assign(const: ModuleName.parse("Regexp"),
+                             type: AST::Types::Any.new) do |_|
+        raise
+      end
+      assert_equal AST::Types::Name.new_class(name: "::Regexp", constructor: true), type
+    end
+
+    # When constant type is unknown
+
+    yield_self do
+      type = type_env.get(const: ModuleName.parse("HOGE")) do end
+      assert_instance_of AST::Types::Any, type
+    end
+
+    yield_self do
+      type = type_env.assign(const: ModuleName.parse("HOGE"),
+                             type: AST::Types::Name.new_instance(name: "::String")) do |error|
+        assert_nil error
+      end
+      assert_instance_of AST::Types::Any, type
+    end
+  end
+
+  def test_const_with_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    type_env.set(const: ModuleName.parse("Regexp"), type: AST::Types::Name.new_instance(name: "::String"))
+
+    yield_self do
+      type = type_env.get(const: ModuleName.parse("Regexp"))
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type
+    end
+
+    yield_self do
+      type = type_env.assign(const: ModuleName.parse("Regexp"),
+                             type: AST::Types::Name.new_instance(name: "::Integer")) do |error|
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type
+    end
+
+    yield_self do
+      type = type_env.assign(const: ModuleName.parse("Regexp"),
+                             type: AST::Types::Name.new_instance(name: "::String")) do |_|
+        raise
+      end
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type
+    end
+  end
+
+  def test_lvar_get_without_assign
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    assert_raises do
+      type_env.get(lvar: :x) {|error| assert_nil error }
+    end
+  end
+
+  def test_lvar_without_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    yield_self do
+      type = type_env.assign(lvar: :x,
+                             type: AST::Types::Name.new_instance(name: "::String")) {|_| raise }
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type
+    end
+
+    yield_self do
+      type = type_env.assign(lvar: :x,
+                             type: AST::Types::Name.new_instance(name: "::Numeric")) do |error|
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type
+    end
+  end
+
+  def test_lvar_with_annotation
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    type_env.set(lvar: :x, type: AST::Types::Name.new_instance(name: "::Numeric"))
+
+    yield_self do
+      type = type_env.assign(lvar: :x,
+                             type: AST::Types::Name.new_instance(name: "::Integer")) {|_| raise }
+      assert_equal AST::Types::Name.new_instance(name: "::Numeric"), type
+    end
+  end
+
+  def test_with_annotation_lvar
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    original_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    union_type = AST::Types::Union.build(types: [
+      AST::Types::Name.new_instance(name: "::Integer"),
+      AST::Types::Name.new_instance(name: "::String")
+    ])
+
+    original_env.set(lvar: :x, type: union_type)
+
+    yield_self do
+      type_env = original_env.with_annotations(lvar_types: {
+        x: AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(lvar: :x) { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(lvar_types: {
+        x: AST::Types::Name.new_instance(name: "::Regexp")
+      }) do |name, error|
+        assert_equal name, :x
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::Regexp"), type_env.get(lvar: :x) { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(lvar_types: {
+        y: AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(lvar: :y) { raise }
+    end
+  end
+
+  def test_with_annotation_ivar
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    original_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    union_type = AST::Types::Union.build(types: [
+      AST::Types::Name.new_instance(name: "::Integer"),
+      AST::Types::Name.new_instance(name: "::String")
+    ])
+
+    original_env.set(ivar: :"@x", type: union_type)
+
+    yield_self do
+      type_env = original_env.with_annotations(ivar_types: {
+        "@x": AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(ivar: :"@x") { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(ivar_types: {
+        "@x": AST::Types::Name.new_instance(name: "::Regexp")
+      }) do |name, error|
+        assert_equal name, :"@x"
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::Regexp"), type_env.get(ivar: :"@x") { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(ivar_types: {
+        "@y": AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(ivar: :"@y") { raise }
+    end
+  end
+
+  def test_with_annotation_gvar
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    original_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    union_type = AST::Types::Union.build(types: [
+      AST::Types::Name.new_instance(name: "::Integer"),
+      AST::Types::Name.new_instance(name: "::String")
+    ])
+
+    original_env.set(gvar: :"$x", type: union_type)
+
+    yield_self do
+      type_env = original_env.with_annotations(gvar_types: {
+        "$x": AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(gvar: :"$x") { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(gvar_types: {
+        "$x": AST::Types::Name.new_instance(name: "::Regexp")
+      }) do |name, error|
+        assert_equal name, :"$x"
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::Regexp"), type_env.get(gvar: :"$x") { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(gvar_types: {
+        "$y": AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(gvar: :"$y") { raise }
+    end
+  end
+
+  def test_with_annotation_const
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    original_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    union_type = AST::Types::Union.build(types: [
+      AST::Types::Name.new_instance(name: "::Integer"),
+      AST::Types::Name.new_instance(name: "::String")
+    ])
+
+    original_env.set(const: ModuleName.parse("FOO"), type: union_type)
+
+    yield_self do
+      type_env = original_env.with_annotations(const_types: {
+        ModuleName.parse("FOO") => AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"),
+                   type_env.get(const: ModuleName.parse("FOO")) { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(const_types: {
+        ModuleName.parse("FOO") => AST::Types::Name.new_instance(name: "::Regexp")
+      }) do |name, error|
+        assert_equal name, ModuleName.parse("FOO")
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::Regexp"),
+                   type_env.get(const: ModuleName.parse("FOO")) { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(const_types: {
+        ModuleName.parse("String") => AST::Types::Name.new_instance(name: "::Regexp")
+      }) do |name, error|
+        assert_equal name, ModuleName.parse("String")
+        assert_instance_of Subtyping::Result::Failure, error
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::Regexp"),
+                   type_env.get(const: ModuleName.parse("String")) { raise }
+    end
+
+    yield_self do
+      type_env = original_env.with_annotations(const_types: {
+        ModuleName.parse("BAR") => AST::Types::Name.new_instance(name: "::String")
+      }) do |_, _|
+        raise
+      end
+
+      assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.get(const: ModuleName.parse("BAR")) { raise }
+    end
+  end
+
+  def test_join
+    subtyping = new_subtyping_checker()
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+    original_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
+
+    original_env.set(lvar: :z, type: AST::Types::Any.new)
+
+    envs = [
+      original_env.with_annotations(lvar_types: {
+        x: AST::Types::Name.new_instance(name: "::String"),
+        y: AST::Types::Name.new_instance(name: "::Integer")
+      }),
+      original_env.with_annotations(lvar_types: {
+        x: AST::Types::Name.new_instance(name: "::Integer"),
+        z: AST::Types::Name.new_instance(name: "::Regexp")
+      })
+    ]
+
+    original_env.join!(envs)
+
+    assert_equal AST::Types::Union.build(types: [
+      AST::Types::Name.new_instance(name: "::String"),
+      AST::Types::Name.new_instance(name: "::Integer"),
+    ]), original_env.get(lvar: :x)
+
+    assert_equal AST::Types::Name.new_instance(name: "::Integer"), original_env.get(lvar: :y)
+    assert_instance_of AST::Types::Any, original_env.get(lvar: :z)
+  end
+
+  def test_build
+    annotations = AST::Annotation::Collection.new(annotations: [
+      AST::Annotation::VarType.new(name: :x, type: AST::Types::Name.new_instance(name: :X)),
+      AST::Annotation::IvarType.new(name: :"@y", type: AST::Types::Name.new_instance(name: :Y)),
+      AST::Annotation::ConstType.new(name: ModuleName.parse("Foo"), type: AST::Types::Name.new_instance(name: "::Integer")),
+      AST::Annotation::ReturnType.new(type: AST::Types::Name.new_instance(name: :Z)),
+      AST::Annotation::BlockType.new(type: AST::Types::Name.new_instance(name: :A)),
+      AST::Annotation::Dynamic.new(name: :path)
+    ])
+
+    subtyping = new_subtyping_checker(<<EOF)
+$foo: String
+EOF
+    signatures = subtyping.builder.signatures
+    const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
+
+    env = TypeInference::TypeEnv.build(annotations: annotations,
+                                       signatures: signatures,
+                                       subtyping: subtyping,
+                                       const_env: const_env)
+
+    assert_equal AST::Types::Name.new_instance(name: :X), env.get(lvar: :x)
+    assert_equal AST::Types::Name.new_instance(name: :Y), env.get(ivar: :"@y")
+    assert_equal AST::Types::Name.new_instance(name: "::Integer"), env.get(const: ModuleName.parse("Foo"))
+    assert_equal AST::Types::Name.new_instance(name: "::String"), env.get(gvar: :"$foo")
+  end
+end

--- a/test/type_env_test.rb
+++ b/test/type_env_test.rb
@@ -186,9 +186,12 @@ class TypeEnvTest < Minitest::Test
     const_env = TypeInference::ConstantEnv.new(builder: subtyping.builder, current_namespace: nil)
     type_env = TypeInference::TypeEnv.new(subtyping: new_subtyping_checker(), const_env: const_env)
 
-    assert_raises do
-      type_env.get(lvar: :x) {|error| assert_nil error }
-    end
+    type = type_env.get(lvar: :x) { AST::Types::Name.new_instance(name: "::String") }
+    # Returns a type which obtained from given block
+    assert_equal AST::Types::Name.new_instance(name: "::String"), type
+
+    # And update environment
+    assert_equal AST::Types::Name.new_instance(name: "::String"), type_env.lvar_types[:x]
   end
 
   def test_lvar_without_annotation
@@ -466,8 +469,8 @@ EOF
                                        subtyping: subtyping,
                                        const_env: const_env)
 
-    assert_equal AST::Types::Name.new_instance(name: :X), env.get(lvar: :x)
-    assert_equal AST::Types::Name.new_instance(name: :Y), env.get(ivar: :"@y")
+    assert_equal AST::Types::Name.new_instance(name: "::X"), env.get(lvar: :x)
+    assert_equal AST::Types::Name.new_instance(name: "::Y"), env.get(ivar: :"@y")
     assert_equal AST::Types::Name.new_instance(name: "::Integer"), env.get(const: ModuleName.parse("Foo"))
     assert_equal AST::Types::Name.new_instance(name: "::String"), env.get(gvar: :"$foo")
   end

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -5,11 +5,15 @@ class TypeTest < Minitest::Test
 
   def test_level
     assert_equal [0], Types::Var.new(name: :foo).level
-    assert_equal [0, 0], Types::Intersection.build(types: [Types::Var.new(name: :foo)]).level
+    assert_equal [0, 0], Types::Intersection.build(types: [Types::Var.new(name: :foo),
+                                                           Types::Var.new(name: :bar)]).level
     assert_equal [1], Types::Any.new.level
     assert_equal [0, 0], Types::Name.new_instance(name: :"String", args: [Types::Var.new(name: :foo)]).level
     assert_equal [0, 1], Types::Name.new_instance(name: :"String", args: [Types::Any.new]).level
     assert_equal [0, 2], Types::Name.new_instance(name: :"String", args: [Types::Any.new, Types::Any.new]).level
-    assert_equal [0, 0, 1], Types::Union.build(types: [Types::Name.new_instance(name: :"String", args: [Types::Any.new])]).level
+    assert_equal [0, 0, 1], Types::Union.build(types: [
+      Types::Name.new_instance(name: :"String", args: [Types::Any.new]),
+      Types::Var.new(name: :x)
+    ]).level
   end
 end


### PR DESCRIPTION
This PR implements branch sensitive typing such that type annotations and local variable type inference works take care of branching.

```rb
# @type var x: Integer | String
x = nil
if test()
  # @type var x: Integer
  y = x + 1  # Type of x is Integer
else
  # @type var x: String
  y = (x + "").length # Type of x is String
end
```

It works for `rescue` and while loops.

It also works for local variables assignment type inference like:

```rb
if test()
  x = 30
  y = x + 1
else
  x = "foo"
  y = (x + "").length
end

# Type of x is Integer | String
```

## Not yet implemented:

* Global variable annotation
