### PR TITLE
Implement trivial typecase for `case` expression

### DIFF
--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -415,17 +415,38 @@ module Steep
     class IncompatibleAnnotation < Base
       attr_reader :var_name
       attr_reader :result
+      attr_reader :relation
 
-      def initialize(node:, var_name:, result:)
+      def initialize(node:, var_name:, result:, relation:)
         super(node: node)
         @var_name = var_name
         @result = result
+        @relation = relation
       end
 
       include ResultPrinter
 
       def to_s
-        "#{location_to_str}: IncompatibleAnnotation: var_name=#{var_name}, #{result.relation}"
+        "#{location_to_str}: IncompatibleAnnotation: var_name=#{var_name}, #{relation}"
+      end
+    end
+
+    class IncompatibleTypeCase < Base
+      attr_reader :var_name
+      attr_reader :result
+      attr_reader :relation
+
+      def initialize(node:, var_name:, result:, relation:)
+        super(node: node)
+        @var_name = var_name
+        @result = result
+        @relation = relation
+      end
+
+      include ResultPrinter
+
+      def to_s
+        "#{location_to_str}: IncompatibleTypeCase: var_name=#{var_name}, #{relation}"
       end
     end
   end

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -189,6 +189,23 @@ module Steep
           end
         end
 
+      when :when
+        last_cond = node.children[-2]
+        body = node.children.last
+
+        node.children.take(node.children.size-1) do |child|
+          construct_mapping(node: child, annotations: annotations, mapping: mapping, line_range: nil)
+        end
+
+        if body
+          cond_end = last_cond.loc.last_line+1
+          body_end = body.loc.last_line
+          construct_mapping(node: body,
+                            annotations: annotations,
+                            mapping: mapping,
+                            line_range: cond_end...body_end)
+        end
+
       when :rescue
         if node.children.last
           else_node = node.children.last
@@ -213,7 +230,7 @@ module Steep
 
       associated_annotations = annotations.select do |annot|
         case node.type
-        when :def, :module, :class, :block, :when, :ensure
+        when :def, :module, :class, :block, :ensure
           loc = node.loc
           loc.line <= annot.line && annot.line < loc.last_line
 

--- a/lib/steep/subtyping/result.rb
+++ b/lib/steep/subtyping/result.rb
@@ -96,7 +96,6 @@ module Steep
           end
         end
 
-        attr_reader :relation
         attr_reader :error
         attr_reader :trace
 

--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -210,7 +210,7 @@ module Steep
         constraints = Subtyping::Constraints.new(unknowns: Set.new)
 
         subtyping.check(relation, constraints: constraints).else do |result|
-          yield name, result
+          yield name, relation, result
         end
 
         annotated_type

--- a/smoke/type_case/a.rb
+++ b/smoke/type_case/a.rb
@@ -1,0 +1,28 @@
+# @type var x: Integer | String | Symbol
+
+x = nil
+
+case x
+when Integer, String
+  # !expects NoMethodError: type=(::Integer | ::String), method=foobar
+  x.foobar()
+end
+
+case x == 1
+when Integer
+  # !expects NoMethodError: type=(::Integer | ::String | ::Symbol), method=foobar
+  x.foobar
+end
+
+case x
+when 1
+  # !expects NoMethodError: type=(::Integer | ::String | ::Symbol), method=foobar
+  x.foobar
+end
+
+case x
+when String
+  # @type var x: Integer
+  # !expects NoMethodError: type=::Integer, method=foobar
+  x.foobar
+end

--- a/smoke/type_case/a.rb
+++ b/smoke/type_case/a.rb
@@ -22,7 +22,14 @@ end
 
 case x
 when String
+  # !expects@+2 IncompatibleAnnotation: var_name=x, ::Integer <: ::String
   # @type var x: Integer
-  # !expects NoMethodError: type=::Integer, method=foobar
+  x + 1
+end
+
+case x
+when Object
+  # !expects@+2 IncompatibleTypeCase: var_name=x, ::Object <: (::Integer | ::String | ::Symbol)
+  # !expects NoMethodError: type=::Object, method=foobar
   x.foobar
 end

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -251,7 +251,7 @@ end
       assert_nil annotations.var_types[:y]
     end
 
-    source.node.children[1].yield_self do |node|
+    source.node.children[1].children.last.yield_self do |node|
       annotations = source.annotations(block: node)
       refute_nil annotations.var_types[:x]
       assert_nil annotations.var_types[:y]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -324,6 +324,10 @@ end
 class Integer <: Numeric
 end
 
+class Symbol
+  def id2name: -> String
+end
+
 class Range<'a>
   def begin: -> 'a
   def end: -> 'a

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3373,4 +3373,42 @@ EOF
                                             Types::Name.new_instance(name: "::Integer")]),
                  type_env.lvar_types[:x]
   end
+
+  def test_type_case_case_when
+    source = parse_ruby(<<EOF)
+# @type var x: String | Integer | Symbol
+x = nil
+
+case x
+when String
+  y = (x + "").size
+when Integer
+  y = x + 1
+else
+  y = x.id2name.size
+end
+EOF
+    typing = Typing.new
+    annotations = source.annotations(block: source.node)
+    checker = new_subtyping_checker("")
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: nil,
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+  end
 end

--- a/test/type_env_test.rb
+++ b/test/type_env_test.rb
@@ -254,7 +254,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(lvar_types: {
         x: AST::Types::Name.new_instance(name: "::Regexp")
-      }) do |name, error|
+      }) do |name, relation, error|
         assert_equal name, :x
         assert_instance_of Subtyping::Result::Failure, error
       end
@@ -265,7 +265,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(lvar_types: {
         y: AST::Types::Name.new_instance(name: "::String")
-      }) do |_, _|
+      }) do |_, _, _|
         raise
       end
 
@@ -288,7 +288,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(ivar_types: {
         "@x": AST::Types::Name.new_instance(name: "::String")
-      }) do |_, _|
+      }) do |_, _, _|
         raise
       end
 
@@ -298,7 +298,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(ivar_types: {
         "@x": AST::Types::Name.new_instance(name: "::Regexp")
-      }) do |name, error|
+      }) do |name, relation, error|
         assert_equal name, :"@x"
         assert_instance_of Subtyping::Result::Failure, error
       end
@@ -309,7 +309,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(ivar_types: {
         "@y": AST::Types::Name.new_instance(name: "::String")
-      }) do |_, _|
+      }) do |_, _, _|
         raise
       end
 
@@ -342,7 +342,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(gvar_types: {
         "$x": AST::Types::Name.new_instance(name: "::Regexp")
-      }) do |name, error|
+      }) do |name, relation, error|
         assert_equal name, :"$x"
         assert_instance_of Subtyping::Result::Failure, error
       end
@@ -387,7 +387,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(const_types: {
         ModuleName.parse("FOO") => AST::Types::Name.new_instance(name: "::Regexp")
-      }) do |name, error|
+      }) do |name, relation, error|
         assert_equal name, ModuleName.parse("FOO")
         assert_instance_of Subtyping::Result::Failure, error
       end
@@ -399,7 +399,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(const_types: {
         ModuleName.parse("String") => AST::Types::Name.new_instance(name: "::Regexp")
-      }) do |name, error|
+      }) do |name, relation, error|
         assert_equal name, ModuleName.parse("String")
         assert_instance_of Subtyping::Result::Failure, error
       end
@@ -411,7 +411,7 @@ class TypeEnvTest < Minitest::Test
     yield_self do
       type_env = original_env.with_annotations(const_types: {
         ModuleName.parse("BAR") => AST::Types::Name.new_instance(name: "::String")
-      }) do |_, _|
+      }) do |_, _, _|
         raise
       end
 


### PR DESCRIPTION
This patch is to support typing based on `case` expression:

```rb
# @type var x: Integer | String | Symbol

x = nil

case x
when Integer
  # x is a Integer
  y = x + 1
when String
  # x is a String
  y = x + ""
else
  # x is a Symbol
  y = x.id2name
end
```

This patch assumes the implementation of `Class#===`, so this behavior may become opt-in.

## Typing rule

* When `case` is on a *value* expression (current implementation only supports `lvar`), and
* `when` clauses have all `*.class` types, then
* `when` body will have an instance of that types (or their union), and
* `else` body will have an instance of left type (or their union)

## Future improvements

* To support assignments like: `case (x = foo)`
* To support other kinds of variables: constants, ivars, gvars
