### PR TITLE
Fix Array typing

### DIFF
--- a/lib/steep/ast/types/name.rb
+++ b/lib/steep/ast/types/name.rb
@@ -85,7 +85,7 @@ module Steep
             self.class.new_class(location: location,
                                  name: name.name,
                                  constructor: constructor,
-                                 args: args)
+                                 args: [])
           when TypeName::Class
             self
           when TypeName::Module, TypeName::Interface

--- a/lib/steep/interface/abstract.rb
+++ b/lib/steep/interface/abstract.rb
@@ -26,6 +26,7 @@ module Steep
       end
 
       def instantiate(type:, args:, instance_type:, module_type:)
+        Steep.logger.debug("type=#{type}, self=#{name}, args=#{args}, params=#{params}")
         subst = Substitution.build(params, args, instance_type: instance_type, module_type: module_type, self_type: type)
 
         Instantiated.new(

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -154,7 +154,6 @@ module Steep
       def class_to_interface(sig, constructor:)
         type_name = TypeName::Class.new(name: sig.name, constructor: constructor)
 
-        params = sig.params&.variables || []
         supers = []
         methods = {}
 
@@ -226,7 +225,7 @@ module Steep
 
         Abstract.new(
           name: type_name,
-          params: params,
+          params: [],
           methods: methods,
           supers: supers,
           ivars: {}
@@ -236,7 +235,6 @@ module Steep
       def module_to_interface(sig)
         type_name = TypeName::Module.new(name: sig.name)
 
-        params = sig.params&.variables || []
         supers = [sig.self_type].compact.map {|type| absolute_type(type, current: nil) }
         methods = {}
 
@@ -279,7 +277,7 @@ module Steep
 
         Abstract.new(
           name: type_name,
-          params: params,
+          params: [],
           methods: methods,
           supers: supers,
           ivars: {}

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -138,7 +138,7 @@ block_params2: { result = nil }
 simple_type: type_name {
         result = AST::Types::Name.new(name: val[0].value, location: val[0].location, args: [])
       }
-    | type_name LT type_seq GT {
+    | instance_type_name LT type_seq GT {
         loc = val[0].location + val[3].location
         name = val[0].value
         args = val[2]
@@ -152,10 +152,16 @@ simple_type: type_name {
     | SELF { result = AST::Types::Self.new(location: val[0].location) }
     | VOID { result = AST::Types::Void.new(location: val[0].location) }
 
-type_name: module_name {
-             result = LocatedValue.new(value: TypeName::Instance.new(name: val[0].value),
-                                       location: val[0].location)
-           }
+instance_type_name: module_name {
+                      result = LocatedValue.new(value: TypeName::Instance.new(name: val[0].value),
+                                                location: val[0].location)
+                    }
+                  | INTERFACE_NAME {
+                      result = LocatedValue.new(value: TypeName::Interface.new(name: val[0].value),
+                                                location: val[0].location)
+                    }
+
+type_name: instance_type_name
          | module_name DOT CLASS constructor {
              loc = val[0].location + (val[3] || val[2]).location
              result = LocatedValue.new(value: TypeName::Class.new(name: val[0].value, constructor: val[3]&.value),
@@ -165,10 +171,6 @@ type_name: module_name {
              loc = val[0].location + val.last.location
              result = LocatedValue.new(value: TypeName::Module.new(name: val[0].value),
                                        location: loc)
-           }
-         | INTERFACE_NAME {
-             result = LocatedValue.new(value: TypeName::Interface.new(name: val[0].value),
-                                       location: val[0].location)
            }
 
 constructor: { result = nil }

--- a/smoke/enumerator/b.rb
+++ b/smoke/enumerator/b.rb
@@ -9,7 +9,7 @@ b = a.each.with_object([]) do |i, xs|
   xs << i.to_s
 end
 
-# !expects IncompatibleAssignment: lhs_type=::Array<::Integer>, rhs_type=Array<String>
+# !expects IncompatibleAssignment: lhs_type=::Array<::Integer>, rhs_type=::Array<::String>
 c = a.each.with_object([]) do |i, xs|
   # @type var xs: Array<String>
   xs << i.to_s

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -35,7 +35,7 @@ end
 
 class Class<'instance> <: Module
   def new: (*any, **any) -> 'instance
-  def class: -> Class.class<any>
+  def class: -> Class.class
   def allocate: -> 'instance
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -337,6 +337,7 @@ class Regexp
 end
 
 class Array<'a>
+  def initialize: -> any
   def []: (Integer) -> 'a
   def []=: (Integer, 'a) -> 'a
   def <<: ('a) -> self

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3475,4 +3475,32 @@ EOF
 
     assert_empty typing.errors
   end
+
+  def test_parametrized_class_constant
+    source = parse_ruby(<<EOF)
+Array.new
+EOF
+    typing = Typing.new
+    annotations = source.annotations(block: source.node)
+    checker = new_subtyping_checker("")
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: nil,
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+  end
 end


### PR DESCRIPTION
This fixes typing of `Array` constant. `Array` is a parametrized type but what about `.class` type???

* Let `.class` types be non-parametrized
* Let `instance` types in `.class` types with with `any` application