### PR TITLE
Improve type case

### DIFF
--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -449,5 +449,13 @@ module Steep
         "#{location_to_str}: IncompatibleTypeCase: var_name=#{var_name}, #{relation}"
       end
     end
+
+    class ElseOnExhaustiveCase < Base
+      def initialize(node:, type:)
+        def to_s
+          "#{location_to_str}: ElseOnExhaustiveCase: type=#{type}"
+        end
+      end
+    end
   end
 end

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -245,6 +245,16 @@ module Steep
           )
       end
 
+      def with(type_params: NONE, params: NONE, block: NONE, return_type: NONE, location: NONE)
+        self.class.new(
+          type_params: type_params.equal?(NONE) ? self.type_params : type_params,
+          params: params.equal?(NONE) ? self.params : params,
+          block: block.equal?(NONE) ? self.block : block,
+          return_type: return_type.equal?(NONE) ? self.return_type : return_type,
+          location: location.equal?(NONE) ? self.location : location
+        )
+      end
+
       def to_s
         type_params = !self.type_params.empty? ? "<#{self.type_params.join(", ")}> " : ""
         params = self.params.to_s

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -520,7 +520,7 @@ end
     ])
     interface = checker.resolve(type, with_initialize: false)
 
-    assert_equal [:tap, :yield_self], interface.methods.keys
+    assert_equal [:tap, :yield_self, :allocate], interface.methods.keys
     assert_equal [type], interface.methods[:tap].types.map {|ty| ty.return_type }
     assert_equal [[type]], interface.methods[:yield_self].types.map {|ty| ty.block.params.required }
   end
@@ -555,6 +555,23 @@ end
                      type.return_type
       end
     end
+  end
+
+  def test_resolve4
+    checker = new_checker("")
+
+    interface = checker.resolve(
+      AST::Types::Union.new(types: [
+        AST::Types::Name.new_instance(name: "::Array", args: [AST::Types::Name.new_instance(name: "::Integer")]),
+        AST::Types::Name.new_instance(name: "::Array", args: [AST::Types::Name.new_instance(name: "::String")])
+      ]),
+      with_initialize: false
+    )
+
+    assert_equal [:tap, :yield_self, :allocate, :[]], interface.methods.keys
+    assert_equal [AST::Types::Union.build(types: [AST::Types::Name.new_instance(name: "::Integer"),
+                                                  AST::Types::Name.new_instance(name: "::String")])],
+                 interface.methods[:[]].types.map(&:return_type)
   end
 
   def test_resolve_void


### PR DESCRIPTION
Improve type case for parametrized types. It also checks if `else` clause present in the exaustive case.

```rb
# @type var x: Array<Integer> | Array<String> | Symbol
x = nil

case x
when Array
  # x is Array<Integer> | Array<String> here
  # x[0] is Integer | String
  y = x[0]
when Symbol
  # x is Symbol
  z = x
else
  # Execution cannot reach here and Steep reports an `ElseOnExhaustiveCase`.
end
```