### PR TITLE
Nil

### DIFF
--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -153,6 +153,8 @@ simple_type: type_name {
     | INSTANCE { result = AST::Types::Instance.new(location: val[0].location) }
     | SELF { result = AST::Types::Self.new(location: val[0].location) }
     | VOID { result = AST::Types::Void.new(location: val[0].location) }
+    | NIL { result = AST::Types::Name.new_instance(name: ModuleName.new(name: "NilClass", absolute: true),
+                                                   location: val[0].location) }
 
 instance_type_name: module_name {
                       result = LocatedValue.new(value: TypeName::Instance.new(name: val[0].value),
@@ -592,6 +594,8 @@ def next_token
     new_token(:LT, :<)
   when input.scan(/>/)
     new_token(:GT, :>)
+  when input.scan(/nil\b/)
+    new_token(:NIL, :nil)
   when input.scan(/any\b/)
     new_token(:ANY, :any)
   when input.scan(/void\b/)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1120,9 +1120,10 @@ module Steep
             cond, body = node.children
 
             synthesize(cond)
+            truthy_vars = node.type == :while ? TypeConstruction.truthy_variables(cond) : Set.new
 
             if body
-              for_loop = for_branch(body).with(break_context: BreakContext.new(break_type: nil, next_type: nil))
+              for_loop = for_branch(body, truthy_vars: truthy_vars).with(break_context: BreakContext.new(break_type: nil, next_type: nil))
               for_loop.synthesize(body)
               type_env.join!([for_loop.type_env])
             end

--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -63,6 +63,8 @@ module Steep
       def join!(envs)
         lvars = {}
 
+        common_vars = envs.map {|env| Set.new(env.lvar_types.keys) }.inject {|a, b| a & b }
+
         envs.each do |env|
           env.lvar_types.each do |name, type|
             unless lvar_types.key?(name)
@@ -73,7 +75,11 @@ module Steep
         end
 
         lvars.each do |name, types|
-          set(lvar: name, type: AST::Types::Union.build(types: types))
+          if lvar_types.key?(name) || common_vars.member?(name)
+            set(lvar: name, type: AST::Types::Union.build(types: types))
+          else
+            set(lvar: name, type: AST::Types::Union.build(types: types + [AST::Types::Name.new_instance(name: "::NilClass")]))
+          end
         end
       end
 

--- a/smoke/and/a.rb
+++ b/smoke/and/a.rb
@@ -3,8 +3,9 @@
 
 a = "foo"
 
+# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::NilClass | ::String)
 b = a && a.to_str
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::String
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::NilClass | ::String)
 c = a && a.to_str
 

--- a/smoke/array/a.rb
+++ b/smoke/array/a.rb
@@ -7,17 +7,15 @@ a[1] = 3
 a[2] = "foo"
 
 # @type var i: Integer
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Integer | ::NilClass)
 i = a[0]
 
 # @type var s: String
-# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::Integer | ::NilClass)
+# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=::Integer
 s = a[1]
 
 
 b = ["a", "b", "c"]
 
-# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::NilClass | ::String)
 s = b[0]
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::NilClass | ::String)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::String
 i = b[1]

--- a/smoke/array/a.rb
+++ b/smoke/array/a.rb
@@ -7,16 +7,17 @@ a[1] = 3
 a[2] = "foo"
 
 # @type var i: Integer
-# @type var s: String
-
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Integer | ::NilClass)
 i = a[0]
 
-# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=::Integer
+# @type var s: String
+# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::Integer | ::NilClass)
 s = a[1]
 
 
 b = ["a", "b", "c"]
 
+# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::NilClass | ::String)
 s = b[0]
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=::String
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::NilClass | ::String)
 i = b[1]

--- a/smoke/block/b.rb
+++ b/smoke/block/b.rb
@@ -1,5 +1,5 @@
 # @type var a: A
-a = nil
+a = (_ = nil)
 
 a.bar do |x|
   # !expects BreakTypeMismatch: expected=::Symbol, actual=::Integer

--- a/smoke/case/a.rb
+++ b/smoke/case/a.rb
@@ -1,6 +1,6 @@
 # @type var a: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Array<::String> | ::Integer | ::String)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Array<::String> | ::Integer | ::NilClass | ::String)
 a = case 1
     when 2
       1
@@ -16,5 +16,5 @@ a = case 1
 a = case
     # !expects ArgumentTypeMismatch: expected=::Integer, actual=::String
     when 1+"a"
-      nil
+      (_ = nil)
     end

--- a/smoke/class/f.rb
+++ b/smoke/class/f.rb
@@ -1,8 +1,8 @@
 # @type var e: E
 # @type var d: D
 
-e = nil
-d = nil
+e = (_ = nil)
+d = (_ = nil)
 
 e = d
 d = e

--- a/smoke/extension/a.rb
+++ b/smoke/extension/a.rb
@@ -1,6 +1,6 @@
 # @type var foo: Foo
 
-foo = nil
+foo = (_ = nil)
 
 foo.try do |x|
   # @type var string: String

--- a/smoke/extension/b.rb
+++ b/smoke/extension/b.rb
@@ -1,5 +1,5 @@
 # @type var foo: Foo
-foo = nil
+foo = (_ = nil)
 
 # @type var integer: Integer
 

--- a/smoke/hello/hello.rb
+++ b/smoke/hello/hello.rb
@@ -1,8 +1,8 @@
 # @type var x: _Foo
 # @type var y: _Bar
 
-x = nil
-y = nil
+x = (_ = nil)
+y = (_ = nil)
 
 a = x.foo
 

--- a/smoke/type_case/a.rb
+++ b/smoke/type_case/a.rb
@@ -1,6 +1,6 @@
 # @type var x: Integer | String | Symbol
 
-x = nil
+x = (_ = nil)
 
 case x
 when Integer, String

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -59,8 +59,8 @@ module Kernel
 end
 
 class Array<'a>
-  def []: (Integer) -> ('a | nil)
-        | (Integer, Integer) -> ('a | nil)
+  def []: (Integer) -> 'a
+        | (Integer, Integer) -> (self | nil)
   def []=: (Integer, 'a) -> 'a
          | (Integer, Integer, self) -> self
   def empty?: -> _Boolean

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -55,19 +55,19 @@ module Kernel
   def require: (*String) -> void
   def loop: { () -> void } -> void
   def puts: (*any) -> void
-  def eval: (String, ?Integer, ?String) -> any
+  def eval: (String, ? Integer | nil, ?String) -> any
 end
 
 class Array<'a>
-  def []: (Integer) -> 'a
-        | (Integer, Integer) -> self
+  def []: (Integer) -> ('a | nil)
+        | (Integer, Integer) -> ('a | nil)
   def []=: (Integer, 'a) -> 'a
          | (Integer, Integer, self) -> self
   def empty?: -> _Boolean
   def size: -> Integer
   def map: <'b> { ('a) -> 'b } -> Array<'b>
   def join: (any) -> String
-  def all?: { (any) -> any } -> _Boolean
+  def all?: { ('a) -> any } -> _Boolean
   def sort_by: { ('a) -> any } -> Array<'a>
   def zip: <'b> (Array<'b>) -> Array<any>
          | <'b, 'c> (Array<'b>) { ('a, 'b) -> 'c }-> Array<'c>
@@ -88,11 +88,11 @@ class Array<'a>
   def pack: (String, ?buffer: String) -> String
   def reverse: -> self
   def +: (self) -> self
-  def last: -> 'a
+  def last: -> ('a | nil)
   def slice!: (Integer) -> self
             | (Integer, Integer) -> self
             | (Range<Integer>) -> self
-  def first: -> 'a
+  def first: -> ('a | nil)
   def replace: (self) -> self
   def transpose: -> self
   def fill: ('a) -> self
@@ -102,7 +102,7 @@ class Array<'a>
 end
 
 class Hash<'key, 'value>
-  def []: ('key) -> 'value
+  def []: ('key) -> ('value | nil)
   def []=: ('key, 'value) -> 'value
   def size: -> Integer
   def transform_values: <'a> { ('value) -> 'a } -> Hash<'key, 'a>
@@ -252,4 +252,5 @@ class File
   def self.readable?: (String) -> _Boolean
   def self.binwrite: (String, String) -> void
   def self.read: (String) -> String
+               | (String, Integer | nil) -> (String | nil)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -301,6 +301,7 @@ end
 class Object <: BasicObject
   def class: -> module
   def tap: { (instance) -> any } -> instance
+  def gets: -> (String | NilClass)
 end
 
 class Class<'a>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -347,6 +347,9 @@ class Array<'a>
   def zip: <'b> (Array<'b>) -> Array<'a | 'b>
   def each_with_object: <'b> ('b) { ('a, 'b) -> any } -> 'b
 end
+
+class NilClass
+end
   EOS
 
   DEFAULT_SIGS = <<-EOS

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -22,7 +22,7 @@ class TypeConstructionTest < Minitest::Test
   def test_lvar_with_annotation
     source = parse_ruby(<<-EOF)
 # @type var x: _A
-x = nil
+x = (_ = nil)
     EOF
 
     typing = Typing.new
@@ -54,7 +54,7 @@ x = nil
     source = parse_ruby(<<-EOF)
 # @type var x: _B
 # @type var z: _A
-x = nil
+x = (_ = nil)
 z = x
     EOF
 
@@ -124,7 +124,7 @@ z = x
   def test_lvar_without_annotation_inference
     source = parse_ruby(<<-EOF)
 # @type var x: _A
-x = nil
+x = (_ = nil)
 z = x
     EOF
 
@@ -156,7 +156,7 @@ z = x
   def test_method_call
     source = parse_ruby(<<-EOF)
 # @type var x: _C
-x = nil
+x = (_ = nil)
 x.f
     EOF
 
@@ -189,8 +189,8 @@ x.f
     source = parse_ruby(<<-EOF)
 # @type var x: _C
 # @type var y: _A
-x = nil
-y = nil
+x = (_ = nil)
+y = (_ = nil)
 x.g(y)
     EOF
 
@@ -223,8 +223,8 @@ x.g(y)
     source = parse_ruby(<<-EOF)
 # @type var x: _C
 # @type var y: _B
-x = nil
-y = nil
+x = (_ = nil)
+y = (_ = nil)
 x.g(y)
     EOF
 
@@ -259,7 +259,7 @@ x.g(y)
 
   def test_method_call_no_error_if_any
     source = parse_ruby(<<-EOF)
-x = nil
+x = (_ = nil)
 x.no_such_method
     EOF
 
@@ -291,7 +291,7 @@ x.no_such_method
   def test_method_call_no_method_error
     source = parse_ruby(<<-EOF)
 # @type var x: _C
-x = nil
+x = (_ = nil)
 x.no_such_method
     EOF
 
@@ -326,8 +326,8 @@ x.no_such_method
     source = parse_ruby(<<-EOF)
 # @type var x: _A
 # @type var a: _C
-a = nil
-x = nil
+a = (_ = nil)
+x = (_ = nil)
 a.g()
     EOF
 
@@ -365,9 +365,9 @@ a.g()
     source = parse_ruby(<<-EOF)
 # @type var x: _A
 # @type var a: _C
-a = nil
-x = nil
-a.g(nil, nil, nil)
+a = (_ = nil)
+x = (_ = nil)
+a.g(_ = nil, _ = nil, _ = nil)
     EOF
 
     typing = Typing.new
@@ -405,9 +405,9 @@ a.g(nil, nil, nil)
 # @type var x: _C
 # @type var a: _A
 # @type var b: _B
-x = nil
-a = nil
-b = nil
+x = (_ = nil)
+a = (_ = nil)
+b = (_ = nil)
 x.h(a: a, b: b)
     EOF
 
@@ -439,7 +439,7 @@ x.h(a: a, b: b)
   def test_keyword_missing
     source = parse_ruby(<<-EOF)
 # @type var x: _C
-x = nil
+x = (_ = nil)
 x.h()
     EOF
 
@@ -477,7 +477,7 @@ x.h()
   def test_extra_keyword_given
     source = parse_ruby(<<-EOF)
 # @type var x: _C
-x = nil
+x = (_ = nil)
 x.h(a: nil, b: nil, c: nil)
     EOF
 
@@ -515,8 +515,8 @@ x.h(a: nil, b: nil, c: nil)
     source = parse_ruby(<<-EOF)
 # @type var x: _C
 # @type var y: _B
-x = nil
-y = nil
+x = (_ = nil)
+y = (_ = nil)
 x.h(a: y)
     EOF
 
@@ -553,7 +553,7 @@ x.h(a: y)
     source = parse_ruby(<<-EOF)
 def foo
   # @type var x: _A
-  x = nil
+  x = (_ = nil)
 end
     EOF
 
@@ -711,12 +711,12 @@ end
   def test_block
     source = parse_ruby(<<-EOF)
 # @type var a: _X
-a = nil
+a = (_ = nil)
 
 b = a.f do |x|
   # @type var x: _A
   # @type var y: _B
-  y = nil
+  y = (_ = nil)
   x
   y
 end
@@ -760,7 +760,7 @@ b
   def test_block_shadow
     source = parse_ruby(<<-EOF)
 # @type var a: _X
-a = nil
+a = (_ = nil)
 
 a.f do |a|
   # @type var a: _A
@@ -799,12 +799,12 @@ end
   def test_block_param_type
     source = parse_ruby(<<-EOF)
 # @type var x: _X
-x = nil
+x = (_ = nil)
 
 x.f do |a|
   # @type var d: _D
   a
-  d = nil
+  d = (_ = nil)
 end
     EOF
 
@@ -838,7 +838,7 @@ end
   def test_block_value_type
     source = parse_ruby(<<-EOF)
 # @type var x: _X
-x = nil
+x = (_ = nil)
 
 x.f do |a|
   a
@@ -876,12 +876,12 @@ end
   def test_block_break_type
     source = parse_ruby(<<-EOF)
 # @type var x: _X
-x = nil
+x = (_ = nil)
 
 x.f do |a|
   break a
   # @type var d: _D
-  d = nil
+  d = (_ = nil)
 end
     EOF
 
@@ -918,7 +918,7 @@ end
 def foo()
   # @type return: _A
   # @type var a: _A
-  a = nil
+  a = (_ = nil)
   return a
 end
     EOF
@@ -952,7 +952,7 @@ end
 def foo()
   # @type return: _X
   # @type var a: _A
-  a = nil
+  a = (_ = nil)
   return a
 end
     EOF
@@ -1155,9 +1155,9 @@ X: Module
 # @type var k: _Kernel
 # @type var a: _A
 # @type var c: _C
-k = nil
-a = nil
-c = nil
+k = (_ = nil)
+a = (_ = nil)
+c = (_ = nil)
 
 # @type var b: _B
 # b = k.foo(a)
@@ -1196,7 +1196,7 @@ def foo
   # @type ivar @x: _A
   # @type var y: _D
   
-  y = nil
+  y = (_ = nil)
   
   @x = y
   y = @x
@@ -1241,7 +1241,7 @@ end
   def test_poly_method_arg
     source = parse_ruby(<<-EOF)
 # @type var poly: _PolyMethod
-poly = nil
+poly = (_ = nil)
 
 # @type var string: String
 string = poly.snd(1, "a")
@@ -1274,7 +1274,7 @@ string = poly.snd(1, "a")
   def test_poly_method_block
     source = parse_ruby(<<-EOF)
 # @type var poly: _PolyMethod
-poly = nil
+poly = (_ = nil)
 
 # @type var string: String
 string = poly.try { "string" }
@@ -2076,7 +2076,7 @@ a, @b = x
   def test_masgn_union
     source = parse_ruby(<<-EOF)
 # @type var x: Array<Integer> | Array<String>
-x = nil
+x = (_ = nil)
 a, b = x
     EOF
 
@@ -2903,7 +2903,7 @@ b = [*1...3]
   def test_splat_object
     source = parse_ruby(<<-'EOF')
 # @type var a: Array<Symbol> | Integer
-a = nil
+a = (_ = nil)
 b = [*a, *["foo"]]
     EOF
 
@@ -3204,7 +3204,7 @@ EOF
   def test_if_annotation
     source = parse_ruby(<<EOF)
 # @type var x: String | Integer
-x = nil
+x = (_ = nil)
 
 if 3
   # @type var x: String
@@ -3249,7 +3249,7 @@ EOF
   def test_if_annotation_error
     source = parse_ruby(<<EOF)
 # @type var x: Array<String>
-x = nil
+x = (_ = nil)
 
 if 3
   # @type var x: String
@@ -3343,7 +3343,7 @@ EOF
   def test_where_typing
     source = parse_ruby(<<EOF)
 # @type var x: Integer | String
-x = nil
+x = (_ = nil)
 
 while 3
   # @type var x: Integer
@@ -3420,7 +3420,7 @@ EOF
   def test_type_case_case_when
     source = parse_ruby(<<EOF)
 # @type var x: String | Integer | Symbol
-x = nil
+x = (_ = nil)
 
 case x
 when String
@@ -3458,7 +3458,7 @@ EOF
   def test_type_case_array
     source = parse_ruby(<<EOF)
 # @type var x: Array<String> | Array<Integer> | Range<Symbol>
-x = nil
+x = (_ = nil)
 
 case x
 when Array
@@ -3499,7 +3499,7 @@ EOF
   def test_type_case_array2
     source = parse_ruby(<<EOF)
 # @type var x: Array<String> | Array<Integer>
-x = nil
+x = (_ = nil)
 
 case x
 when Array
@@ -3669,7 +3669,7 @@ class Optional
 end
 
 # @type var x: Optional
-x = nil
+x = (_ = nil)
 (x.map("foo") {|x| x.size }) + 3
 (x.map("foo") {|x| (_ = x) }) + 3
 EOF
@@ -3866,6 +3866,56 @@ EOF
     source = parse_ruby(<<EOF)
 # @type var x: Integer    
 x = Array.new(3)[0]
+EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node)
+    checker = new_subtyping_checker("")
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: nil,
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+  end
+
+  def test_truthy_variables
+    assert_equal Set.new([:x]), TypeConstruction.truthy_variables(parse_ruby("x = 1").node)
+    assert_equal Set.new([:x, :y]), TypeConstruction.truthy_variables(parse_ruby("x = y = 1").node)
+    assert_equal Set.new([:x]), TypeConstruction.truthy_variables(parse_ruby("(x = 1) && f()").node)
+  end
+
+  def test_unwrap
+    assert_equal Types::Name.new_instance(name: "::Integer"),
+                 TypeConstruction.unwrap(
+                   Types::Union.build(types: [
+                     Types::Name.new_instance(name: "::Integer"),
+                     Types::Name.new_instance(name: "::NilClass"),
+                   ])
+                 )
+  end
+
+  def test_if_unwrap
+    source = parse_ruby(<<EOF)
+# @type var x: Integer | NilClass    
+x = nil
+
+if x
+  x + 1
+end
 EOF
 
     typing = Typing.new

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3987,4 +3987,41 @@ EOF
       Types::Name.new_instance(name: "::NilClass")
     ]), type_env.lvar_types[:z]
   end
+
+  def test_csend_unwrap
+    source = parse_ruby(<<EOF)
+# @type var x: String | NilClass    
+x = nil
+
+z = x&.size()
+EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node)
+    checker = new_subtyping_checker("")
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: nil,
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+
+    assert_equal Types::Union.build(types: [
+      Types::Name.new_instance(name: "::Integer"),
+      Types::Name.new_instance(name: "::NilClass")
+    ]), type_env.lvar_types[:z]
+  end
 end

--- a/test/type_env_test.rb
+++ b/test/type_env_test.rb
@@ -444,7 +444,9 @@ class TypeEnvTest < Minitest::Test
       AST::Types::Name.new_instance(name: "::Integer"),
     ]), original_env.get(lvar: :x)
 
-    assert_equal AST::Types::Name.new_instance(name: "::Integer"), original_env.get(lvar: :y)
+    assert_equal AST::Types::Union.build(types: [AST::Types::Name.new_instance(name: "::Integer"),
+                                                 AST::Types::Name.new_instance(name: "::NilClass")]),
+                 original_env.get(lvar: :y)
     assert_instance_of AST::Types::Any, original_env.get(lvar: :z)
   end
 

--- a/test/type_parsing_test.rb
+++ b/test/type_parsing_test.rb
@@ -118,4 +118,13 @@ class TypeParsingTest < Minitest::Test
     assert_equal AST::Types::Void.new, type
     assert_location type, start_line: 1, start_column: 6, end_line: 1, end_column: 10
   end
+
+  def test_optional
+    type = parse_method_type("() -> (String | nil)").return_type
+    assert_equal AST::Types::Union.build(types: [
+      AST::Types::Name.new_instance(name: ModuleName.parse("String")),
+      AST::Types::Name.new_instance(name: "::NilClass"),
+    ]), type
+    assert_location type, start_line: 1, start_column: 6, end_line: 1, end_column: 20
+  end
 end


### PR DESCRIPTION
This PR makes type checking nil sensitive.

* `nil` has type `nil`, or `NilClass`.
* Union types with `nil` can be unwrapped automatically with *if*, *csend*, *and*, and *while* expressions.
* Exhaustiveness of `case` expression can be checked using union with `nil`.

### Known issues

* *masgn* typing is broken
* Assignment in *csend* argument will break type checking
