### PR TITLE
add rubocop gem for refactoring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 /lib/steep/parser.output
 /lib/steep/parser.rb
+/.ruby-version

--- a/.rubocop-disabled.yml
+++ b/.rubocop-disabled.yml
@@ -1,0 +1,49 @@
+# disabled for rubocop-rspec
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+RSpec/MessageChain:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/ExpectInHook:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false
+
+RSpec/SubjectStub:
+  Enabled: false
+
+RSpec/VoidExpect:
+  Enabled: false
+
+RSpec/BeforeAfterAll:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,115 @@
+inherit_from: '.rubocop-disabled.yml'
+
+AllCops:
+  TargetRubyVersion: 2.2
+  Exclude:
+    - '**/Gemfile'
+    - '**/Gemfile.lock'
+    - '**/Rakefile'
+    - '**/*.gemspec'
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+AlignParameters:
+  Enabled: false
+
+ClassLength:
+  CountComments: false
+  Max: 150
+
+ModuleLength:
+  CountComments: false
+  Max: 250
+  Exclude:
+    - '**/test/**/*'
+
+Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 150
+  Exclude:
+    - '**/test/**/*'
+
+MethodLength:
+  CountComments: false
+  Max: 50
+
+BlockLength:
+  CountComments: false
+  Max: 50
+  Exclude:
+    - '**/test/**/*'
+    - '**/*.rake'
+
+Metrics/AbcSize:
+ Max: 45
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Performance/RegexpMatch:
+  Enabled: false
+
+Style/UnneededPercentQ:
+  Enabled: false
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 7
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - '**/test/**/*'
+
+Style/NumericLiterals:
+  Enabled: false

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "racc", "~> 1.4"
   spec.add_development_dependency "rainbow", "~> 2.2.2"
+  spec.add_development_dependency "rubocop", "~> 0.56.0"
 
   spec.add_runtime_dependency "parser", "~> 2.4"
   spec.add_runtime_dependency "ast_utils", "~> 0.1.0"


### PR DESCRIPTION
In my case, I always use the rubocop gem in my project.
It is a very cool gem for refactoring such as find useless space.

It is very easy to install and run a test.
`
> bundle
> rubocop
126 files inspected, 1977 offenses detected
`

I found 1977 offenses with this gem in your project.
How about your thinking?