### PR TITLE
Fix block parameter binding

### DIFF
--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -33,9 +33,8 @@ module Steep
         value(token)
       end
 
-      def emit_lambda
-        true
-      end
+      self.emit_lambda = true
+      self.emit_procarg0 = true
     end
 
     def self.parser

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -15,7 +15,7 @@ module Steep
         end
 
         def ==(other)
-          other.is_a?(Param) && other.var == var && other.type == type && other.value == value && other.node == node
+          other.is_a?(self.class) && other.var == var && other.type == type && other.value == value && other.node == node
         end
 
         alias eql? ==
@@ -25,17 +25,34 @@ module Steep
         end
       end
 
-      attr_reader :params
-      attr_reader :rest
+      attr_reader :leading_params
+      attr_reader :optional_params
+      attr_reader :rest_param
+      attr_reader :trailing_params
 
-      def initialize(params:, rest:)
-        @params = params
-        @rest = rest
+      def initialize(leading_params:, optional_params:, rest_param:, trailing_params:)
+        @leading_params = leading_params
+        @optional_params = optional_params
+        @rest_param = rest_param
+        @trailing_params = trailing_params
+      end
+
+      def params
+        [].tap do |params|
+          params.push *leading_params
+          params.push *optional_params
+          params.push rest_param if rest_param
+          params.push *trailing_params
+        end
       end
 
       def self.from_node(node, annotations:)
-        params = []
-        rest = nil
+        leading_params = []
+        optional_params = []
+        rest_param = nil
+        trailing_params = []
+
+        default_params = leading_params
 
         node.children.each do |arg|
           var = arg.children.first
@@ -43,45 +60,56 @@ module Steep
 
           case arg.type
           when :arg, :procarg0
-            params << Param.new(var: var, type: type, value: nil, node: arg)
+            default_params << Param.new(var: var, type: type, value: nil, node: arg)
           when :optarg
-            params << Param.new(var: var, type: type, value: arg.children.last, node: arg)
+            default_params = trailing_params
+            optional_params << Param.new(var: var, type: type, value: arg.children.last, node: arg)
           when :restarg
-            rest = Param.new(var: var, type: type, value: nil, node: arg)
+            default_params = trailing_params
+            rest_param = Param.new(var: var, type: type, value: nil, node: arg)
           end
         end
 
         new(
-          params: params,
-          rest: rest
+          leading_params: leading_params,
+          optional_params: optional_params,
+          rest_param: rest_param,
+          trailing_params: trailing_params
         )
       end
 
       def zip(params_type)
+        if trailing_params.any?
+          Steep.logger.error "Block definition with trailing required parameters are not supported yet"
+        end
+
         [].tap do |zip|
           types = params_type.flat_unnamed_params
-          params.each do |param|
-            type = types.shift&.last || params_type.rest || AST::Types::Any.new
+
+          (leading_params + optional_params).each do |param|
+            type = types.shift&.last || params_type.rest
 
             if type
               zip << [param, type]
+            else
+              zip << [param, AST::Types::Nil.new]
             end
           end
 
-          if rest
+          if rest_param
             if types.empty?
               array = AST::Types::Name.new_instance(
-                name: :Array,
+                name: "::Array",
                 args: [params_type.rest || AST::Types::Any.new]
               )
-              zip << [rest, array]
+              zip << [rest_param, array]
             else
               union = AST::Types::Union.build(types: types.map(&:last) + [params_type.rest])
               array = AST::Types::Name.new_instance(
-                name: :Array,
+                name: "::Array",
                 args: [union]
               )
-              zip << [rest, array]
+              zip << [rest_param, array]
             end
           end
         end
@@ -90,7 +118,6 @@ module Steep
       def each(&block)
         if block_given?
           params.each &block
-          yield rest if rest
         else
           enum_for :each
         end

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -84,34 +84,97 @@ module Steep
         end
 
         [].tap do |zip|
-          types = params_type.flat_unnamed_params
+          if expandable_params?(params_type) && expandable?
+            type = params_type.required[0]
 
-          (leading_params + optional_params).each do |param|
-            type = types.shift&.last || params_type.rest
+            case
+            when array?(type)
+              type_arg = type.args[0]
+              params.each do |param|
+                unless param == rest_param
+                  zip << [param, AST::Types::Union.build(types: [type_arg, AST::Types::Nil.new])]
+                else
+                  zip << [param, AST::Types::Name.new_instance(name: "::Array", args: [type_arg])]
+                end
+              end
+            when type.is_a?(AST::Types::Tuple)
+              types = type.types.dup
+              (leading_params + optional_params).each do |param|
+                ty = types.shift
+                if ty
+                  zip << [param, ty]
+                else
+                  zip << [param, AST::Types::Nil.new]
+                end
+              end
 
-            if type
-              zip << [param, type]
-            else
-              zip << [param, AST::Types::Nil.new]
+              if rest_param
+                if types.any?
+                  union = AST::Types::Union.build(types: types)
+                  zip << [rest_param, AST::Types::Name.new_instance(name: "::Array", args: [union])]
+                else
+                  zip << [rest_param, AST::Types::Nil.new]
+                end
+              end
+            end
+          else
+            types = params_type.flat_unnamed_params
+
+            (leading_params + optional_params).each do |param|
+              type = types.shift&.last || params_type.rest
+
+              if type
+                zip << [param, type]
+              else
+                zip << [param, AST::Types::Nil.new]
+              end
+            end
+
+            if rest_param
+              if types.empty?
+                array = AST::Types::Name.new_instance(
+                  name: "::Array",
+                  args: [params_type.rest || AST::Types::Any.new]
+                )
+                zip << [rest_param, array]
+              else
+                union = AST::Types::Union.build(types: types.map(&:last) + [params_type.rest])
+                array = AST::Types::Name.new_instance(
+                  name: "::Array",
+                  args: [union]
+                )
+                zip << [rest_param, array]
+              end
             end
           end
+        end
+      end
 
-          if rest_param
-            if types.empty?
-              array = AST::Types::Name.new_instance(
-                name: "::Array",
-                args: [params_type.rest || AST::Types::Any.new]
-              )
-              zip << [rest_param, array]
-            else
-              union = AST::Types::Union.build(types: types.map(&:last) + [params_type.rest])
-              array = AST::Types::Name.new_instance(
-                name: "::Array",
-                args: [union]
-              )
-              zip << [rest_param, array]
-            end
+      def array?(type)
+        type.is_a?(AST::Types::Name) &&
+          type.name.is_a?(TypeName::Instance) &&
+          type.name.name.name == "Array" && type.name.name.absolute?
+      end
+
+      def expandable_params?(params_type)
+        if params_type.flat_unnamed_params.size == 1
+          case (type = params_type.required.first)
+          when AST::Types::Tuple
+            true
+          when AST::Types::Name
+            array?(type)
           end
+        end
+      end
+
+      def expandable?
+        case
+        when leading_params.size + trailing_params.size > 1
+          true
+        when (leading_params.any? || trailing_params.any?) && rest_param
+          true
+        when params.size == 1 && params[0].node.type == :arg
+          true
         end
       end
 

--- a/smoke/hash/a.rb
+++ b/smoke/hash/a.rb
@@ -1,0 +1,17 @@
+{ foo: "bar" }.each do |x, y|
+  # @type var x1: Symbol
+  # @type var y1: String
+
+  x1 = x
+  y1 = y
+end
+
+{ foo: "bar" }.each.with_index do |x, y|
+  # @type var a: Symbol
+  # @type var b: String
+  # @type var c: Integer
+
+  a = x[0]
+  b = x[1]
+  c = y
+end

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -225,6 +225,10 @@ class Hash<'key, 'value>
               | -> Enumerator<'a, self>
   def self.[]: (Array<any>) -> Hash<'key, 'value>
   def keys: () -> Array<'key>
+  def each: { (['key, 'value]) -> any } -> self
+          | -> Enumerator<['key, 'value], self>
+
+  include Enumerable<['key, 'value], self>
 end
 
 class Symbol

--- a/test/block_params_test.rb
+++ b/test/block_params_test.rb
@@ -119,4 +119,61 @@ proc {|a, b=1, *c, d|
       assert_equal [params.params[0], parse_type("Integer")], zip[0]
     end
   end
+
+  def test_zip_expand_array
+    type = Params.new(
+      required: [parse_type("::Array<Integer>")],
+      optional: [],
+      rest: nil,
+      required_keywords: {},
+      optional_keywords: {},
+      rest_keywords: nil
+    )
+
+    block_params("proc {|x,y,*z| }") do |params|
+      zip = params.zip(type)
+
+      assert_equal [params.params[0], parse_type("Integer | nil")], zip[0]
+      assert_equal [params.params[1], parse_type("Integer | nil")], zip[1]
+      assert_equal [params.params[2], parse_type("::Array<Integer>")], zip[2]
+    end
+
+    block_params("proc {|x,| }") do |params|
+      zip = params.zip(type)
+
+      assert_equal [params.params[0], parse_type("Integer | nil")], zip[0]
+    end
+  end
+
+  def test_zip_expand_tuple
+    type = Params.new(
+      required: [parse_type("[Symbol, Integer]")],
+      optional: [],
+      rest: nil,
+      required_keywords: {},
+      optional_keywords: {},
+      rest_keywords: nil
+    )
+
+    block_params("proc {|x,y,*z| }") do |params|
+      zip = params.zip(type)
+
+      assert_equal [params.params[0], parse_type("Symbol")], zip[0]
+      assert_equal [params.params[1], parse_type("Integer")], zip[1]
+      assert_equal [params.params[2], parse_type("nil")], zip[2]
+    end
+
+    block_params("proc {|x,| }") do |params|
+      zip = params.zip(type)
+
+      assert_equal [params.params[0], parse_type("Symbol")], zip[0]
+    end
+
+    block_params("proc {|x, *y| }") do |params|
+      zip = params.zip(type)
+
+      assert_equal [params.params[0], parse_type("Symbol")], zip[0]
+      assert_equal [params.params[1], parse_type("::Array<Integer>")], zip[1]
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -357,6 +357,7 @@ end
 class Hash<'a, 'b>
   def []: ('a) -> 'b
   def []=: ('a, 'b) -> 'b
+  def each: { (['a, 'b]) -> void } -> self
 end
 
 class NilClass

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4782,4 +4782,44 @@ EOF
       assert_equal parse_type("(::Integer | ::String)"), error.type
     end
   end
+
+  def test_hash_tuple
+    source = parse_ruby(<<EOF)
+hash = { "foo" => 1 }
+
+hash.each do |x|
+  a = x[0] + ""
+  b = x[1] + 3
+end
+
+hash.each do |a, b|
+  a + ""
+  b + 3
+end
+EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node)
+    checker = new_subtyping_checker()
+
+    const_env = ConstantEnv.new(builder: checker.builder, current_namespace: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: Types::Name.new_instance(name: "::Object"),
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+  end
 end


### PR DESCRIPTION
This PR implements array argument expansion to block parameters.

This allows, for example, typing `Hash#each`.

```rb
hash = { x: 1, y: 2 }

hash.each do |x, y|
  # Tuple is expanded to block parameters.
  # x is Symbol and y is Integer.
end

hash.each.with_index do |a, b|
  # Because expanding masgn on block parameters is not supported yet, you cannot write something like |(x, y), i|.
  # a is [Symbol, Integer] and b is Integer.
end
```

* The implementation is based on explanation of http://www.a-k-r.org/d/2007-08.html#a2007_08_16_1