### PR TITLE
Introduce *incompatible* method

### DIFF
--- a/lib/steep/ast/signature/members.rb
+++ b/lib/steep/ast/signature/members.rb
@@ -52,6 +52,10 @@ module Steep
           def constructor?
             attributes.include?(:constructor)
           end
+
+          def incompatible?
+            attributes.include?(:incompatible)
+          end
         end
 
         class Ivar

--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -333,6 +333,19 @@ module Steep
       end
     end
 
+    class IncompatibleZuper < Base
+      attr_reader :method
+
+      def initialize(node:, method:)
+        super(node: node)
+        @method = method
+      end
+
+      def to_s
+        "#{location_to_str}: IncompatibleZuper: method=#{method}"
+      end
+    end
+
     class MethodDefinitionMissing < Base
       attr_reader :module_name
       attr_reader :kind

--- a/lib/steep/interface/instantiated.rb
+++ b/lib/steep/interface/instantiated.rb
@@ -85,7 +85,7 @@ module Steep
       end
 
       def validate_method(check, method)
-        if method.super_method
+        if method.super_method && !method.incompatible?
           result = check.check_method(method.name,
                                       method,
                                       method.super_method,

--- a/lib/steep/interface/method.rb
+++ b/lib/steep/interface/method.rb
@@ -24,6 +24,10 @@ module Steep
           other.attributes == attributes
       end
 
+      def incompatible?
+        attributes.include?(:incompatible)
+      end
+
       def closed?
         types.all?(&:closed?)
       end

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -410,6 +410,7 @@ method_annotation_seq: method_annotation_keyword { result = [val[0]] }
                      | method_annotation_keyword COMMA method_annotation_seq { result = [val[0]] + val[2] }
 
 method_annotation_keyword: CONSTRUCTOR { result = val[0].value }
+                         | INCOMPATIBLE { result = val[0].value }
 
 super_opt: { result = nil }
          | LTCOLON super_class { result = val[1] }
@@ -498,6 +499,7 @@ method_name0: LIDENT
             | NOCONSTRUCTOR { result = LocatedValue.new(location: val[0].location, value: :noconstructor) }
             | ATTR_READER
             | ATTR_ACCESSOR
+            | INCOMPATIBLE
 
 annotation: AT_TYPE VAR subject COLON type {
               loc = val.first.location + val.last.location
@@ -705,6 +707,8 @@ def next_token
     new_token(:TYPE, :type)
   when input.scan(/interface\b/)
     new_token(:INTERFACE, :interface)
+  when input.scan(/incompatible\b/)
+    new_token(:INCOMPATIBLE, :incompatible)
   when input.scan(/end\b/)
     new_token(:END, :end)
   when input.scan(/\|/)

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -201,8 +201,8 @@ type_name: application_type_name
            }
 
 constructor: { result = nil }
-           | CONSTRUCTOR
-           | NOCONSTRUCTOR
+           | CONSTRUCTOR { result = LocatedValue.new(location: val[0].location, value: true) }
+           | NOCONSTRUCTOR { result = LocatedValue.new(location: val[0].location, value: false) }
 
 type: paren_type
     | union_seq {
@@ -340,34 +340,34 @@ ivar_member: IVAR_NAME COLON type {
                )
              }
 
-instance_method_member: DEF constructor_method method_name COLON method_type_union {
+instance_method_member: DEF method_annotations method_name COLON method_type_union {
                           loc = val.first.location + val.last.last.location
                           result = AST::Signature::Members::Method.new(
                             name: val[2].value,
                             types: val[4],
                             kind: :instance,
                             location: loc,
-                            attributes: [val[1] ? :constructor : nil].compact
+                            attributes: val[1] || []
                           )
                         }
-module_method_member: DEF constructor_method SELF DOT method_name COLON method_type_union {
+module_method_member: DEF method_annotations SELF DOT method_name COLON method_type_union {
                         loc = val.first.location + val.last.last.location
                         result = AST::Signature::Members::Method.new(
                           name: val[4].value,
                           types: val[6],
                           kind: :module,
                           location: loc,
-                          attributes: [val[1] ? :constructor : nil].compact
+                          attributes: val[1] || []
                         )
                       }
-module_instance_method_member: DEF constructor_method SELFQ DOT method_name COLON method_type_union {
+module_instance_method_member: DEF method_annotations SELFQ DOT method_name COLON method_type_union {
                                  loc = val.first.location + val.last.last.location
                                  result = AST::Signature::Members::Method.new(
                                    name: val[4].value,
                                    types: val[6],
                                    kind: :module_instance,
                                    location: loc,
-                                   attributes: [val[1] ? :constructor : nil].compact
+                                   attributes: val[1] || []
                                  )
                                }
 include_member: INCLUDE module_name {
@@ -403,8 +403,13 @@ attr_ivar_opt: { result = nil }
              | LPAREN RPAREN { result = false }
              | LPAREN IVAR_NAME RPAREN { result = val[1].value }
 
-constructor_method: { result = false }
-                  | LPAREN CONSTRUCTOR RPAREN { result = true }
+method_annotations: { result = nil }
+                  | LPAREN method_annotation_seq RPAREN { result = val[1] }
+
+method_annotation_seq: method_annotation_keyword { result = [val[0]] }
+                     | method_annotation_keyword COMMA method_annotation_seq { result = [val[0]] + val[2] }
+
+method_annotation_keyword: CONSTRUCTOR { result = val[0].value }
 
 super_opt: { result = nil }
          | LTCOLON super_class { result = val[1] }
@@ -763,9 +768,9 @@ def next_token
   when input.scan(/extension\b/)
     new_token(:EXTENSION, :extension)
   when input.scan(/constructor\b/)
-    new_token(:CONSTRUCTOR, true)
+    new_token(:CONSTRUCTOR, :constructor)
   when input.scan(/noconstructor\b/)
-    new_token(:NOCONSTRUCTOR, false)
+    new_token(:NOCONSTRUCTOR, :noconstructor)
   when input.scan(/\$\w+\b/)
     new_token(:GVAR, input.matched.to_sym)
   when input.scan(/[A-Z]\w*/)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1035,8 +1035,13 @@ module Steep
           yield_self do
             if method_context&.method
               if method_context.super_method
-                types = method_context.super_method.types.map(&:return_type)
-                typing.add_typing(node, union_type(*types))
+                if method_context.method.incompatible?
+                  typing.add_error Errors::IncompatibleZuper.new(node: node, method: method_context.name)
+                  typing.add_typing node, Types.any
+                else
+                  types = method_context.super_method.types.map(&:return_type)
+                  typing.add_typing(node, union_type(*types))
+                end
               else
                 typing.add_error(Errors::UnexpectedSuper.new(node: node, method: method_context.name))
                 fallback_to_any node

--- a/smoke/class/i.rb
+++ b/smoke/class/i.rb
@@ -10,5 +10,8 @@ class IncompatibleChild
   def initialize()
     # !expects IncompatibleArguments: receiver=::IncompatibleChild, method_type=(name: ::String) -> any
     super()
+
+    # !expects IncompatibleZuper: method=initialize
+    super
   end
 end

--- a/smoke/class/i.rb
+++ b/smoke/class/i.rb
@@ -1,0 +1,9 @@
+class IncompatibleChild
+  def foo(arg)
+    # @type var x: Symbol
+    # !expects IncompatibleAssignment: lhs_type=::Symbol, rhs_type=::Integer
+    x = super()
+
+    "123"
+  end
+end

--- a/smoke/class/i.rb
+++ b/smoke/class/i.rb
@@ -6,4 +6,9 @@ class IncompatibleChild
 
     "123"
   end
+
+  def initialize()
+    # !expects IncompatibleArguments: receiver=::IncompatibleChild, method_type=(name: ::String) -> any
+    super()
+  end
 end

--- a/smoke/class/i.rbi
+++ b/smoke/class/i.rbi
@@ -1,7 +1,9 @@
 class IncompatibleSuper
   def foo: () -> Integer
+  def initialize: (name: String) -> any
 end
 
 class IncompatibleChild <: IncompatibleSuper
+  def initialize: () -> any
   def (incompatible) foo: (Object) -> String
 end

--- a/smoke/class/i.rbi
+++ b/smoke/class/i.rbi
@@ -1,0 +1,7 @@
+class IncompatibleSuper
+  def foo: () -> Integer
+end
+
+class IncompatibleChild <: IncompatibleSuper
+  def (incompatible) foo: (Object) -> String
+end

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -483,4 +483,21 @@ type baz = bar<String>
       assert_equal parse_type("foo | Array<'a>"), sig.type
     end
   end
+
+  def test_incompatible_method
+    sigs = parse(<<-EOF)
+class Foo
+  def (constructor, incompatible) method: () -> Method
+end
+    EOF
+
+    sigs[0].yield_self do |sig|
+      assert_instance_of Steep::AST::Signature::Class, sig
+      assert_equal 1, sig.members.size
+      sig.members[0].yield_self do |method|
+        assert_operator method, :constructor?
+        assert_operator method, :incompatible?
+      end
+    end
+  end
 end


### PR DESCRIPTION
A method is *incompatible* if it's type is not a subtype of that method of the super class.

```
class Super
  def foo: (Object) -> Integer
end

class Child <: Super
  def (incompatible) foo: () -> String
end
```

In this case, `Child` is not a subtype of `Super`, and this kind of inheritance cannot be typed. Steep cannot check if this inheritance breaks nothing, but it allows to user to annotate `incompatible` to let this bypass type checking.

This also allows `super` calls in `initialize` method definitions.