### PR TITLE
Improve typing of optional blocks

### DIFF
--- a/lib/steep/ast/method_type.rb
+++ b/lib/steep/ast/method_type.rb
@@ -90,11 +90,13 @@ module Steep
         attr_reader :location
         attr_reader :params
         attr_reader :return_type
+        attr_reader :optional
 
-        def initialize(location:, params:, return_type:)
+        def initialize(location:, params:, return_type:, optional:)
           @location = location
           @params = params
           @return_type = return_type
+          @optional = optional
         end
       end
 

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -462,7 +462,8 @@ module Steep
         params = params_to_params(method_type.params, current: current)
         block = method_type.block && Block.new(
           params: params_to_params(method_type.block.params, current: current),
-          return_type: absolute_type(method_type.block.return_type, current: current)
+          return_type: absolute_type(method_type.block.return_type, current: current),
+          optional: method_type.block.optional
         )
 
         MethodType.new(

--- a/lib/steep/interface/method.rb
+++ b/lib/steep/interface/method.rb
@@ -62,6 +62,10 @@ module Steep
         )
       end
 
+      def map_types
+        with_types(types.map {|type| yield type })
+      end
+
       def include_in_chain?(method)
         (method.type_name == type_name &&
           method.name == name &&

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -181,14 +181,20 @@ module Steep
     class Block
       attr_reader :params
       attr_reader :return_type
+      attr_reader :optional
 
-      def initialize(params:, return_type:)
+      def initialize(params:, return_type:, optional:)
         @params = params
         @return_type = return_type
+        @optional = optional
+      end
+
+      def optional?
+        @optional
       end
 
       def ==(other)
-        other.is_a?(self.class) && other.params == params && other.return_type == return_type
+        other.is_a?(self.class) && other.params == params && other.return_type == return_type && other.optional == optional
       end
 
       def closed?
@@ -198,7 +204,8 @@ module Steep
       def subst(s)
         self.class.new(
           params: params.subst(s),
-          return_type: return_type.subst(s)
+          return_type: return_type.subst(s),
+          optional: optional
         )
       end
 
@@ -207,7 +214,7 @@ module Steep
       end
 
       def to_s
-        "{ #{params} -> #{return_type} }"
+        "#{optional? ? "?" : ""}{ #{params} -> #{return_type} }"
       end
     end
 

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -92,16 +92,21 @@ optional_keyword: QUESTION keyword COLON type { result = [val[0].location + val[
                                                           val[3]] }
 
 block_opt: { result = nil }
-         | LBRACE RBRACE {
+         | block_optional LBRACE RBRACE {
              result = AST::MethodType::Block.new(params: nil,
                                                  return_type: nil,
-                                                 location: val[0].location + val[1].location)
+                                                 location: (val[0] || val[1]).location + val[2].location,
+                                                 optional: val[0]&.value || false)
            }
-         | LBRACE block_params ARROW type RBRACE {
-             result = AST::MethodType::Block.new(params: val[1],
-                                                 return_type: val[3],
-                                                 location: val[0].location + val[4].location)
+         | block_optional LBRACE block_params ARROW type RBRACE {
+             result = AST::MethodType::Block.new(params: val[2],
+                                                 return_type: val[4],
+                                                 location: (val[0] || val[1]).location + val[5].location,
+                                                 optional: val[0]&.value || false)
            }
+
+block_optional: { result = nil }
+              | QUESTION { result = LocatedValue.new(location: val[0].location, value: true) }
 
 block_params: { result = nil }
             | LPAREN block_params0 RPAREN {

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -355,7 +355,9 @@ module Steep
         case
         when !super_block && !sub_block
           success(constraints: constraints)
-        when super_block && sub_block
+        when super_block && sub_block && super_block.optional? == sub_block.optional?
+          success(constraints: constraints)
+        when sub_block&.optional?
           success(constraints: constraints)
         else
           failure(
@@ -502,7 +504,7 @@ module Steep
       end
 
       def check_block_params(name, sub_block, super_block, assumption:, trace:, constraints:)
-        if sub_block
+        if sub_block && super_block
           check_method_params(name,
                               super_block.params,
                               sub_block.params,
@@ -515,7 +517,7 @@ module Steep
       end
 
       def check_block_return(sub_block, super_block, assumption:, trace:, constraints:)
-        if sub_block
+        if sub_block && super_block
           relation = Relation.new(sub_type: super_block.return_type,
                                       super_type: sub_block.return_type)
           check(relation, assumption: assumption, trace: trace, constraints: constraints)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1927,7 +1927,7 @@ module Steep
               fallback_any_rec node
             end
 
-          when !method_type.block && !block_params && !block_body
+          when (!method_type.block || method_type.block.optional?) && !block_params && !block_body
             # OK, without block
             method_type.subst(constraints.solution(checker, variance: variance, variables: fresh_vars)).return_type.tap do
               child_typing.save!
@@ -1939,7 +1939,7 @@ module Steep
               method_type: method_type
             )
 
-          when method_type.block && !block_params && !block_body
+          when method_type.block && !method_type.block.optional? && !block_params && !block_body
             Errors::RequiredBlockMissing.new(
               node: node,
               method_type: method_type

--- a/smoke/block/c.rb
+++ b/smoke/block/c.rb
@@ -1,0 +1,10 @@
+class OptionalBlock
+  def optional_block
+    yield
+    30
+  end
+end
+
+OptionalBlock.new.optional_block()
+OptionalBlock.new.optional_block() { :foo }
+

--- a/smoke/block/c.rbi
+++ b/smoke/block/c.rbi
@@ -1,0 +1,3 @@
+class OptionalBlock
+  def optional_block: ?{ () -> void } -> Integer
+end

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -500,4 +500,23 @@ end
       end
     end
   end
+
+  def test_optional_block
+    klass, = parse(<<-EOF)
+class Foo
+  def required_block: (Integer) { } -> Object
+  def optional_block: (Integer) ?{ () -> String } -> Object
+end
+    EOF
+
+    klass.members[0].yield_self do |required_block|
+      refute_operator required_block.types[0].block, :optional
+      assert_equal "{ }", required_block.types[0].block.location.source
+    end
+
+    klass.members[1].yield_self do |required_block|
+      assert_operator required_block.types[0].block, :optional
+      assert_equal "?{ () -> String }", required_block.types[0].block.location.source
+    end
+  end
 end


### PR DESCRIPTION
There has been no way to type check overloaded methods with optional blocks.

```
class Foo
  def bar: () -> Integer
         | <'a> { () -> 'a } -> 'a
end
```

Now, you can type check the method with in-line method type annotation.

```rb
class Foo
  # @type method bar: () ?{ -> any } -> any
  def bar
    if block_given?
      yield
    else
      30
    end
  end
end
```

Steep now allows writing an *optional block* in method type explicitly, not as a overloading. You can use the `?`-prefixed block type to annotate methods in your Ruby code.

Note that Steep does not provide any support if `yield` can work or not. Checking if a block is given before `yield` in that methods is your responsibility. 😢