### PR TITLE
Fix ActiveSupport version

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.5.0'
-  
+
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "parser", "~> 2.4"
   spec.add_runtime_dependency "ast_utils", "~> 0.1.0"
-  spec.add_runtime_dependency "activesupport", "~> 5.1.0"
+  spec.add_runtime_dependency "activesupport", "~> 5.1"
   spec.add_runtime_dependency "rainbow", "~> 2.2.2"
 end


### PR DESCRIPTION
Hi! 😃 

This makes Steep available also in Rails 5.2.

Reproduction
------------

1. Edit `Gemfile`.

    ```diff
    +gem 'steep'
    ```

2. Run `bundle install` command.

    ```
    $ bundle install
    Fetching gem metadata from https://rubygems.org/.........
    Fetching gem metadata from https://rubygems.org/.
    Resolving dependencies...
    Bundler could not find compatible versions for gem "activesupport":
      In snapshot (Gemfile.lock):
        activesupport (= 5.2.1)

      In Gemfile:
        rails (~> 5.2.1) was resolved to 5.2.1, which depends on
          activesupport (= 5.2.1)

        steep was resolved to 0.5.0, which depends on
          activesupport (~> 5.1.0)

    Running `bundle update` will rebuild your snapshot from scratch, using only
    the gems in your Gemfile, which may resolve the conflict.

    Bundler could not find compatible versions for gem "steep":
      In Gemfile:
        steep

    Could not find gem 'steep' in any of the sources.
    ```

Thanks.