### PR TITLE
Allow Rainbow v3

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.5.0'
-  
+
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "parser", "~> 2.4"
   spec.add_runtime_dependency "ast_utils", "~> 0.1.0"
   spec.add_runtime_dependency "activesupport", "~> 5.1.0"
-  spec.add_runtime_dependency "rainbow", "~> 2.2.2"
+  spec.add_runtime_dependency "rainbow", "~> 2.2.2", "< 4.0"
 end


### PR DESCRIPTION
Now Steep depends on Rainbow 2.2, and this commit allows that Steep depends on Rainbow 3 also.
Thus, Steep is available along with RuboCop latest version (0.58.2).
Rainbow 3 doesn't break Steep.

See also:
- https://github.com/rubocop-hq/rubocop/pull/5164
- https://github.com/sickill/rainbow/blob/v3.0.0/Changelog.md

Reproduction
------------

1. Run following commands in terminal (Bash / Zsh).

    ```sh
    # Create Gemfile
    cat <<EOF >Gemfile
    source 'https://rubygems.org'
    gem 'rubocop'
    EOF

    # Install gems
    bundle install

    # Install Steep
    echo "gem 'steep'" >> Gemfile
    bundle install
    ```

2. Following error is output.

    ```
    Bundler could not find compatible versions for gem "rainbow":
      In snapshot (Gemfile.lock):
        rainbow (= 3.0.0)

      In Gemfile:
        rubocop was resolved to 0.58.2, which depends on
          rainbow (< 4.0, >= 2.2.2)

        steep was resolved to 0.5.0, which depends on
          rainbow (~> 2.2.2)

    Running `bundle update` will rebuild your snapshot from scratch, using only
    the gems in your Gemfile, which may resolve the conflict.

    Bundler could not find compatible versions for gem "steep":
      In Gemfile:
        steep

    Could not find gem 'steep' in any of the sources.
    ```