### PR TITLE
Update signature syntax

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -87,7 +87,7 @@ module Steep
     unless @logger
       @logger = ActiveSupport::TaggedLogging.new(Logger.new(STDERR))
       @logger.push_tags "Steep #{VERSION}"
-      @logger.level = Logger::ERROR
+      @logger.level = Logger::WARN
     end
 
     @logger

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -1063,7 +1063,7 @@ def next_token
     new_token(:tPLUS, :+)
   when input.scan(/\./)
     new_token(:tDOT)
-  when input.scan(/<:/)
+  when input.scan(/<:(?!:)/)
     new_token(:tLTCOLON)
   when input.scan(/\^/)
     new_token(:tHAT, :"^")

--- a/smoke/class/i.rbi
+++ b/smoke/class/i.rbi
@@ -3,7 +3,7 @@ class IncompatibleSuper
   def initialize: (name: String) -> any
 end
 
-class IncompatibleChild <: IncompatibleSuper
+class IncompatibleChild < IncompatibleSuper
   def initialize: () -> any
   def (incompatible) foo: (Object) -> String
 end

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -2,7 +2,7 @@ class BasicObject
   def __id__: -> Integer
 end
 
-class Object <: BasicObject
+class Object < BasicObject
   include Kernel
   def tap: { (self) -> any } -> self
   def to_s: -> String
@@ -43,7 +43,7 @@ end
 class Method
 end
 
-class Class <: Module
+class Class < Module
   def class: -> Class.class
   def allocate: -> any
 end
@@ -267,7 +267,7 @@ class Numeric
   def -@: -> self
 end
 
-class Integer <: Numeric
+class Integer < Numeric
   def to_int: -> Integer
   def +: (Integer) -> Integer
        | (Numeric) -> Numeric
@@ -295,7 +295,7 @@ class Integer <: Numeric
   def ~: () -> Integer
 end
 
-class Float <: Numeric
+class Float < Numeric
   def *: (Float) -> Float
        | (Integer) -> Float
        | (Numeric) -> Numeric
@@ -312,7 +312,7 @@ end
 
 Math::PI: Float
 
-class Complex <: Numeric
+class Complex < Numeric
   def self.polar: (Numeric, Numeric) -> instance
   def +: (Complex) -> Complex
        | (Numeric) -> Numeric
@@ -571,7 +571,7 @@ end
 
 File::FNM_DOTMATCH: Integer
 
-class File <: IO
+class File < IO
   def self.binread: (String) -> String
   def self.extname: (String) -> String
   def self.basename: (String) -> String

--- a/test/block_params_test.rb
+++ b/test/block_params_test.rb
@@ -50,7 +50,7 @@ proc {|a, b=1, *c, d|
 
     assert_equal [BlockParams::Param.new(var: args[0].children[0], type: parse_type("::String"), value: nil, node: args[0])], params.leading_params
     assert_equal [BlockParams::Param.new(var: args[1].children[0], type: nil, value: parse_ruby("1").node, node: args[1])], params.optional_params
-    assert_equal BlockParams::Param.new(var: args[2].children[0], type: parse_type("::Array< ::Symbol>"), value: nil, node: args[2]), params.rest_param
+    assert_equal BlockParams::Param.new(var: args[2].children[0], type: parse_type("::Array<::Symbol>"), value: nil, node: args[2]), params.rest_param
     assert_equal [BlockParams::Param.new(var: args[3].children[0], type: nil, value: nil, node: args[3])], params.trailing_params
   end
 
@@ -105,7 +105,7 @@ proc {|a, b=1, *c, d|
       zip = params.zip(type)
 
       assert_equal [params.params[0], parse_type("::Integer")], zip[0]
-      assert_equal [params.params[1], parse_type("::Array< ::Object | ::String>")], zip[1]
+      assert_equal [params.params[1], parse_type("::Array<::Object | ::String>")], zip[1]
     end
   end
 
@@ -142,7 +142,7 @@ proc {|a, b=1, *c, d|
 
       assert_equal [params.params[0], parse_type("::Integer | nil")], zip[0]
       assert_equal [params.params[1], parse_type("::Integer | nil")], zip[1]
-      assert_equal [params.params[2], parse_type("::Array< ::Integer>")], zip[2]
+      assert_equal [params.params[2], parse_type("::Array<::Integer>")], zip[2]
     end
 
     block_params("proc {|x,| }") do |params|
@@ -180,7 +180,7 @@ proc {|a, b=1, *c, d|
       zip = params.zip(type)
 
       assert_equal [params.params[0], parse_type("::Symbol")], zip[0]
-      assert_equal [params.params[1], parse_type("::Array< ::Integer>")], zip[1]
+      assert_equal [params.params[1], parse_type("::Array<::Integer>")], zip[1]
     end
   end
 

--- a/test/constant_env_test.rb
+++ b/test/constant_env_test.rb
@@ -11,7 +11,7 @@ class ConstantEnvTest < Minitest::Test
 class BasicObject
 end
 
-class Object <: BasicObject
+class Object < BasicObject
   def class: -> module
   def tap: { (instance) -> any } -> instance
 end

--- a/test/constraints_test.rb
+++ b/test/constraints_test.rb
@@ -8,7 +8,7 @@ class ConstraintsTest < Minitest::Test
 class BasicObject
 end
 
-class Object <: BasicObject
+class Object < BasicObject
   def class: () -> class
 end
 

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -22,7 +22,7 @@ end
 class Class
   def new: (*any) -> any
 end
-class Object <: BasicObject end
+class Object < BasicObject end
 class BasicObject
   def initialize: () -> any
 end
@@ -281,7 +281,7 @@ class A
   def foo: () -> A
 end
 
-class B <: A
+class B < A
   include C
   def foo: () -> B
 end
@@ -320,7 +320,7 @@ module B<'a>
   def bar: () -> 'a
 end
 
-class C <: A<String>
+class C < A<String>
   include B<Integer>
 end
     EOF
@@ -615,7 +615,7 @@ class Foo
   @foo: String
 end
 
-class Bar <: Foo
+class Bar < Foo
   @foo: Integer
 end
     EOF
@@ -654,15 +654,15 @@ class Foo
   @foo: String
 end
 
-class Bar <: Foo
+class Bar < Foo
   @foo: String
 end
 
-class Baz <: Foo
+class Baz < Foo
   @foo: Integer
 end
 
-class Hoge <: Foo
+class Hoge < Foo
   @foo: any
 end
     EOF
@@ -746,7 +746,7 @@ class Hello
   def foo: () -> Integer
 end
 
-class World <: Hello
+class World < Hello
   def (incompatible) foo: (Object) -> String 
 end
     EOF

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -36,7 +36,7 @@ end
 
   def test_parsing_class2
     klass, _ = parse(<<-EOS)
-class A <: Object
+class A < Object
 end
     EOS
 
@@ -44,12 +44,12 @@ end
     assert_location klass, start_line: 1, start_column: 0, end_line: 2, end_column: 3
 
     assert_super_class klass.super_class, name: Names::Module.parse("Object")
-    assert_location klass.super_class, start_line: 1, start_column: 11, end_line: 1, end_column: 17
+    assert_location klass.super_class, start_line: 1, start_column: 10, end_line: 1, end_column: 16
   end
 
   def test_parsing_class3
     klass, _ = parse(<<-EOS)
-class A <: Array<Integer>
+class A<'x> < Array<Integer>
 end
     EOS
 
@@ -61,7 +61,7 @@ end
       assert_instance_of AST::Types::Name::Instance, args[0]
       assert_equal Names::Module.parse("Integer"), args[0].name
     end
-    assert_location klass.super_class, start_line: 1, start_column: 11, end_line: 1, end_column: 25
+    assert_location klass.super_class, start_line: 1, start_column: 14, end_line: 1, end_column: 28
   end
 
   def test_parsing_module0

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -8,7 +8,7 @@ class SubtypingTest < Minitest::Test
 class BasicObject
 end
 
-class Object <: BasicObject
+class Object < BasicObject
   def class: () -> class
   def tap: { (self) -> any } -> self
   def yield_self: <'a> { (self) -> 'a } -> 'a
@@ -563,7 +563,7 @@ end
   def test_resolve_instance2
     checker = new_checker("")
 
-    type = parse_type("::Array< ::Integer>")
+    type = parse_type("::Array<::Integer>")
     interface = checker.resolve(type)
 
     assert_equal [:class, :tap, :yield_self, :[], :[]=], interface.methods.keys
@@ -658,7 +658,7 @@ interface _A<'a>
 end
 EOF
 
-    type = parse_type("_A< ::Integer>")
+    type = parse_type("_A<::Integer>")
     interface = checker.resolve(type)
 
     assert_equal [:each], interface.methods.keys
@@ -695,7 +695,7 @@ EOF
   def test_resolve4
     checker = new_checker("")
 
-    interface = checker.resolve(parse_type("::Array< ::Integer> | ::Array< ::String>"))
+    interface = checker.resolve(parse_type("::Array<::Integer> | ::Array<::String>"))
 
     assert_equal [:tap, :yield_self, :[]], interface.methods.keys
     assert_equal ["() { ((::Array<::Integer> | ::Array<::String>)) -> any } -> (::Array<::Integer> | ::Array<::String>)"],
@@ -863,7 +863,7 @@ end
     result = checker.check(
       Subtyping::Relation.new(
         sub_type: parse_type("[123]"),
-        super_type: parse_type("::Array< ::Integer | ::String>"),
+        super_type: parse_type("::Array<::Integer | ::String>"),
         ),
       constraints: Subtyping::Constraints.empty
     )
@@ -895,7 +895,7 @@ type bar<'a> = 'a | Array<'a> | foo
     EOF
 
     assert_equal parse_type("::String | ::Integer"), checker.expand_alias(parse_type("foo"))
-    assert_equal parse_type("::Integer | ::Array< ::Integer> | ::String"), checker.expand_alias(parse_type("bar< ::Integer>"))
+    assert_equal parse_type("::Integer | ::Array<::Integer> | ::String"), checker.expand_alias(parse_type("bar<::Integer>"))
     assert_raises { checker.expand_alias(parse_type("hello")) }
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -314,7 +314,7 @@ module SubtypingHelper
 class BasicObject
 end
 
-class Object <: BasicObject
+class Object < BasicObject
   def class: -> module
   def tap: { (instance) -> any } -> instance
   def gets: -> String?
@@ -342,7 +342,7 @@ class Numeric
   def to_int: -> Integer
 end
 
-class Integer <: Numeric
+class Integer < Numeric
 end
 
 class Symbol

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4911,7 +4911,7 @@ class TestSuper
   def foo: () -> Integer
 end
 
-class TestSuperChild <: TestSuper
+class TestSuperChild < TestSuper
 end
     EOF
     annotations = source.annotations(block: source.node, builder: checker.builder, current_module: Namespace.root)
@@ -5354,7 +5354,7 @@ EOF
     end
 
     assert_empty typing.errors
-    assert_equal parse_type("::Array< ::String>"), type_env.lvar_types[:a]
+    assert_equal parse_type("::Array<::String>"), type_env.lvar_types[:a]
   end
 
   def test_type_proc_objects

--- a/test/type_parsing_test.rb
+++ b/test/type_parsing_test.rb
@@ -137,6 +137,13 @@ class TypeParsingTest < Minitest::Test
     refute_nil parse_method_type("() -> Array<Array<Integer>>")
   end
 
+  def test_application3
+    type = parse_type("Array<::Object>")
+    assert_instance_name_type type, name: Names::Module.parse("Array")
+    assert_equal 1, type.args.size
+    assert_instance_name_type type.args[0], name: Names::Module.parse("::Object")
+  end
+
   def test_self
     type = parse_method_type("() -> self").return_type
 


### PR DESCRIPTION
Now Steep allows writing `<` for class inheritance, not `<:`.

* When you write `<:` it prints a warning message.