### PR TITLE
Fix hash typing

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -575,51 +575,6 @@ module Steep
         end
       end
 
-      def module_type(type)
-        case type.name
-        when TypeName::Instance
-          case
-          when builder.signatures.class_name?(type.name.name)
-            type.class_type(constructor: nil)
-          when builder.signatures.module_name?(type.name.name)
-            type.module_type
-          end
-        else
-          nil
-        end
-      end
-
-      def compact(types)
-        types = types.reject {|type| type.is_a?(AST::Types::Any) }
-
-        if types.empty?
-          [AST::Types::Any.new]
-        else
-          compact0(types)
-        end
-      end
-
-      def compact0(types)
-        if types.size == 1
-          types
-        else
-          type, *types_ = types
-          compacted = compact0(types_)
-          compacted.flat_map do |type_|
-            case
-            when type == type_
-              [type]
-            when check(Relation.new(sub_type: type_, super_type: type), constraints: Constraints.empty).success?
-              [type]
-            when check(Relation.new(sub_type: type, super_type: type_), constraints: Constraints.empty).success?
-              [type_]
-            else
-              [type, type_]
-            end
-          end.uniq
-        end
-      end
-
       class CannotResolveError < StandardError
         attr_reader :type
 

--- a/smoke/hash/d.rb
+++ b/smoke/hash/d.rb
@@ -2,5 +2,5 @@
 
 params = { id: 30, name: "Matz" }
 
-# !expects IncompatibleAssignment: lhs_type={ :name => ::String, :id => ::Integer }, rhs_type=::Hash<::Symbol, ::String>
+# !expects IncompatibleAssignment: lhs_type={ :name => ::String, :id => ::Integer }, rhs_type={ :id => ::String, :name => ::String, :email => ::String }
 params = { id: "30", name: "foo", email: "matsumoto@soutaro.com" }

--- a/smoke/hash/e.rb
+++ b/smoke/hash/e.rb
@@ -1,0 +1,2 @@
+# !expects NoMethodError: type=::Integer, method=fffffffffffff
+Foo.new.get({ foo: 3 }).fffffffffffff

--- a/smoke/hash/e.rbi
+++ b/smoke/hash/e.rbi
@@ -1,0 +1,3 @@
+class Foo
+  def get: <'a> ({ foo: 'a }) -> 'a
+end

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -991,16 +991,47 @@ type foo = String | Integer
       trace: Subtyping::Trace.new
     )
     assert_instance_of Subtyping::Result::Success, result
+  end
 
+  def test_hash2
+    checker = new_checker("")
+
+    constraints = Subtyping::Constraints.new(unknowns: [:a])
     result = checker.check0(
       Subtyping::Relation.new(
         sub_type: parse_type("{ foo: Integer }"),
-        super_type: parse_type("{ }")
+        super_type: parse_type("{ foo: 'a }")
       ),
-      constraints: Subtyping::Constraints.empty,
+      constraints: constraints,
       assumption: Set.new,
       trace: Subtyping::Trace.new
     )
-    assert_instance_of Subtyping::Result::Failure, result
+    assert_instance_of Subtyping::Result::Success, result
+
+    assert_equal({ a: parse_type("Integer") },
+                 constraints.solution(checker,
+                                      variance: Subtyping::VariableVariance.new(covariants: Set.new, contravariants: Set.new),
+                                      variables: [:a]).dictionary)
+  end
+
+  def test_hash3
+    checker = new_checker("")
+
+    constraints = Subtyping::Constraints.new(unknowns: [:a])
+    result = checker.check0(
+      Subtyping::Relation.new(
+        sub_type: parse_type("{ foo: Integer, bar: String }"),
+        super_type: parse_type("{ foo: 'a }")
+      ),
+      constraints: constraints,
+      assumption: Set.new,
+      trace: Subtyping::Trace.new
+    )
+    assert_instance_of Subtyping::Result::Success, result
+
+    assert_equal({ a: parse_type("Integer") },
+                 constraints.solution(checker,
+                                      variance: Subtyping::VariableVariance.new(covariants: Set.new, contravariants: Set.new),
+                                      variables: [:a]).dictionary)
   end
 end


### PR DESCRIPTION
Type inference for type variables inside *Hash* type is now supported.

```
class Foo
  def get: <'a> ({ foo: 'a }) -> 'a
end
```

```rb
Foo.new.get({ foo: 3 })       # : Integer
```