### PR TITLE
Add option to show Steep's version

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -2,6 +2,8 @@ require 'optparse'
 
 module Steep
   class CLI
+    ::Version = Steep::VERSION
+
     attr_reader :argv
     attr_reader :stdout
     attr_reader :stdin
@@ -20,6 +22,12 @@ module Steep
     end
 
     def setup_global_options
+      version = OptionParser.new.version
+      if version
+        stdout.puts version
+        return false
+      end
+
       true
     end
 


### PR DESCRIPTION
This PR adds a new option `--version` (`-v`), which only outputs the Steep version to STDOUT.

E.g.

```
$ steep --version
steep 0.7.0

$ steep -v
steep 0.7.0
```