### PR TITLE
Update built-in types: `Regexp`, `MatchData`

### DIFF
--- a/smoke/regexp/a.rb
+++ b/smoke/regexp/a.rb
@@ -1,0 +1,147 @@
+# ALLOW FAILURE
+
+new_1 = Regexp.new("a")
+# !expects NoMethodError: type=::Regexp, method=foo
+new_1.foo
+
+new_2 = Regexp.new("a", true)
+# !expects NoMethodError: type=::Regexp, method=foo
+new_2.foo
+
+new_3 = Regexp.new("a", Regexp::EXTENDED | Regexp::IGNORECASE)
+# !expects NoMethodError: type=::Regexp, method=foo
+new_3.foo
+
+new_4 = Regexp.new(/a/)
+# !expects NoMethodError: type=::Regexp, method=foo
+new_4.foo
+
+compile_1 = Regexp.compile("a")
+# !expects NoMethodError: type=::Regexp, method=foo
+compile_1.foo
+
+compile_2 = Regexp.compile("a", true)
+# !expects NoMethodError: type=::Regexp, method=foo
+compile_2.foo
+
+compile_3 = Regexp.compile("a", Regexp::EXTENDED | Regexp::IGNORECASE)
+# !expects NoMethodError: type=::Regexp, method=foo
+compile_3.foo
+
+compile_4 = Regexp.compile(/a/)
+# !expects NoMethodError: type=::Regexp, method=foo
+compile_4.foo
+
+escape_1 = Regexp.escape("a")
+# !expects NoMethodError: type=::String, method=foo
+escape_1.foo
+
+last_match_1 = Regexp.last_match
+# !expects NoMethodError: type=(::MatchData | nil), method=foo
+last_match_1.foo
+
+last_match_2 = Regexp.last_match(1)
+# !expects NoMethodError: type=(::String | nil), method=foo
+last_match_2.foo
+
+quote_1 = Regexp.quote("a")
+# !expects NoMethodError: type=::String, method=foo
+quote_1.foo
+
+try_convert_1 = Regexp.try_convert(Object.new)
+# !expects NoMethodError: type=(::Regexp | nil), method=foo
+try_convert_1.foo
+
+union_1 = Regexp.union
+# !expects NoMethodError: type=::Regexp, method=foo
+union_1.foo
+
+union_2 = Regexp.union("a")
+# !expects NoMethodError: type=::Regexp, method=foo
+union_2.foo
+
+union_3 = Regexp.union("a", "b")
+# !expects NoMethodError: type=::Regexp, method=foo
+union_3.foo
+
+union_4 = Regexp.union(["a", "b"])
+# !expects NoMethodError: type=::Regexp, method=foo
+union_4.foo
+
+union_5 = Regexp.union(/a/)
+# !expects NoMethodError: type=::Regexp, method=foo
+union_5.foo
+
+union_6 = Regexp.union(/a/, /b/)
+# !expects NoMethodError: type=::Regexp, method=foo
+union_6.foo
+
+union_7 = Regexp.union([/a/, /b/])
+# !expects NoMethodError: type=::Regexp, method=foo
+union_7.foo
+
+op_eqeqeq_1 = /a/ === "a"
+# !expects NoMethodError: type=bool, method=foo
+op_eqeqeq_1.foo
+
+op_match_1 = /a/ =~ "a"
+# !expects NoMethodError: type=::Integer, method=foo
+op_match_1.foo
+
+casefold_1 = /a/.casefold?
+# !expects NoMethodError: type=bool, method=foo
+casefold_1.foo
+
+encoding_1 = /a/.encoding
+# !expects NoMethodError: type=::Encoding, method=foo
+encoding_1.foo
+
+fixed_encoding_1 = /a/.fixed_encoding?
+# !expects NoMethodError: type=bool, method=foo
+fixed_encoding_1.foo
+
+match_1 = /a/.match("a")
+# !expects NoMethodError: type=(::MatchData | nil), method=foo
+match_1.foo
+
+match_2 = /a/.match("a", 0)
+# !expects NoMethodError: type=(::MatchData | nil), method=foo
+match_2.foo
+
+/a/.match("a") do |m|
+  # !expects NoMethodError: type=::MatchData, method=foo
+  m.foo
+end
+
+/a/.match("a", 0) do |m|
+  # !expects NoMethodError: type=::MatchData, method=foo
+  m.foo
+end
+
+match_q_1 = /a/.match?("a")
+# !expects NoMethodError: type=bool, method=foo
+match_q_1.foo
+
+match_q_2 = /a/.match?("a", 0)
+# !expects NoMethodError: type=bool, method=foo
+match_q_2.foo
+
+named_captures_1 = /(?<foo>.)/.named_captures
+# !expects NoMethodError: type=::Hash<::String, ::Array<::Integer>>, method=foo
+named_captures_1.foo
+
+names_1 = /(?<foo>.)/.names
+# !expects NoMethodError: type=::Array<::String>, method=foo
+names_1.foo
+
+options_1 = /a/ix.options
+# !expects NoMethodError: type=::Integer, method=foo
+options_1.foo
+
+source_1 = /a/ix.source
+# !expects NoMethodError: type=::String, method=foo
+source_1.foo
+
+op_unary_match_1 = ~ /a/
+# !expects NoMethodError: type=(::Integer | nil), method=foo
+op_unary_match_1.foo

--- a/smoke/regexp/b.rb
+++ b/smoke/regexp/b.rb
@@ -1,0 +1,105 @@
+/(?<foo>a)/.match("a") do |match|
+  match_ref_1 = match[0]
+  # !expects NoMethodError: type=(::String | nil), method=foo
+  match_ref_1.foo
+
+  match_ref_2 = match["foo"]
+  # !expects NoMethodError: type=(::String | nil), method=foo
+  match_ref_2.foo
+
+  match_ref_3 = match[:foo]
+  # !expects NoMethodError: type=(::String | nil), method=foo
+  match_ref_3.foo
+
+  match_ref_4 = match[0, 1]
+  # !expects NoMethodError: type=::Array<::String>, method=foo
+  match_ref_4.foo
+
+  match_ref_5 = match[0..1]
+  # !expects NoMethodError: type=::Array<::String>, method=foo
+  match_ref_5.foo
+
+  begin_1 = match.begin(0)
+  # !expects NoMethodError: type=(::Integer | nil), method=foo
+  begin_1.foo
+
+  begin_2 = match.begin("foo")
+  # !expects NoMethodError: type=::Integer, method=foo
+  begin_2.foo
+
+  begin_3 = match.begin(:foo)
+  # !expects NoMethodError: type=::Integer, method=foo
+  begin_3.foo
+
+  captures_1 = match.captures
+  # !expects NoMethodError: type=::Array<::String>, method=foo
+  captures_1.foo
+
+  end_1 = match.end(0)
+  # !expects NoMethodError: type=::Integer, method=foo
+  end_1.foo
+
+  end_2 = match.end("foo")
+  # !expects NoMethodError: type=::Integer, method=foo
+  end_2.foo
+
+  end_3 = match.end(:foo)
+  # !expects NoMethodError: type=::Integer, method=foo
+  end_3.foo
+
+  length_1 = match.length
+  # !expects NoMethodError: type=::Integer, method=foo
+  length_1.foo
+
+  named_captures_1 = match.named_captures
+  # !expects NoMethodError: type=::Hash<::String, (::String | nil)>, method=foo
+  named_captures_1.foo
+
+  names_1 = match.names
+  # !expects NoMethodError: type=::Array<::String>, method=foo
+  names_1.foo
+
+  offset_1 = match.offset(0)
+  # !expects NoMethodError: type=[::Integer, ::Integer], method=foo
+  offset_1.foo
+
+  offset_2 = match.offset("foo")
+  # !expects NoMethodError: type=[::Integer, ::Integer], method=foo
+  offset_2.foo
+
+  offset_3 = match.offset(:foo)
+  # !expects NoMethodError: type=[::Integer, ::Integer], method=foo
+  offset_3.foo
+
+  post_match_1 = match.post_match
+  # !expects NoMethodError: type=::String, method=foo
+  post_match_1.foo
+
+  pre_match_1 = match.pre_match
+  # !expects NoMethodError: type=::String, method=foo
+  pre_match_1.foo
+
+  regexp_1 = match.regexp
+  # !expects NoMethodError: type=::Regexp, method=foo
+  regexp_1.foo
+
+  size_1 = match.size
+  # !expects NoMethodError: type=::Integer, method=foo
+  size_1.foo
+
+  string_1 = match.string
+  # !expects NoMethodError: type=::String, method=foo
+  string_1.foo
+
+  to_a_1 = match.to_a
+  # !expects NoMethodError: type=::Array<::String>, method=foo
+  to_a_1.foo
+
+  values_at_1 = match.values_at
+  # !expects NoMethodError: type=::Array<(::String | nil)>, method=foo
+  values_at_1.foo
+
+  values_at_2 = match.values_at(0, "foo", :foo)
+  # !expects NoMethodError: type=::Array<(::String | nil)>, method=foo
+  values_at_2.foo
+end

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -560,10 +560,65 @@ class Enumerator<'a, 'b>
                 | -> Enumerator<['a, Integer], 'b>
 end
 
+class Encoding
+end
+
 class Regexp
-  def self.compile: (String, *any) -> Regexp
+  def self.compile: (String) -> Regexp
+                  | (String, Integer) -> Regexp
+                  | (String, bool) -> Regexp
+                  | (Regexp) -> Regexp
   def self.escape: (String) -> String
+  def self.last_match: -> MatchData?
+                     | (Integer) -> String?
+  def self.quote: (String) -> String
+  def self.try_convert: (any) -> Regexp?
+  def self.union: (*String) -> Regexp
+                | (Array<String>) -> Regexp
+                | (*Regexp) -> Regexp
+                | (Array<Regexp>) -> Regexp
+
+  def initialize: (String) -> any
+                | (String, Integer) -> any
+                | (String, bool) -> any
+                | (Regexp) -> any
+  def ===: (String) -> bool
+  def =~: (String) -> Integer?
+  def casefold?: -> bool
+  def encoding: -> Encoding
+  def fixed_encoding?: -> bool
+  def match: (String) -> MatchData?
+           | (String, Integer) -> MatchData?
+           | <'a> (String) { (MatchData) -> 'a } -> ('a | nil)
+           | <'a> (String, Integer) { (MatchData) -> 'a } -> ('a | nil)
+  def match?: (String) -> bool
+            | (String, Integer) -> bool
+  def named_captures: -> Hash<String, Array<Integer>>
+  def names: -> Array<String>
+  def options: -> Integer
   def source: -> String
+  def ~: -> Integer?
+end
+
+class MatchData
+  def []: (Integer | String | Symbol) -> String?
+        | (Integer, Integer) -> Array<String>
+        | (Range<Integer>) -> Array<String>
+  def begin: (Integer) -> Integer?
+           | (String | Symbol) -> Integer
+  def captures: -> Array<String>
+  def end: (Integer | String | Symbol) -> Integer
+  def length: -> Integer
+  def named_captures: -> Hash<String, String?>
+  def names: -> Array<String>
+  def offset: (Integer | String | Symbol) -> [Integer, Integer]
+  def post_match: -> String
+  def pre_match: -> String
+  def regexp: -> Regexp
+  def size: -> Integer
+  def string: -> String
+  def to_a: -> Array<String>
+  def values_at: (*(Integer | String | Symbol)) -> Array<String?>
 end
 
 class IO


### PR DESCRIPTION
This PR updates built-in types `Regexp` and `MetaData`.

- `Regexp`:
  - Add missing methods.
  - API Doc: http://ruby-doc.org/core-2.5.1/Regexp.html
- `MatchData`:
  - Add class and methods.
  - API Doc: http://ruby-doc.org/core-2.5.1/MatchData.html
- `Encoding`:
  - `Regexp#encoding` requires `Encoding` type.
  - API Doc: http://ruby-doc.org/core-2.5.1/Encoding.html