### PR TITLE
Fix keyword typing

### DIFF
--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -503,5 +503,31 @@ module Steep
         "#{location_to_str}: IncompatibleTuple: expected_tuple=#{expected_tuple}"
       end
     end
+
+    class UnexpectedKeyword < Base
+      attr_reader :unexpected_keywords
+
+      def initialize(node:, unexpected_keywords:)
+        super(node: node)
+        @unexpected_keywords = unexpected_keywords
+      end
+
+      def to_s
+        "#{location_to_str}: UnexpectedKeyword: #{unexpected_keywords.join(", ")}"
+      end
+    end
+
+    class MissingKeyword < Base
+      attr_reader :missing_keywords
+
+      def initialize(node:, missing_keywords:)
+        super(node: node)
+        @missing_keywords = missing_keywords
+      end
+
+      def to_s
+        "#{location_to_str}: MissingKeyword: #{missing_keywords.join(", ")}"
+      end
+    end
   end
 end

--- a/smoke/literal/b.rb
+++ b/smoke/literal/b.rb
@@ -5,5 +5,5 @@ l.foo(3)
 l.foo(4)
 
 l.bar(foo: :foo)
-# !expects ArgumentTypeMismatch: receiver=::LiteralMethods, expected=:foo, actual=::Symbol
+# !expects IncompatibleAssignment: lhs_type=:foo, rhs_type=::Symbol
 l.bar(foo: :bar)


### PR DESCRIPTION
This fixes keyword typing to correctly type check the following example.

```
class A
  def foo: (any, ?foo: any) -> void
end
```

and

```rb
A.new.foo({ foo: 3 })
```