### PR TITLE
Load types from gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in steep.gemspec
 gemspec
+
+gem "with_steep_types", path: "test/gems/with_steep_types"

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -82,7 +82,7 @@ module Steep
     end
 
     def self.available_commands
-      [:check, :validate, :annotations, :scaffold, :interface, :version]
+      [:check, :validate, :annotations, :scaffold, :interface, :version, :paths]
     end
 
     def process_global_options
@@ -184,6 +184,18 @@ module Steep
 
     def process_version
       stdout.puts Steep::VERSION
+    end
+
+    def process_paths
+      signature_options = SignatureOptions.new
+
+      OptionParser.new do |opts|
+        handle_dir_options opts, signature_options
+      end.parse!(argv)
+
+      signature_options.paths.each do |path|
+        stdout.puts path
+      end
     end
   end
 end

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -2,6 +2,72 @@ require 'optparse'
 
 module Steep
   class CLI
+    BUILTIN_PATH = Pathname(__dir__).join("../../stdlib").realpath
+
+    class SignatureOptions
+      attr_reader :no_builtin
+
+      def initialize
+        @options = []
+      end
+
+      def no_builtin!
+        @no_builtin = true
+      end
+
+      def <<(option)
+        @options << option
+      end
+
+      def find_gem_dir(gem)
+        name, version = gem.split(/:/)
+        spec = Gem::Specification.find_by_name(name, version)
+
+        type_dirs = spec.metadata["steep_types"].yield_self do |types|
+          case types
+          when nil
+            []
+          when true
+            [Pathname("sig")]
+          else
+            Array(types).map do |type|
+              Pathname(type)
+            end
+          end
+        end
+
+        base_dir = Pathname(spec.base_dir)
+        type_dirs.map do |dir|
+          base_dir + dir
+        end.select(&:directory?)
+      end
+
+      def paths
+        options = if @options.none? {|option| option.is_a?(Pathname) }
+                    [Pathname("sig")]
+                  else
+                    @options
+                  end
+
+        paths = options.flat_map do |option|
+          case option
+          when Pathname
+            # Dir
+            [option]
+          when String
+            # gem name
+            find_gem_dir(option)
+          end
+        end
+
+        unless no_builtin
+          paths.unshift BUILTIN_PATH
+        end
+
+        paths
+      end
+    end
+
     attr_reader :argv
     attr_reader :stdout
     attr_reader :stdin
@@ -48,37 +114,33 @@ module Steep
       __send__(:"process_#{command}")
     end
 
+    def handle_dir_options(opts, options)
+      opts.on("-I [PATH]") {|path| options << Pathname(path) }
+      opts.on("-G [GEM]") {|gem| options << gem }
+      opts.on("--no-builtin") { options.no_builtin! }
+    end
+
     def process_check
-      signature_dirs = []
+      signature_options = SignatureOptions.new
       verbose = false
-      no_builtin = false
       dump_all_types = false
       fallback_any_is_error = false
       strict = false
 
       OptionParser.new do |opts|
-        opts.on("-I [PATH]") {|path| signature_dirs << Pathname(path) }
-        opts.on("--no-builtin") { no_builtin = true }
+        handle_dir_options opts, signature_options
         opts.on("--verbose") { verbose = true }
         opts.on("--dump-all-types") { dump_all_types = true }
         opts.on("--strict") { strict = true }
         opts.on("--fallback-any-is-error") { fallback_any_is_error = true }
       end.parse!(argv)
 
-      if signature_dirs.empty?
-        signature_dirs << Pathname("sig")
-      end
-
-      unless no_builtin
-        signature_dirs.unshift Pathname(__dir__).join("../../stdlib").realpath
-      end
-
       source_paths = argv.map {|path| Pathname(path) }
       if source_paths.empty?
         source_paths << Pathname(".")
       end
 
-      Drivers::Check.new(source_paths: source_paths, signature_dirs: signature_dirs, stdout: stdout, stderr: stderr).tap do |check|
+      Drivers::Check.new(source_paths: source_paths, signature_dirs: signature_options.paths, stdout: stdout, stderr: stderr).tap do |check|
         check.verbose = verbose
         check.dump_all_types = dump_all_types
         check.fallback_any_is_error = fallback_any_is_error || strict
@@ -88,23 +150,14 @@ module Steep
 
     def process_validate
       verbose = false
-      no_builtin = false
+      signature_options = SignatureOptions.new
 
       OptionParser.new do |opts|
+        handle_dir_options opts, signature_options
         opts.on("--verbose") { verbose = true }
-        opts.on("--no-builtin") { no_builtin = true }
       end.parse!(argv)
 
-      signature_dirs = argv.map {|path| Pathname(path) }
-      if signature_dirs.empty?
-        signature_dirs << Pathname(".")
-      end
-
-      unless no_builtin
-        signature_dirs.unshift Pathname(__dir__).join("../../stdlib").realpath
-      end
-
-      Drivers::Validate.new(signature_dirs: signature_dirs, stdout: stdout, stderr: stderr).tap do |validate|
+      Drivers::Validate.new(signature_dirs: signature_options.paths, stdout: stdout, stderr: stderr).tap do |validate|
         validate.verbose = verbose
       end.run
     end
@@ -120,19 +173,13 @@ module Steep
     end
 
     def process_interface
-      signature_dirs = []
-      no_builtin = false
+      signature_options = SignatureOptions.new
 
       OptionParser.new do |opts|
-        opts.on("-I [PATH]") {|path| signature_dirs << Pathname(path) }
-        opts.on("--no-builtin") { no_builtin = true }
+        handle_dir_options opts, signature_options
       end.parse!(argv)
 
-      unless no_builtin
-        signature_dirs.unshift Pathname(__dir__).join("../../stdlib").realpath
-      end
-
-      Drivers::PrintInterface.new(type_name: argv.first, signature_dirs: signature_dirs, stdout: stdout, stderr: stderr).run
+      Drivers::PrintInterface.new(type_name: argv.first, signature_dirs: signature_options.paths, stdout: stdout, stderr: stderr).run
     end
 
     def process_version

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -27,16 +27,14 @@ module Steep
           case types
           when nil
             []
-          when true
-            [Pathname("sig")]
-          else
-            Array(types).map do |type|
+          when String
+            types.split(/:/).map do |type|
               Pathname(type)
             end
           end
         end
 
-        base_dir = Pathname(spec.base_dir)
+        base_dir = Pathname(spec.gem_dir)
         type_dirs.map do |dir|
           base_dir + dir
         end.select(&:directory?)
@@ -44,7 +42,7 @@ module Steep
 
       def paths
         options = if @options.none? {|option| option.is_a?(Pathname) }
-                    [Pathname("sig")]
+                    @options + [Pathname("sig")]
                   else
                     @options
                   end

--- a/test/gem_cli_test.rb
+++ b/test/gem_cli_test.rb
@@ -13,16 +13,30 @@ class GemCLITest < Minitest::Test
 
   def test_G_option
     chdir Pathname(__dir__).parent do
-      sh!("bundle exec exe/steep interface -G with_steep_types ::WithSteepTypes")
+      sh!("bundle exec exe/steep interface --no-bundler -G with_steep_types ::WithSteepTypes")
     end
   end
 
   def test_G_option_with_invalid_gem
     chdir Pathname(__dir__).parent do
-      _, stderr, status = sh("bundle exec exe/steep interface -G with_steep_types123 ::WithSteepTypes")
+      _, stderr, status = sh("bundle exec exe/steep interface --no-bundler -G with_steep_types123 ::WithSteepTypes")
 
       refute_operator status, :success?
       assert_match /MissingSpecError/, stderr
+    end
+  end
+
+  def test_bundler_load
+    chdir Pathname(__dir__).parent do
+      sh!("bundle exec exe/steep interface ::WithSteepTypes")
+    end
+  end
+
+  def test_no_bundler_option
+    chdir Pathname(__dir__).parent do
+      _, _, status = sh("bundle exec exe/steep interface --no-bundler ::WithSteepTypes")
+
+      refute_operator status, :success?
     end
   end
 end

--- a/test/gem_cli_test.rb
+++ b/test/gem_cli_test.rb
@@ -1,0 +1,28 @@
+require_relative 'test_helper'
+
+class GemCLITest < Minitest::Test
+  include ShellHelper
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def envs
+    @envs ||= []
+  end
+
+  def test_G_option
+    chdir Pathname(__dir__).parent do
+      sh!("bundle exec exe/steep interface -G with_steep_types ::WithSteepTypes")
+    end
+  end
+
+  def test_G_option_with_invalid_gem
+    chdir Pathname(__dir__).parent do
+      _, stderr, status = sh("bundle exec exe/steep interface -G with_steep_types123 ::WithSteepTypes")
+
+      refute_operator status, :success?
+      assert_match /MissingSpecError/, stderr
+    end
+  end
+end

--- a/test/gems/with_steep_types/lib/with_steep_types.rb
+++ b/test/gems/with_steep_types/lib/with_steep_types.rb
@@ -1,0 +1,2 @@
+class WithSteepTypes
+end

--- a/test/gems/with_steep_types/sig/with_steep_types.rbi
+++ b/test/gems/with_steep_types/sig/with_steep_types.rbi
@@ -1,0 +1,3 @@
+class WithSteepTypes
+  def foo: -> String
+end

--- a/test/gems/with_steep_types/with_steep_types.gemspec
+++ b/test/gems/with_steep_types/with_steep_types.gemspec
@@ -1,0 +1,25 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "with_steep_types"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Soutaro Matsumoto"]
+  spec.email         = ["matsumoto@soutaro.com"]
+
+  spec.summary       = %q{Test Gem}
+  spec.description   = %q{Test Gem with steep_types metadata}
+  spec.homepage      = "https://example.com"
+  spec.license       = 'MIT'
+
+  spec.files         = [
+    "lib/with_steep_types.rb",
+    "sig/with_steep_types.rbi"
+  ]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "steep_types" => "sig"
+  }
+end


### PR DESCRIPTION
This PR is to allow shipping type definitions in gems. For this, gem developers and steep users should follow the protocol below.

## Gem developers

Put `*.rbi` files in a directory and ship them in the gem. And put a key/value pair `"steep_types" => signature_dir` in `metadata` of its gemspec.

```rb
spec.metadata = { "steep_types" => "sig" }
```

We recommend using `sig` as the name of the directory to have type definitions, but you can use any directory.

## Steep users

Run Steep with `-G` option, which accepts gem name `strong_json` or with version `strong_json:1.2.3`.

```
$ steep check -G strong_json -G other_gem -G another_gem lib
```

When you are using with bundler, `steep` detect that and load types from bundled gems automatically.

```
$ bundle exec steep check lib
```

`steep` also has `paths` subcommand, which print detected paths for signatures, and `--no-bundler` option, which disables bundled gem loading.