### PR TITLE
Report error if -G gem does not provide “steep_types”

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem "with_steep_types", path: "test/gems/with_steep_types"
+gem "without_steep_types", path: "test/gems/without_steep_types"

--- a/test/gem_cli_test.rb
+++ b/test/gem_cli_test.rb
@@ -22,7 +22,16 @@ class GemCLITest < Minitest::Test
       _, stderr, status = sh("bundle exec exe/steep interface --no-bundler -G with_steep_types123 ::WithSteepTypes")
 
       refute_operator status, :success?
-      assert_match /MissingSpecError/, stderr
+      assert_match /Gem not found: name=with_steep_types123, version=/, stderr
+    end
+  end
+
+  def test_G_option_with_gem_without_types
+    chdir Pathname(__dir__).parent do
+      _, stderr, status = sh("bundle exec exe/steep interface --no-bundler -G without_steep_types ::Integer")
+
+      refute_operator status, :success?
+      assert_match /Type definition directory not found: without_steep_types \(1.0.0\)/, stderr
     end
   end
 

--- a/test/gems/without_steep_types/lib/without_steep_types.rb
+++ b/test/gems/without_steep_types/lib/without_steep_types.rb
@@ -1,0 +1,3 @@
+class WithoutSteepTypes
+
+end

--- a/test/gems/without_steep_types/without_steep_types.gemspec
+++ b/test/gems/without_steep_types/without_steep_types.gemspec
@@ -1,0 +1,20 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "without_steep_types"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Soutaro Matsumoto"]
+  spec.email         = ["matsumoto@soutaro.com"]
+
+  spec.summary       = %q{Test Gem2}
+  spec.description   = %q{Test Gem2 without steep_types metadata}
+  spec.homepage      = "https://example.com"
+  spec.license       = 'MIT'
+
+  spec.files         = [
+    "lib/without_steep_types.rb",
+  ]
+  spec.require_paths = ["lib"]
+end


### PR DESCRIPTION
Revise two error message.

When specified gem cannot be found:

```
Gem not found: name=rake1, version=
```

When specified gem does not provide type definition:

```
Type definition directory not found: gem=rake, version=10.5.0
```

