### PR TITLE
Unique signature paths

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -114,7 +114,7 @@ module Steep
           paths.unshift BUILTIN_PATH
         end
 
-        paths
+        paths.reverse.uniq(&:realpath).reverse
       end
     end
 

--- a/test/gem_cli_test.rb
+++ b/test/gem_cli_test.rb
@@ -26,6 +26,14 @@ class GemCLITest < Minitest::Test
     end
   end
 
+  def test_G_option_does_not_have_duplicated_paths
+    chdir Pathname(__dir__).parent do
+      stdout, _ = sh!("bundle exec exe/steep paths --no-bundler -G with_steep_types -G with_steep_types -I test/gems/with_steep_types/sig ::WithSteepTypes")
+      assert_includes stdout.lines, "test/gems/with_steep_types/sig\n"
+      assert_equal 1, stdout.lines.count {|line| line =~ /with_steep_types/ }
+    end
+  end
+
   def test_G_option_with_gem_without_types
     chdir Pathname(__dir__).parent do
       _, stderr, status = sh("bundle exec exe/steep interface --no-bundler -G without_steep_types ::Integer")


### PR DESCRIPTION
Fix type checking when developing a rubygem.

Because steep detects bundled gem signatures, the signatures of the developing gem loaded twice. Use `#uniq` to solve this issue.