### PR TITLE
Fix interpreted as argument prefix warning

### DIFF
--- a/lib/steep/subtyping/trace.rb
+++ b/lib/steep/subtyping/trace.rb
@@ -37,7 +37,7 @@ module Steep
       def each
         if block_given?
           array.each do |pair|
-            yield *pair
+            yield(*pair)
           end
         else
           enum_for :each

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -165,14 +165,14 @@ module Steep
         annotation_types = annotation_method.types.each.with_object([]) do |method_type, array|
           fresh = method_type.type_params.map {|var| AST::Types::Var.fresh(var) }
           unknowns.push(*fresh)
-          
+
           subst = Interface::Substitution.build(method_type.type_params, fresh)
           array << method_type.instantiate(subst)
         end
 
         constraints = Subtyping::Constraints.new(unknowns: unknowns)
         interface_types.each do |type|
-          constraints.add_var *type.free_variables.to_a
+          constraints.add_var(*type.free_variables.to_a)
         end
 
         result = checker.check_method(method_name,

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -39,10 +39,10 @@ module Steep
 
       def params
         [].tap do |params|
-          params.push *leading_params
-          params.push *optional_params
+          params.push(*leading_params)
+          params.push(*optional_params)
           params.push rest_param if rest_param
-          params.push *trailing_params
+          params.push(*trailing_params)
         end
       end
 

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -229,7 +229,7 @@ module Steep
 
       def each(&block)
         if block_given?
-          params.each &block
+          params.each(&block)
         else
           enum_for :each
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -274,7 +274,7 @@ module ASTAssertion
   def assert_interface_method(method, name: nil)
     assert_instance_of Steep::AST::Signature::Interface::Method, method
     assert_equal name, method.name if name
-    yield *method.types if block_given?
+    yield(*method.types) if block_given?
   end
 
   def assert_include_member(member, name: nil, args: nil)


### PR DESCRIPTION
## v0.8.1

```
% RUBYOPT="-w" bundle exec rake test 2>&1 | grep interpreted
/home/sei/src/github.com/soutaro/steep/test/test_helper.rb:277: warning: `*' interpreted as argument prefix
/home/sei/src/github.com/soutaro/steep/lib/steep/subtyping/trace.rb:40: warning: `*' interpreted as argument prefix
/home/sei/src/github.com/soutaro/steep/lib/steep/type_construction.rb:175: warning: `*' interpreted as argument prefix
/home/sei/src/github.com/soutaro/steep/lib/steep/type_inference/block_params.rb:42: warning: `*' interpreted as argument prefix
/home/sei/src/github.com/soutaro/steep/lib/steep/type_inference/block_params.rb:43: warning: `*' interpreted as argument prefix
/home/sei/src/github.com/soutaro/steep/lib/steep/type_inference/block_params.rb:45: warning: `*' interpret
/home/sei/src/github.com/soutaro/steep/lib/steep/type_inference/block_params.rb:232: warning: `&' interpreted as argument prefix
```

## This pull request

```
% RUBYOPT="-w" bundle exec rake test 2>&1 | grep interpreted
```