### PR TITLE
Fix Steep::Names::Base#hash

### DIFF
--- a/lib/steep/names.rb
+++ b/lib/steep/names.rb
@@ -24,7 +24,7 @@ module Steep
       end
 
       def hash
-        self.class.hash ^ name.hash ^ @absolute.hash
+        self.class.hash ^ name.hash ^ namespace.hash
       end
 
       alias eql? ==


### PR DESCRIPTION
`@absolute` was renamed at 5000a506dd1be641819059db9ad0d18904a492f0