### PR TITLE
Add `Kernel.#Integer` method's type definition

### DIFF
--- a/smoke/integer/a.rb
+++ b/smoke/integer/a.rb
@@ -1,0 +1,31 @@
+integer_1 = Integer(1)
+# !expects NoMethodError: type=::Integer, method=foo
+integer_1.foo
+
+integer_2 = Integer("1")
+# !expects NoMethodError: type=::Integer, method=foo
+integer_2.foo
+
+class WithToInt
+  def to_int; 1; end
+end
+integer_3 = Integer(WithToInt.new)
+# !expects NoMethodError: type=::Integer, method=foo
+integer_3.foo
+
+class WithToI
+  def to_i; 1; end
+end
+integer_4 = Integer(WithToI.new)
+# !expects NoMethodError: type=::Integer, method=foo
+integer_4.foo
+
+integer_5 = Integer("10", 2)
+# !expects NoMethodError: type=::Integer, method=foo
+integer_5.foo
+
+# !expects IncompatibleArguments: receiver=::Object, method_type=(::String, ::Integer) -> ::Integer
+Integer(Object.new)
+
+# !expects IncompatibleArguments: receiver=::Object, method_type=(::String, ::Integer) -> ::Integer
+Integer(nil)

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -12,7 +12,6 @@ class Object < BasicObject
   def ===: (any) -> bool
   def !=: (any) -> bool
   def class: -> class
-  def to_i: -> Integer
   def is_a?: (Module) -> bool
   def inspect: -> String
   def freeze: -> self
@@ -64,6 +63,8 @@ module Kernel
   def loop: { () -> void } -> void
   def puts: (*any) -> void
   def eval: (String, ? Integer?, ?String) -> any
+  def Integer: (String, Integer) -> Integer
+             | (_ToI | _ToInt) -> Integer
 end
 
 class Array<'a>
@@ -251,6 +252,14 @@ interface _ToS
   def to_s: -> String
 end
 
+interface _ToI
+  def to_i: -> Integer
+end
+
+interface _ToInt
+  def to_int: -> Integer
+end
+
 class TrueClass
   def !: -> bool
 end
@@ -273,6 +282,7 @@ class Numeric
 end
 
 class Integer < Numeric
+  def to_i: -> Integer
   def to_int: -> Integer
   def +: (Integer) -> Integer
        | (Numeric) -> Numeric
@@ -377,6 +387,8 @@ class String
   def empty?: -> bool
   def length: -> Integer
   def force_encoding: (any) -> self
+  def to_i: -> Integer
+          | (Integer) -> Integer
 end
 
 interface _Iteratable<'a, 'b>


### PR DESCRIPTION
This PR adds the type definition of `Kernel.#Integer` method.
Please see API documentation: <http://ruby-doc.org/core-2.5.3/Kernel.html#method-i-Integer>

In addition, some types are added for smoke tests.

- `_ToI` (`interface`)
- `_ToInt` (`interface`) - see https://github.com/soutaro/steep/pull/71#discussion_r230157794
- ~~`Time` (implements `_ToI` interface)~~
  - Instead, add `WithToI` class for test
- `String#to_i` method
  - http://ruby-doc.org/core-2.5.3/String.html#method-i-to_i

Further, `Object#to_i` definition is removed, because `Object` doesn't have `to_i` method.
See also <http://ruby-doc.org/core-2.5.3/Object.html>.