### PR TITLE
Support private

### DIFF
--- a/lib/steep/ast/signature/members.rb
+++ b/lib/steep/ast/signature/members.rb
@@ -56,6 +56,10 @@ module Steep
           def incompatible?
             attributes.include?(:incompatible)
           end
+
+          def private?
+            attributes.include?(:private)
+          end
         end
 
         class Ivar

--- a/lib/steep/drivers/utils/validator.rb
+++ b/lib/steep/drivers/utils/validator.rb
@@ -34,7 +34,7 @@ module Steep
 
             when AST::Signature::Module
               yield_self do
-                instance_interface = builder.build_instance(sig.name, with_initialize: true)
+                instance_interface = builder.build_instance(sig.name)
                 instance_args = instance_interface.params.map {|var| AST::Types::Var.fresh(var) }
 
                 module_interface = builder.build_module(sig.name)
@@ -58,7 +58,7 @@ module Steep
 
             when AST::Signature::Class
               yield_self do
-                instance_interface = builder.build_instance(sig.name, with_initialize: true)
+                instance_interface = builder.build_instance(sig.name)
                 instance_args = instance_interface.params.map {|var| AST::Types::Var.fresh(var) }
 
                 module_interface = builder.build_class(sig.name, constructor: true)

--- a/lib/steep/interface/abstract.rb
+++ b/lib/steep/interface/abstract.rb
@@ -39,6 +39,30 @@ module Steep
           ivar_chains: ivar_chains.transform_values {|chain| chain.subst(subst) }
         )
       end
+
+      def without_private(option)
+        if option
+          self.class.new(
+            name: name,
+            params: params,
+            methods: methods.reject {|_, method| method.private? },
+            supers: supers,
+            ivar_chains: ivar_chains
+          )
+        else
+          self
+        end
+      end
+
+      def without_initialize
+        self.class.new(
+          name: name,
+          params: params,
+          methods: methods.reject {|_, method| method.name == :initialize },
+          supers: supers,
+          ivar_chains: ivar_chains
+        )
+      end
     end
   end
 end

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -444,7 +444,7 @@ module Steep
           when AST::Signature::Members::Method
             if member.instance_method?
               if with_initialize || member.name != :initialize
-                extra_attrs = member.name == :initialize ? [:incompatible] : []
+                extra_attrs = member.name == :initialize ? [:incompatible, :private] : []
                 add_method(module_name, member, methods: methods, extra_attributes: extra_attrs, current: namespace)
               end
             end

--- a/lib/steep/interface/method.rb
+++ b/lib/steep/interface/method.rb
@@ -28,6 +28,10 @@ module Steep
         attributes.include?(:incompatible)
       end
 
+      def private?
+        attributes.include?(:private)
+      end
+
       def closed?
         types.all?(&:closed?)
       end

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -3,7 +3,7 @@ class Steep::Parser
 token kCLASS kMODULE kINTERFACE kDEF kEND kNIL kBOOL kANY kVOID kTYPE
       kINCOMPATIBLE kAT_TYPE kAT_IMPLEMENTS kAT_DYNAMIC kCONST kVAR kRETURN
       kBLOCK kBREAK kMETHOD kSELF kSELFQ kATTR_READER kATTR_ACCESSOR kINSTANCE
-      kINCLUDE kEXTEND kINSTANCE kIVAR kCONSTRUCTOR kNOCONSTRUCTOR kEXTENSION
+      kINCLUDE kEXTEND kINSTANCE kIVAR kCONSTRUCTOR kNOCONSTRUCTOR kEXTENSION kPRIVATE
       tARROW tBANG tBAR tCOLON tCOMMA tDOT tEQ tGT tGVAR tHAT tINT
       tINTERFACE_NAME tIVAR_NAME tLBRACE tLBRACKET tIDENT tLPAREN tLT tROCKET
       tMINUS tOPERATOR tPERCENT tPLUS tQUESTION tRBRACE tRBRACKET
@@ -790,6 +790,10 @@ rule
                                 {
                                   result = val[0].value
                                 }
+                              | kPRIVATE
+                                {
+                                  result = val[0].value
+                                }
 
                    super_class: module_name
                                 {
@@ -919,6 +923,7 @@ rule
                               | kATTR_READER
                               | kATTR_ACCESSOR
                               | kINCOMPATIBLE
+                              | kPRIVATE
 
                     annotation: kAT_TYPE kVAR subject tCOLON type
                                 {
@@ -1203,6 +1208,8 @@ def next_token
     new_token(:kINSTANCE, :instance)
   when input.scan(/ivar\b/)
     new_token(:kIVAR, :ivar)
+  when input.scan(/private\b/)
+    new_token(:kPRIVATE, :private)
   when input.scan(/%/)
     new_token(:tPERCENT, :%)
   when input.scan(/-/)

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -603,8 +603,8 @@ module Steep
         end
       end
 
-      def resolve_instance(type, self_type:, instance_type:, module_type:, with_initialize: false)
-        abstract_interface = builder.build_instance(type.name, with_initialize: with_initialize)
+      def resolve_instance(type, self_type:, instance_type:, module_type:, with_private: false)
+        abstract_interface = builder.build_instance(type.name).without_private(!with_private)
 
         module_type = module_type || case builder.signatures.find_class_or_module(type.name)
                                      when AST::Signature::Class

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -621,7 +621,7 @@ module Steep
         )
       end
 
-      def resolve(type, self_type: type, instance_type: nil, module_type: nil)
+      def resolve(type, self_type: type, instance_type: nil, module_type: nil, with_private: false)
         Steep.logger.debug("Check#resolve: type=#{type}")
         case type
         when AST::Types::Any, AST::Types::Var, AST::Types::Class, AST::Types::Instance
@@ -631,14 +631,19 @@ module Steep
           resolve(type.back_type,
                   self_type: self_type,
                   instance_type: instance_type,
-                  module_type: module_type)
+                  module_type: module_type,
+                  with_private: with_private)
 
         when AST::Types::Name::Instance
-          resolve_instance(type, self_type: self_type, instance_type: instance_type, module_type: module_type)
+          resolve_instance(type,
+                           self_type: self_type,
+                           instance_type: instance_type,
+                           module_type: module_type,
+                           with_private: with_private)
 
         when AST::Types::Name::Class
           yield_self do
-            abstract_interface = builder.build_class(type.name, constructor: type.constructor)
+            abstract_interface = builder.build_class(type.name, constructor: type.constructor).without_private(!with_private)
 
             unless instance_type
               type_params = builder.signatures.find_class(type.name).params&.variables || []
@@ -662,7 +667,7 @@ module Steep
 
         when AST::Types::Name::Module
           yield_self do
-            abstract_interface = builder.build_module(type.name)
+            abstract_interface = builder.build_module(type.name).without_private(!with_private)
 
             unless instance_type
               type_params = builder.signatures.find_module(type.name).params&.variables || []
@@ -697,13 +702,17 @@ module Steep
           end
 
         when AST::Types::Name::Alias
-          resolve(expand_alias(type), self_type: self_type, instance_type: instance_type, module_type: module_type)
+          resolve(expand_alias(type),
+                  self_type: self_type,
+                  instance_type: instance_type,
+                  module_type: module_type,
+                  with_private: with_private)
 
         when AST::Types::Union
           interfaces = type.types.map do |member_type|
             fresh = AST::Types::Var.fresh(:___)
 
-            resolve(member_type, self_type: type, instance_type: fresh, module_type: fresh).select_method_type do |method_type|
+            resolve(member_type, self_type: type, instance_type: fresh, module_type: fresh, with_private: with_private).select_method_type do |method_type|
               !method_type.each_type.include?(fresh)
             end
           end
@@ -772,7 +781,9 @@ module Steep
                                       ivar_chains: {})
 
         when AST::Types::Intersection
-          interfaces = type.types.map do |type| resolve(type) end
+          interfaces = type.types.map do |type|
+            resolve(type, with_private: with_private)
+          end
 
           methods = interfaces.inject(nil) do |methods, i|
             if methods
@@ -825,7 +836,7 @@ module Steep
           yield_self do
             element_type = AST::Types::Union.build(types: type.types)
             array_type = AST::Builtin::Array.instance_type(element_type)
-            array_interface = resolve(array_type, self_type: self_type)
+            array_interface = resolve(array_type, self_type: self_type, with_private: with_private)
 
             array_interface.methods[:[]] = array_interface.methods[:[]].yield_self do |aref|
               types = type.types.map.with_index {|elem_type, index|
@@ -870,7 +881,7 @@ module Steep
           yield_self do
             key_type = AST::Types::Union.build(types: type.elements.keys.map {|val| AST::Types::Literal.new(value: val) })
             value_type = AST::Types::Union.build(types: type.elements.values)
-            hash_interface = resolve(AST::Builtin::Hash.instance_type(key_type, value_type), self_type: self_type)
+            hash_interface = resolve(AST::Builtin::Hash.instance_type(key_type, value_type), self_type: self_type, with_private: with_private)
 
             hash_interface.methods[:[]] = hash_interface.methods[:[]].yield_self do |ref|
               types = type.elements.map do |key, value_type|
@@ -915,7 +926,7 @@ module Steep
 
         when AST::Types::Proc
           yield_self do
-            proc_interface = resolve(type.back_type, self_type: self_type)
+            proc_interface = resolve(type.back_type, self_type: self_type, with_private: with_private)
             apply_type = Interface::MethodType.new(
               type_params: [],
               params: type.params,

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1767,7 +1767,7 @@ module Steep
 
                     else
                       begin
-                        interface = checker.resolve(receiver_type)
+                        interface = checker.resolve(receiver_type, with_private: !receiver)
 
                         method = interface.methods[method_name]
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -124,7 +124,7 @@ module Steep
                                                                                                                 self_type: self_type,
                                                                                                                 instance_type: self_type,
                                                                                                                 module_type: class_type,
-                                                                                                                with_initialize: true)
+                                                                                                                with_private: true)
                                                                                      end
                                                                                    else
                                                                                      checker.resolve(self_type)
@@ -398,7 +398,7 @@ module Steep
         class_name = implement_module_name.name
         class_args = implement_module_name.args.map {|x| AST::Types::Var.new(name: x) }
 
-        _ = checker.builder.build_instance(class_name, with_initialize: true)
+        _ = checker.builder.build_instance(class_name)
 
         instance_type = AST::Types::Name::Instance.new(name: class_name, args: class_args)
         module_type = AST::Types::Name::Class.new(name: class_name, constructor: true)

--- a/smoke/initialize/a.rb
+++ b/smoke/initialize/a.rb
@@ -6,7 +6,7 @@ class A
   end
 
   def foo()
-    # !expects NoMethodError: type=::A, method=initialize
+    # initialize is a private method, so can be called here
     initialize()
   end
 end

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -184,7 +184,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     mod = signatures.find_module(Names::Module.parse("::A"))
-    interface = builder.instance_to_interface(mod, with_initialize: false)
+    interface = builder.instance_to_interface(mod)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Names::Module.parse(:A).absolute!, interface.name
@@ -226,7 +226,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     mod = signatures.find_module(Names::Module.parse(:B))
-    interface = builder.instance_to_interface(mod, with_initialize: false)
+    interface = builder.instance_to_interface(mod)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Names::Module.parse(:B).absolute!, interface.name
@@ -256,7 +256,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse("::A"))
-    interface = builder.instance_to_interface(klass, with_initialize: false)
+    interface = builder.instance_to_interface(klass)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Names::Module.parse("::A"), interface.name
@@ -293,7 +293,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse("::B"))
-    interface = builder.instance_to_interface(klass, with_initialize: false)
+    interface = builder.instance_to_interface(klass)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Names::Module.parse("::B"), interface.name
@@ -327,7 +327,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse("::C"))
-    interface = builder.instance_to_interface(klass, with_initialize: false)
+    interface = builder.instance_to_interface(klass)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Names::Module.parse("::C"), interface.name
@@ -563,7 +563,7 @@ end
     builder = Builder.new(signatures: signatures)
 
     assert_raises Builder::RecursiveDefinitionError do
-      builder.build_instance(Names::Module.parse("::A"), with_initialize: false)
+      builder.build_instance(Names::Module.parse("::A"))
     end
   end
 
@@ -577,7 +577,7 @@ end
     builder = Builder.new(signatures: signatures)
 
     sig = signatures.find_class(Names::Module.parse(:Object))
-    interface = builder.instance_to_interface(sig, with_initialize: false)
+    interface = builder.instance_to_interface(sig)
 
     assert_instance_of Interface::Abstract, interface
 
@@ -602,7 +602,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse(:Foo))
-    interface = builder.instance_to_interface(klass, with_initialize: false)
+    interface = builder.instance_to_interface(klass)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Types::Name.new_instance(name: "::String"), interface.ivars[:"@foo"]
@@ -622,7 +622,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse(:Bar))
-    interface = builder.instance_to_interface(klass, with_initialize: false)
+    interface = builder.instance_to_interface(klass)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Types::Name.new_instance(name: "::Integer"), interface.ivars[:"@foo"]
@@ -637,7 +637,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse(:Foo))
-    interface = builder.instance_to_interface(klass, with_initialize: false).instantiate(
+    interface = builder.instance_to_interface(klass).instantiate(
       type: Types::Self.new,
       args: [Types::Var.new(name: :hoge)],
       instance_type: Types::Instance.new,
@@ -671,7 +671,7 @@ end
     checker = Steep::Subtyping::Check.new(builder: builder)
 
     signatures.find_class(Names::Module.parse(:Bar)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: false)
+      interface = builder.instance_to_interface(klass)
       instantiated = interface.instantiate(type: Types::Name.new_instance(name: "::Bar"),
                                            args: [],
                                            instance_type: Types::Name.new_instance(name: "::Bar"),
@@ -682,7 +682,7 @@ end
     end
 
     signatures.find_class(Names::Module.parse(:Baz)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: false)
+      interface = builder.instance_to_interface(klass)
       instantiated = interface.instantiate(type: Types::Name.new_instance(name: "::Baz"),
                                            args: [],
                                            instance_type: Types::Name.new_instance(name: "::Baz"),
@@ -695,7 +695,7 @@ end
     end
 
     signatures.find_class(Names::Module.parse(:Hoge)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: false)
+      interface = builder.instance_to_interface(klass)
       instantiated = interface.instantiate(type: Types::Name.new_instance(name: "::Hoge"),
                                            args: [],
                                            instance_type: Types::Name.new_instance(name: "::Hoge"),
@@ -719,7 +719,7 @@ end
 
     builder = Builder.new(signatures: signatures)
     klass = signatures.find_class(Names::Module.parse(:Hello))
-    interface = builder.instance_to_interface(klass, with_initialize: false)
+    interface = builder.instance_to_interface(klass)
 
     assert_instance_of Interface::Abstract, interface
     assert_equal Types::Name.new_instance(name: "::String"), interface.ivars[:@name]
@@ -753,12 +753,12 @@ end
 
     builder = Builder.new(signatures: signatures)
     signatures.find_class(Names::Module.parse(:Hello)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: false)
+      interface = builder.instance_to_interface(klass)
       refute_operator interface.methods[:foo], :incompatible?
     end
 
     signatures.find_class(Names::Module.parse(:World)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: false)
+      interface = builder.instance_to_interface(klass)
       assert_operator interface.methods[:foo], :incompatible?
     end
   end
@@ -773,7 +773,7 @@ end
     builder = Builder.new(signatures: signatures)
 
     signatures.find_class(Names::Module.parse(:Hello)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: true)
+      interface = builder.instance_to_interface(klass)
       assert_operator interface.methods[:initialize], :incompatible?
       refute_nil interface.methods[:initialize].super_method
     end
@@ -789,7 +789,7 @@ end
     builder = Builder.new(signatures: signatures)
 
     signatures.find_class(Names::Module.parse(:Hello)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: true)
+      interface = builder.instance_to_interface(klass)
       assert_operator interface.methods[:initialize], :private?
       refute_nil interface.methods[:initialize].super_method
     end
@@ -805,7 +805,7 @@ end
     builder = Builder.new(signatures: signatures)
 
     signatures.find_class(Names::Module.parse(:Hello)).yield_self do |klass|
-      interface = builder.instance_to_interface(klass, with_initialize: false)
+      interface = builder.instance_to_interface(klass)
       assert_operator interface.methods[:puts], :private?
       assert_nil interface.methods[:puts].super_method
     end
@@ -830,12 +830,12 @@ end
     builder = Builder.new(signatures: signatures)
 
     signatures.find_class(Names::Module.parse("::A::B::X")).yield_self do |klass|
-      builder.instance_to_interface(klass, with_initialize: true)
+      builder.instance_to_interface(klass)
       builder.class_to_interface(klass, constructor: true)
     end
 
     signatures.find_module(Names::Module.parse("::A::B::Y")).yield_self do |klass|
-      builder.instance_to_interface(klass, with_initialize: true)
+      builder.instance_to_interface(klass)
       builder.module_to_interface(klass)
     end
   end

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -779,6 +779,38 @@ end
     end
   end
 
+  def test_initialize_is_private
+    signatures = signatures(<<-EOF)
+class Hello
+  def initialize: (Integer) -> any
+end
+    EOF
+
+    builder = Builder.new(signatures: signatures)
+
+    signatures.find_class(Names::Module.parse(:Hello)).yield_self do |klass|
+      interface = builder.instance_to_interface(klass, with_initialize: true)
+      assert_operator interface.methods[:initialize], :private?
+      refute_nil interface.methods[:initialize].super_method
+    end
+  end
+
+  def test_private_method_type
+    signatures = signatures(<<-EOF)
+class Hello
+  def (private) puts: (String) -> void
+end
+    EOF
+
+    builder = Builder.new(signatures: signatures)
+
+    signatures.find_class(Names::Module.parse(:Hello)).yield_self do |klass|
+      interface = builder.instance_to_interface(klass, with_initialize: false)
+      assert_operator interface.methods[:puts], :private?
+      assert_nil interface.methods[:puts].super_method
+    end
+  end
+
   def test_relative_include
     signatures = signatures(<<-EOF)
 module A::B::C

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -504,6 +504,22 @@ end
     end
   end
 
+  def test_private_method
+    sigs = parse(<<-EOF)
+class Foo
+  def (private) method: () -> Method
+end
+    EOF
+
+    sigs[0].yield_self do |sig|
+      assert_instance_of Steep::AST::Signature::Class, sig
+      assert_equal 1, sig.members.size
+      sig.members[0].yield_self do |method|
+        assert_operator method, :private?
+      end
+    end
+  end
+
   def test_optional_block
     klass, = parse(<<-EOF)
 class Foo

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5835,4 +5835,127 @@ end
 
     assert_empty typing.errors
   end
+
+  def test_private_method1
+    checker = new_subtyping_checker(<<-EOF)
+class WithPrivate
+  def (private) foo: () -> void
+end
+    EOF
+
+    source = parse_ruby(<<-EOF)
+WithPrivate.new.foo
+    EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node, builder: checker.builder, current_module: Namespace.root)
+    const_env = ConstantEnv.new(builder: checker.builder, context: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: Types::Name.new_instance(name: "::Object"),
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+
+    construction.synthesize(source.node)
+
+    assert_equal 1, typing.errors.size
+    assert_any typing.errors do |error|
+      error.is_a?(Steep::Errors::NoMethod)
+    end
+  end
+
+  def test_private_method2
+    checker = new_subtyping_checker(<<-EOF)
+class WithPrivate
+  def (private) foo: () -> void
+end
+    EOF
+
+    source = parse_ruby(<<-EOF)
+class WithPrivate
+  def foo; end
+
+  def bar
+    foo
+  end
+end
+    EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node, builder: checker.builder, current_module: Namespace.root)
+    const_env = ConstantEnv.new(builder: checker.builder, context: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: Types::Name.new_instance(name: "::Object"),
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+  end
+
+  def test_private_method3
+    checker = new_subtyping_checker(<<-EOF)
+class WithPrivate
+  def (private) foo: () -> void
+end
+    EOF
+
+    source = parse_ruby(<<-EOF)
+class WithPrivate
+  def foo; end
+
+  def bar
+    self.foo
+  end
+end
+    EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node, builder: checker.builder, current_module: Namespace.root)
+    const_env = ConstantEnv.new(builder: checker.builder, context: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: Types::Name.new_instance(name: "::Object"),
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+
+    construction.synthesize(source.node)
+
+    assert_equal 1, typing.errors.size
+    assert_any typing.errors do |error|
+      error.is_a?(Steep::Errors::NoMethod)
+    end
+  end
 end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -1,0 +1,36 @@
+require_relative 'test_helper'
+
+class ValidationTest < Minitest::Test
+  include TestHelper
+  include SubtypingHelper
+
+  def test_visibility_validation
+    checker = new_subtyping_checker(<<-EOF)
+class Super
+  def foo: () -> void
+end
+
+class Child < Super
+  def (private) foo: () -> void
+end
+    EOF
+
+    assert_raises Steep::Interface::Instantiated::PrivateOverrideError do
+      checker.resolve(parse_type("::Child"), with_private: true).validate(checker)
+    end
+  end
+
+  def test_visibility_validation2
+    checker = new_subtyping_checker(<<-EOF)
+class Super
+  def (private) foo: () -> void
+end
+
+class Child < Super
+  def foo: () -> void
+end
+    EOF
+
+    checker.resolve(parse_type("::Child"), with_private: true).validate(checker)
+  end
+end


### PR DESCRIPTION
Private method can be declared as:

```
class Foo
  def (private) foo: () -> void
end
```

Only a method call without receiver can call the `foo` method.

```rb
class Foo
  def foo; end

  def bar
    foo()      # ok
    self.foo() # NoMethod error
  end
end
```

Steep validates type definition not to have a method definition override from public to private.

* You have to write `private` to all private methods
* If you don't write `private`, the method is *public*