### PR TITLE
Allow skipping type checking

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -525,8 +525,11 @@ module Steep
             var = node.children[0]
             rhs = node.children[1]
 
-            if var.name == :_
+            case var.name
+            when :_, :__any__
               synthesize(rhs, hint: AST::Builtin.any_type)
+              typing.add_typing(node, AST::Builtin.any_type)
+            when :__skip__
               typing.add_typing(node, AST::Builtin.any_type)
             else
               type_assignment(var, rhs, node, hint: hint)

--- a/smoke/skip/skip.rb
+++ b/smoke/skip/skip.rb
@@ -1,0 +1,15 @@
+__skip__ = begin
+  self.no_such_method
+end
+
+# @type var foo: String
+
+foo = _ = begin
+  # !expects NoMethodError: type=::Object, method=no_such_method
+  self.no_such_method
+end
+
+foo = __any__ = begin
+  # !expects NoMethodError: type=::Object, method=no_such_method
+  self.no_such_method
+end


### PR DESCRIPTION
Steep skips type checking right-hand side of an assignment to `__skip__`. This can be used to workaround writing Ruby code with an unsupported syntax.

Also introducing `__any__` for more descriptive *cast*.

```rb
__skip__ = begin
  def object.foo
    # Singleton method definition is not yet supported by Steep.
    # It raises an error without the meaningless the assignment.
  end
end
```