### PR TITLE
Fix typo hath -> hash

### DIFF
--- a/lib/steep/ast/namespace.rb
+++ b/lib/steep/ast/namespace.rb
@@ -56,7 +56,7 @@ module Steep
       alias eql? ==
 
       def hash
-        self.class.hath ^ path.hash ^ absolute?.hash
+        self.class.hash ^ path.hash ^ absolute?.hash
       end
 
       def to_s


### PR DESCRIPTION
## before

```
% bin/console
irb(main):001:0> Steep::AST::Namespace.empty.hash
Traceback (most recent call last):
        3: from bin/console:14:in `<main>'
        2: from (irb):1
        1: from /home/sei/src/github.com/soutaro/steep/lib/steep/ast/namespace.rb:59:in `hash'
NoMethodError (undefined method `hath' for Steep::AST::Namespace:Class)
Did you mean?  hash
```

## after

```
% bin/console
irb(main):001:0> Steep::AST::Namespace.empty.hash
=> 653728956248800086
```