### PR TITLE
Add `alias` signature member

### DIFF
--- a/lib/steep/ast/signature/members.rb
+++ b/lib/steep/ast/signature/members.rb
@@ -97,6 +97,18 @@ module Steep
             kind == :accessor
           end
         end
+
+        class MethodAlias
+          attr_reader :location
+          attr_reader :new_name
+          attr_reader :original_name
+
+          def initialize(location:, new_name:, original_name:)
+            @location = location
+            @new_name = new_name
+            @original_name = original_name
+          end
+        end
       end
     end
   end

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -453,6 +453,24 @@ module Steep
           end
         end
 
+        sig.members.each do |member|
+          case member
+          when AST::Signature::Members::MethodAlias
+            method = methods[member.original_name]
+            if method
+              methods[member.new_name] =  Method.new(
+                type_name: module_name,
+                name: member.new_name,
+                types: method.types,
+                super_method: nil,
+                attributes: method.attributes
+              )
+            else
+              Steep.logger.error "Cannot alias find original method `#{member.original_name}` for `#{member.new_name}` in #{module_name} (#{member.location.name || '-'}:#{member.location})"
+            end
+          end
+        end
+
         signatures.find_extensions(sig.name).each do |ext|
           ext.members.each do |member|
             case member

--- a/stdlib/builtin.rbi
+++ b/stdlib/builtin.rbi
@@ -413,9 +413,8 @@ module Enumerable<'a, 'b> : _Iteratable<'a, 'b>
   def collect: <'x> { ('a) -> 'x } -> Array<'x>
              | <'x> -> Enumerator<'a, Array<'x>>
 
-  def map: <'x> { ('a) -> 'x } -> Array<'x>
-         | <'x> -> Enumerator<'a, Array<'x>>
-
+  alias map collect
+  
   def flat_map: <'x> { ('a) -> Array<'x> } -> Array<'x>
               | <'x> -> Enumerator<'a, Array<'x>>
 
@@ -737,7 +736,7 @@ class Set<'a>
   def clear: -> self
 
   def collect!: { ('a) -> 'a } -> self
-  def map!: { ('a) -> 'a } -> self
+  alias map! collect!
 
   def delete: (any) -> self
   def delete?: (any) -> self?
@@ -761,7 +760,7 @@ class Set<'a>
   def keep_if: { ('a) -> any } -> self
 
   def size: -> Integer
-  def length: -> Integer
+  alias length size
 
   def merge: (_Iteratable<'a, any>) -> self
 

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -839,4 +839,23 @@ end
       builder.module_to_interface(klass)
     end
   end
+
+  def test_method_alias
+    signatures = signatures(<<-EOF)
+class Hello < String
+  alias to_s to_str
+  alias foo bar
+end
+    EOF
+
+    builder = Builder.new(signatures: signatures)
+    signatures.find_class(Names::Module.parse("::Hello")).yield_self do |klass|
+      interface = builder.instance_to_interface(klass)
+      method = interface.methods[:to_s]
+      assert_equal ["() -> ::String"], method.types.map(&:to_s)
+      assert_nil method.super_method
+
+      assert_nil interface.methods[:foo]
+    end
+  end
 end

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -538,4 +538,17 @@ end
       assert_equal "?{ () -> String }", required_block.types[0].block.location.source
     end
   end
+
+  def test_alias
+    klass, = parse(<<-EOF)
+class Foo
+  def count: -> Integer
+  alias size count 
+end
+    EOF
+
+    klass.members[1].yield_self do |member|
+      assert_instance_of Steep::AST::Signature::Members::MethodAlias, member
+    end
+  end
 end


### PR DESCRIPTION
`alias` allows defining an alias of method definition.

```
class Array<'a>
  def map: <'x> { ('a) -> 'x } -> Array<'x>
  alias collect map
end
```

We don't have to repeat the `map` method types, which may be very long, to define the type of `collect`. The aliasing is for interface method type level:

* `super` information is not passed to `alias` method
* Other attributes are copied