### PR TITLE
`super` in method type definition

### DIFF
--- a/lib/steep/ast/method_type.rb
+++ b/lib/steep/ast/method_type.rb
@@ -113,6 +113,14 @@ module Steep
         @block = block
         @return_type = return_type
       end
+
+      class Super
+        attr_reader :location
+
+        def initialize(location:)
+          @location = location
+        end
+      end
     end
   end
 end

--- a/lib/steep/parser.y
+++ b/lib/steep/parser.y
@@ -4,6 +4,7 @@ token kCLASS kMODULE kINTERFACE kDEF kEND kNIL kBOOL kANY kVOID kTYPE
       kINCOMPATIBLE kAT_TYPE kAT_IMPLEMENTS kAT_DYNAMIC kCONST kVAR kRETURN
       kBLOCK kBREAK kMETHOD kSELF kSELFQ kATTR_READER kATTR_ACCESSOR kINSTANCE
       kINCLUDE kEXTEND kINSTANCE kIVAR kCONSTRUCTOR kNOCONSTRUCTOR kEXTENSION kPRIVATE kALIAS
+      kSUPER
       tARROW tBANG tBAR tCOLON tCOMMA tDOT tEQ tGT tGVAR tHAT tINT
       tINTERFACE_NAME tIVAR_NAME tLBRACE tLBRACKET tIDENT tLPAREN tLT tROCKET
       tMINUS tOPERATOR tPERCENT tPLUS tQUESTION tRBRACE tRBRACKET
@@ -854,6 +855,10 @@ rule
                                 {
                                   result = [val[0]]
                                 }
+                              | kSUPER
+                                {
+                                  result = [AST::MethodType::Super.new(location: val[0].location)]
+                                }
                               | method_type tBAR method_type_union
                                 {
                                   result = [val[0]] + val[2]
@@ -1223,6 +1228,8 @@ def next_token
     new_token(:kPRIVATE, :private)
   when input.scan(/alias\b/)
     new_token(:kALIAS, :alias)
+  when input.scan(/super\b/)
+    new_token(:kSUPER, :super)
   when input.scan(/%/)
     new_token(:tPERCENT, :%)
   when input.scan(/-/)

--- a/smoke/extension/e.rb
+++ b/smoke/extension/e.rb
@@ -1,0 +1,2 @@
+# @type var x: NumberLike
+x = 1 + NumberLike.new

--- a/smoke/extension/e.rbi
+++ b/smoke/extension/e.rbi
@@ -1,0 +1,8 @@
+class NumberLike
+  def to_number: -> Integer
+end
+
+extension Integer (NumberLike)
+  def +: (NumberLike) -> NumberLike
+       | super
+end

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -858,4 +858,45 @@ end
       assert_nil interface.methods[:foo]
     end
   end
+
+  def test_method_super
+    signatures = signatures(<<-EOF)
+class Parent
+  def foo: () -> Integer
+end
+
+class Child < Parent
+  def foo: () -> String
+         | super
+end
+    EOF
+
+    builder = Builder.new(signatures: signatures)
+    signatures.find_class(Names::Module.parse("::Child")).yield_self do |klass|
+      interface = builder.instance_to_interface(klass)
+
+      method = interface.methods[:foo]
+      assert_equal ["() -> ::String", "() -> ::Integer"], method.types.map(&:to_s)
+    end
+  end
+
+  def test_method_super2
+    signatures = signatures(<<-EOF)
+class Parent
+end
+
+class Child < Parent
+  def foo: () -> String
+         | super
+end
+    EOF
+
+    builder = Builder.new(signatures: signatures)
+    signatures.find_class(Names::Module.parse("::Child")).yield_self do |klass|
+      interface = builder.instance_to_interface(klass)
+
+      method = interface.methods[:foo]
+      assert_equal ["() -> ::String"], method.types.map(&:to_s)
+    end
+  end
 end

--- a/test/signature_parsing_test.rb
+++ b/test/signature_parsing_test.rb
@@ -551,4 +551,19 @@ end
       assert_instance_of Steep::AST::Signature::Members::MethodAlias, member
     end
   end
+
+  def test_super
+    klass, = parse(<<-EOF)
+class Bar < Integer
+  def +: (Bar) -> Bar
+       | super
+end
+    EOF
+
+    klass.members[0].yield_self do |member|
+      assert_equal 2, member.types.size
+      assert_equal "(Bar) -> Bar", member.types[0].location.source
+      assert_instance_of Steep::AST::MethodType::Super, member.types[1]
+    end
+  end
 end


### PR DESCRIPTION
Some library providing `Number` like class extends existing numeric classes to allow binary operators to accept the new class.

```rbi
class MyFloat
  def +: (MyFloat) -> MyFloat
       | (Integer) -> MyFloat
       | (Float) -> MyFloat
end

extension Integer (MyFloat)
  def +: (MyFloat) -> MyFloat
       | 🤔  # What to write here??? Other libraries may extend Integer#+ too.
end
```

This patch is to allow writing `super` here which means existing method types.