### PR TITLE
Skip alias on typing

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1559,9 +1559,9 @@ module Steep
             typing.add_typing node, AST::Builtin.any_type
           end
 
-        when :splat, :sclass
+        when :splat, :sclass, :alias
           yield_self do
-            Steep.logger.error "Unsupported node #{node.type}"
+            Steep.logger.error "Unsupported node #{node.type} (#{node.location.expression.source_buffer.name}:#{node.location.expression.line})"
 
             each_child_node node do |child|
               synthesize(child)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6074,4 +6074,36 @@ y = x || []
     assert_empty typing.errors
     assert_equal parse_type("::Array<::Integer>"), type_env.lvar_types[:y]
   end
+
+  def test_skip_alias
+    checker = new_subtyping_checker()
+
+    source = parse_ruby(<<-EOF)
+alias foo bar
+    EOF
+
+    typing = Typing.new
+    annotations = source.annotations(block: source.node, builder: checker.builder, current_module: Namespace.root)
+    const_env = ConstantEnv.new(builder: checker.builder, context: nil)
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.builder.signatures)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        type_env: type_env,
+                                        block_context: nil,
+                                        self_type: Types::Name.new_instance(name: "::Object"),
+                                        method_context: nil,
+                                        typing: typing,
+                                        module_context: nil,
+                                        break_context: nil)
+
+    construction.synthesize(source.node)
+
+    assert_empty typing.errors
+    assert_equal parse_type("any"), typing.type_of(node: source.node)
+  end
 end


### PR DESCRIPTION
For #84, just skip the typing of `alias` node for now. Typing may be possible, but skips for now.
