### PR TITLE
Relax rainbow dependency

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "parser", "~> 2.4"
   spec.add_runtime_dependency "ast_utils", "~> 0.3.0"
   spec.add_runtime_dependency "activesupport", "~> 5.1"
-  spec.add_runtime_dependency "rainbow", "~> 2.2.2", "< 4.0"
+  spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.1"
   spec.add_runtime_dependency "pry", "~> 0.12.2"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.14.0"


### PR DESCRIPTION
It seems that the rainbow 3.0.0 is compatible with 2.2.2 for ruby >= 2.5.0 (steep required).
Changelog: https://github.com/sickill/rainbow/blob/master/Changelog.md#300-2017-11-29
https://rubygems.org/gems/rainbow