### PR TITLE
Propose implementation of Steepfile DSL

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -65,6 +65,8 @@ require "steep/type_inference/block_params"
 require "steep/type_inference/constant_env"
 require "steep/type_inference/type_env"
 require "steep/ast/types"
+require "steep/dsl"
+require "steep/configuration"
 
 require "steep/project"
 require "steep/project/file"

--- a/lib/steep/configuration.rb
+++ b/lib/steep/configuration.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "optparse"
+
+module Steep
+  class Configuration
+    class << self
+      # with_merged_options
+      #
+      # This method yields a new configuration object
+      # with merged results in the following precedence:
+      #
+      # 1. Command line arguments
+      # 2. Steepfile DSL arguments
+      # 3. Default arguments
+      def with_merged_options(argv)
+        configuration = Configuration.new
+
+        merge_steepfile(configuration) if File.exists?("Steepfile")
+        merge_cli_arguments(argv, configuration)
+        yield(configuration)
+      end
+
+      private
+
+      # merge_steepfile
+      #
+      # Reads Steepfile and loads all the
+      # DSL configuration. For each configuration
+      # provided in the Steepfile, invoke the appropriate
+      # Configuration setter.
+      def merge_steepfile(configuration)
+        dsl = Dsl.new
+        dsl.evaluate_steepfile(File.read("Steepfile"))
+
+        dsl.instance_variables.each do |ivar|
+          dsl_config = dsl.instance_variable_get(ivar)
+          accessor_name = ivar.to_s.delete("@")
+
+          configuration.send("#{accessor_name}=", dsl_config) unless dsl_config.nil?
+        end
+      end
+
+      # merge_cli_arguments
+      #
+      # This method merges CLI arguments into the
+      # configuration object.
+      def merge_cli_arguments(argv, configuration)
+        OptionParser.new do |options|
+          options.on("-I [PATH]") { |path| configuration.signatures = [path] }
+        end.parse!(argv)
+      end
+    end
+
+    attr_reader :signatures
+
+    def initialize
+      @signatures = [Pathname("sig")]
+    end
+
+    def signatures=(paths)
+      paths.each do |path|
+        @signatures << Pathname(path)
+      end
+    end
+  end
+end

--- a/lib/steep/dsl.rb
+++ b/lib/steep/dsl.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Steep
+  # Dsl
+  #
+  # Domain Specific Language parser
+  # for the Steepfile
+  class Dsl
+    def initialize
+      @signatures = nil
+    end
+
+    def evaluate_steepfile(contents)
+      instance_eval(contents)
+    end
+
+    private
+
+    def signatures(path)
+      @signatures ||= []
+      @signatures << path
+    end
+
+    def method_missing(method, _)
+      raise NoMethodError, "Unknown Steep configuration '#{method}'"
+    end
+
+    def respond_to_missing?
+      true
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConfigurationTest < Minitest::Test
+  def test_signatures_setter
+    config = Steep::Configuration.new
+    config.signatures = ["sig-private"]
+    expected_signatures = [Pathname("sig"), Pathname("sig-private")]
+
+    assert_equal expected_signatures, config.signatures
+  end
+
+  def test_with_merged_options
+    steepfile_contents = <<~STEEPFILE
+      signatures "sig-private"
+    STEEPFILE
+
+    expected_signatures = [Pathname("sig"), Pathname("sig-private"), Pathname("sig-third")]
+
+    File.stub(:read, steepfile_contents) do
+      File.stub(:exists?, true) do
+        Steep::Configuration.with_merged_options(%w[-I sig-third]) do |config|
+          assert_equal expected_signatures, config.signatures
+        end
+      end
+    end
+  end
+end

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DslTest < Minitest::Test
+  def setup
+    @steepfile_contents = <<~CONTENTS
+      signatures "sig"
+      signatures "sig-private"
+    CONTENTS
+  end
+
+  def test_signatures
+    dsl = Steep::Dsl.new
+    dsl.evaluate_steepfile(@steepfile_contents)
+
+    assert_equal %w[sig sig-private], dsl.instance_variable_get(:@signatures)
+  end
+
+  def test_method_missing
+    dsl = Steep::Dsl.new
+
+    assert_raises NoMethodError do
+      dsl.evaluate_steepfile("some_method 'some_arg'")
+    end
+  end
+end


### PR DESCRIPTION
Based on the discussion in #93. This PR is a simple proposal of a DSL for creating a Steepfile configuration file. The proposal is as follows:

1. Create a Dsl class that defines the available methods to be used in the Steepfile
2. Create a Configuration class to store merged options. These merged options will include Steep's defaults, Steepfile directives and command line arguments.

Let me know your feedback so that we can work towards the correct implementation.

Observations:

* The Configuration class is not yet used for the CLI class. If we decide that this implementation is the way to go, I can make changes to actually use it.
* At this moment, I only added the signatures directive to get a quick feedback on the implementation. We can incrementally move more of the options to the Dsl if so desired