### PR TITLE
Do not make Steepfile in the project directory on test

### DIFF
--- a/test/langserver_test.rb
+++ b/test/langserver_test.rb
@@ -18,11 +18,11 @@ class LangserverTest < Minitest::Test
 
   def test_initialize
     in_tmpdir do
-      (Pathname.pwd + "Steepfile").write <<EOF
+      (current_dir + "Steepfile").write <<EOF
 target :app do end
 EOF
 
-      Open3.popen3(langserver_command) do |stdin, stdout, stderr, wait_thr|
+      Open3.popen3(langserver_command, chdir: current_dir) do |stdin, stdout, stderr, wait_thr|
         stdin.puts jsonrpc(
           id: 0,
           method: "initialize",


### PR DESCRIPTION



Currently `bundle exec rake` generates a `Steepfile` in the project directory unexpectedly.
This pull request will suppress it.



The test case makes a temporary directory, but actually it did not use the directory.
So this change makes it use the directory.