### PR TITLE
Revise LSP test

### DIFF
--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -30,7 +30,7 @@ module Steep
           Steep.logger.tagged "lsp" do
             Steep.logger.debug { "Received a request: request=#{request.to_json}" }
             handle_request(project, request) do |id, result|
-              if id && result
+              if id
                 Steep.logger.debug { "Writing response to #{id}: #{result.to_json}" }
                 writer.write(id: id, result: result)
               end
@@ -111,6 +111,9 @@ module Steep
                      yield id, response_to_hover(project: project, path: path, line: line, column: column)
 
                    when :shutdown
+                     yield id, nil
+
+                   when :exit
                      exit
                    end
         end

--- a/test/lsp_double.rb
+++ b/test/lsp_double.rb
@@ -1,0 +1,103 @@
+class LSPDouble
+  attr_reader :reader
+  attr_reader :writer
+  attr_reader :diagnostics
+  attr_reader :reader_thread
+  attr_reader :response_queue
+
+  attr_reader :responses
+  attr_reader :mutex
+
+  def initialize(reader:, writer:)
+    @reader = reader
+    @writer = writer
+
+    @next_request_id = 0
+
+    @response_queue = Queue.new
+    @diagnostics = {}
+    @responses = {}
+    @mutex = Mutex.new
+  end
+
+  def next_request_id
+    @next_request_id += 1
+  end
+
+  def start()
+    raise if reader_thread
+
+    @reader_thread = Thread.new do
+      reader.read do |event|
+        if event.key?(:method)
+          process_request event
+        else
+          process_response event
+        end
+      end
+    end
+
+    if block_given?
+      begin
+        yield
+      ensure
+        stop
+      end
+    else
+      self
+    end
+  end
+
+  def stop
+    send_request(method: "shutdown") {}
+    send_request(method: "exit")
+    reader_thread.join
+  end
+
+  def process_request(request)
+    case request[:method]
+    when "textDocument/publishDiagnostics"
+      uri = request[:params][:uri]
+      synchronize_ui do
+        diagnostics[uri] = request[:params][:diagnostics]
+      end
+    end
+  end
+
+  def synchronize_ui(&block)
+    mutex.synchronize(&block)
+  end
+
+  def process_response(response)
+    responses[response[:id]] = response
+  end
+
+  def send_request(id: nil, method:, params: nil, response_timeout: 3)
+    id ||= next_request_id
+    writer.write(id: id, method: method, params: params)
+
+    if block_given?
+      yield retrieve_response(id, timeout: response_timeout)
+    else
+      id
+    end
+  end
+
+  def retrieve_response(request_id, timeout: 3)
+    finally(timeout: timeout) do
+      if responses.key?(request_id)
+        return responses[request_id]
+      end
+    end
+
+    nil
+  end
+
+  def finally(timeout: 3)
+    started_at = Time.now
+    while Time.now < started_at + timeout
+      yield
+      sleep 0.2
+    end
+  end
+end


### PR DESCRIPTION
I found `LangserverTest#test_did_change` failed on my new iMac. I'm not very sure why it happens only on my new computer, but anyway it fails.

So, I add new abstraction to make LSP test more stable, easier, and more reliable. `LSPDouble` objects can be used as a client to langserver. You can write operations from a LSP client and write tests about the status of LSP client.