### PR TITLE
No inheritance validation

### DIFF
--- a/lib/steep/interface/method.rb
+++ b/lib/steep/interface/method.rb
@@ -24,10 +24,6 @@ module Steep
           other.attributes == attributes
       end
 
-      def incompatible?
-        attributes.include?(:incompatible)
-      end
-
       def private?
         attributes.include?(:private)
       end

--- a/lib/steep/signature/errors.rb
+++ b/lib/steep/signature/errors.rb
@@ -48,26 +48,6 @@ module Steep
           io.puts "#{loc_to_s}\tInvalidTypeApplicationError: name=#{name}, expected=[#{params.join(", ")}], actual=[#{args.join(", ")}]"
         end
       end
-
-      class NoSubtypingInheritanceError < Base
-        attr_reader :type
-        attr_reader :super_type
-        attr_reader :error
-        attr_reader :trace
-
-        def initialize(type:, super_type:, error:, trace:, location:)
-          @type = type
-          @super_type = super_type
-          @error = error
-          @trace = trace
-          @location = location
-        end
-
-        def puts(io)
-          io.puts "#{loc_to_s}\tNoSubtypingInheritanceError: expected subtyping relation: #{type} <: #{super_type}"
-          Drivers::TracePrinter.new(io).print(trace, level: 2)
-        end
-      end
     end
   end
 end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -174,40 +174,6 @@ end
           error.name == parse_type("::Arryay").name
       end
     end
-
-    with_checker <<-EOF do |checker|
-class Foo
-  def to_s: -> Integer
-end
-    EOF
-
-      validator = Validator.new(checker: checker)
-      validator.validate_decl
-
-      assert_operator validator, :has_error?
-      assert_any validator.each_error do |error|
-        error.is_a?(Errors::NoSubtypingInheritanceError) &&
-          error.type == parse_type("::Foo") &&
-          error.super_type == parse_type("::Object")
-      end
-    end
-
-    with_checker <<-EOF do |checker|
-class Foo
-  def self.to_s: -> Integer
-end
-    EOF
-
-      validator = Validator.new(checker: checker)
-      validator.validate_decl
-
-      assert_operator validator, :has_error?
-      assert_any validator.each_error do |error|
-        error.is_a?(Errors::NoSubtypingInheritanceError) &&
-          error.type == parse_type("singleton(::Foo)") &&
-          error.super_type == parse_type("singleton(::Object)")
-      end
-    end
   end
 
   def test_validate_module


### PR DESCRIPTION
Steep does not validate overridden methods compatibilities. Since it involves too many type errors from Ruby standard libraries, like `Object#select` vs `Enumerable#select` vs `Hash#select`...