### PR TITLE
Print stacktrace to stderr instead of stdout

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1770,9 +1770,9 @@ module Steep
                           end
                         end
                       rescue => exn
-                        p exn
+                        $stderr.puts exn.inspect
                         exn.backtrace.each do |t|
-                          puts t
+                          $stderr.puts t
                         end
 
                         fallback_to_any node do


### PR DESCRIPTION


I'd like to save Steep's output to a file to review them. But if I execute `steep check > out`, the `out` also contains many stack traces.


This pull request will split the stack traces to $stderr.