### PR TITLE
Add `steep vendor` command

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -81,6 +81,7 @@ require "steep/drivers/signature_error_printer"
 require "steep/drivers/trace_printer"
 require "steep/drivers/print_project"
 require "steep/drivers/init"
+require "steep/drivers/vendor"
 
 if ENV["NO_COLOR"]
   Rainbow.enabled = false

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -16,7 +16,7 @@ module Steep
     end
 
     def self.available_commands
-      [:init, :check, :validate, :annotations, :version, :project, :watch, :langserver]
+      [:init, :check, :validate, :annotations, :version, :project, :watch, :langserver, :vendor]
     end
 
     def process_global_options
@@ -135,6 +135,21 @@ module Steep
         OptionParser.new do |opts|
           handle_logging_options opts
         end.parse!(argv)
+      end.run
+    end
+
+    def process_vendor
+      Drivers::Vendor.new(stdout: stdout, stderr: stderr, stdin: stdin).tap do |command|
+        OptionParser.new do |opts|
+          opts.banner = "Usage: steep vendor [options] [dir]"
+          handle_logging_options opts
+
+          opts.on("--[no-]clean") do |v|
+            command.clean_before = v
+          end
+        end.parse!(argv)
+
+        command.vendor_dir = Pathname(argv[0] || "vendor/sigs")
       end.run
     end
 

--- a/lib/steep/drivers/vendor.rb
+++ b/lib/steep/drivers/vendor.rb
@@ -1,0 +1,46 @@
+module Steep
+  module Drivers
+    class Vendor
+      attr_reader :stdout
+      attr_reader :stderr
+      attr_reader :stdin
+
+      attr_accessor :vendor_dir
+      attr_accessor :clean_before
+
+      def initialize(stdout:, stderr:, stdin:)
+        @stdout = stdout
+        @stderr = stderr
+        @stdin = stdin
+
+        @clean_before = false
+        @vendor_dir = nil
+      end
+
+      def run
+        stdout.puts "Vendoring into #{vendor_dir}..."
+
+        vendorer = Ruby::Signature::Vendorer.new(vendor_dir: vendor_dir)
+
+        if clean_before
+          stdout.puts "  Cleaning directory..."
+          vendorer.clean!
+        end
+
+        stdout.puts "  Vendoring standard libraries..."
+        vendorer.stdlib!
+
+        if defined?(Bundler)
+          Bundler.locked_gems.specs.each do |spec|
+            if Ruby::Signature::EnvironmentLoader.gem_sig_path(spec.name, spec.version.to_s).directory?
+              stdout.puts "  Vendoring rubygem: #{spec.full_name}..."
+              vendorer.gem! spec.name, spec.version.to_s
+            end
+          end
+        end
+
+        0
+      end
+    end
+  end
+end

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -8,6 +8,7 @@ module Steep
         attr_reader :signatures
         attr_reader :ignored_sources
         attr_reader :no_builtin
+        attr_reader :vendor_dir
 
         def initialize(name, sources: [], libraries: [], signatures: [], ignored_sources: [])
           @name = name
@@ -15,7 +16,7 @@ module Steep
           @libraries = libraries
           @signatures = signatures
           @ignored_sources = ignored_sources
-          @no_builtin = false
+          @vendor_dir = nil
         end
 
         def initialize_copy(other)
@@ -24,7 +25,7 @@ module Steep
           @libraries = other.libraries.dup
           @signatures = other.signatures.dup
           @ignored_sources = other.ignored_sources.dup
-          @no_builtin = other.no_builtin
+          @vendor_dir = other.vendor_dir
         end
 
         def check(*args)
@@ -54,7 +55,11 @@ module Steep
         end
 
         def no_builtin!(value = true)
-          @no_builtin = no_builtin
+          Steep.logger.error "`no_builtin!` in Steepfile is deprecated and ignored. Use `vendor` instead."
+        end
+
+        def vendor(dir = "vendor/sigs")
+          @vendor_dir = Pathname(dir)
         end
       end
 
@@ -101,7 +106,11 @@ module Steep
           signature_patterns: target.signatures,
           options: Options.new.tap do |options|
             options.libraries.push(*target.libraries)
-            options.no_builtin = true if target.no_builtin
+
+            if target.vendor_dir
+              options.vendored_stdlib_path = target.vendor_dir + "stdlib"
+              options.vendored_gems_path = target.vendor_dir + "gems"
+            end
           end
         ).tap do |target|
           project.targets << target

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -3,13 +3,16 @@ module Steep
     class Options
       attr_accessor :fallback_any_is_error
       attr_accessor :allow_missing_definitions
-      attr_accessor :no_builtin
+      attr_accessor :vendored_stdlib_path
+      attr_accessor :vendored_gems_path
       attr_reader :libraries
 
       def initialize
         self.fallback_any_is_error = false
         self.allow_missing_definitions = true
-        self.no_builtin = false
+        self.vendored_gems_path = nil
+        self.vendored_stdlib_path = nil
+
         @libraries = []
       end
     end

--- a/lib/steep/project/target.rb
+++ b/lib/steep/project/target.rb
@@ -90,8 +90,9 @@ module Steep
 
       def environment
         @environment ||= Ruby::Signature::Environment.new().tap do |env|
-          loader = Ruby::Signature::EnvironmentLoader.new()
-          loader.no_builtin! if options.no_builtin
+          stdlib_root = options.vendored_stdlib_path || Ruby::Signature::EnvironmentLoader::STDLIB_ROOT
+          gem_vendor_path = options.vendored_gems_path
+          loader = Ruby::Signature::EnvironmentLoader.new(stdlib_root: stdlib_root, gem_vendor_path: gem_vendor_path)
           options.libraries.each do |lib|
             loader.add(library: lib)
           end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -20,8 +20,11 @@ target :app do
   library "strong_json"
 end
 
-target :Gemfile, template: :gemfile
+target :Gemfile, template: :gemfile do
+  vendor stdlib: nil, gems: "vendor/signatures/gems"
+end
 EOF
+
     assert_equal 2, project.targets.size
 
     project.targets.find {|target| target.name == :app }.tap do |target|
@@ -41,7 +44,7 @@ EOF
       assert_equal [], target.signature_patterns
       assert_equal ["gemfile"], target.options.libraries
       assert_nil target.options.vendored_stdlib_path
-      assert_nil target.options.vendored_gems_path
+      assert_equal Pathname("vendor/signatures/gems"), target.options.vendored_gems_path
     end
   end
 

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -12,10 +12,9 @@ class SteepfileDSLTest < Minitest::Test
 target :app do
   check "app"
   ignore "app/views"
+  vendor
 
   signature "sig", "sig-private"
-
-  no_builtin!
 
   library "set"
   library "strong_json"
@@ -31,6 +30,8 @@ EOF
       assert_equal ["app/views"], target.ignore_patterns
       assert_equal ["sig", "sig-private"], target.signature_patterns
       assert_equal ["set", "strong_json"], target.options.libraries
+      assert_equal Pathname("vendor/sigs/stdlib"), target.options.vendored_stdlib_path
+      assert_equal Pathname("vendor/sigs/gems"), target.options.vendored_gems_path
     end
 
     project.targets.find {|target| target.name == :Gemfile }.tap do |target|
@@ -39,6 +40,8 @@ EOF
       assert_equal [], target.ignore_patterns
       assert_equal [], target.signature_patterns
       assert_equal ["gemfile"], target.options.libraries
+      assert_nil target.options.vendored_stdlib_path
+      assert_nil target.options.vendored_gems_path
     end
   end
 

--- a/test/vendor_test.rb
+++ b/test/vendor_test.rb
@@ -1,0 +1,41 @@
+require_relative "test_helper"
+
+class VendorTest < Minitest::Test
+  include TestHelper
+  include ShellHelper
+
+  Vendor = Steep::Drivers::Vendor
+
+  def stdout
+    @stdout ||= StringIO.new
+  end
+
+  def stderr
+    @stderr ||= StringIO.new
+  end
+
+  def stdin
+    @stdin ||= StringIO.new
+  end
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def test_vendor
+    in_tmpdir do
+      path = current_dir + "vendor/sigs"
+
+      v = Vendor.new(stdout: stdout, stdin: stdin, stderr: stderr)
+      v.vendor_dir = path
+      v.clean_before = true
+
+      v.run
+
+      assert_match(/Vendoring into #{path}.../, stdout.string)
+      assert_operator path, :directory?
+      assert_operator path + "stdlib", :directory?
+      assert_operator path + "gems/with_steep_types", :directory?
+    end
+  end
+end


### PR DESCRIPTION
`steep vendor` command copies all of the related signatures, from standard library and bundled gems, to `vendor/sigs` directory. You can check in the directory content to your git repository, and edit them if you need.

```
$ steep vendor              # Vendors in vendor/sigs
$ steep vendor some/where   # Vendors in another location
```

You can access the vendored signatures through `vendor` command in `Steepfile`.

```rb
target :app do
  check "app"
  ignore "app/views"
  vendor             # Equivalent to: vendor "vendor/sigs"

  ...
end
```