### PR TITLE
Fix self typing in module

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -265,10 +265,7 @@ module Steep
           ].compact
         )
 
-        module_type = AST::Types::Intersection.build(types: [
-          AST::Builtin::Module.instance_type,
-          AST::Types::Name::Class.new(name: module_name, constructor: nil)
-        ])
+        module_type = AST::Types::Name::Class.new(name: module_name, constructor: nil)
       end
 
       if annots.instance_type
@@ -545,6 +542,7 @@ module Steep
                      else
                        module_type
                      end
+
               typing.add_typing(node, type)
             else
               type_send(node, send_node: node, block_params: nil, block_body: nil)

--- a/smoke/module/c.rb
+++ b/smoke/module/c.rb
@@ -18,6 +18,6 @@ module A
   # ok
   block_given?
 
-  # !expects NoMethodError: type=(::Module & singleton(::A)), method=no_such_method_in_module
+  # !expects NoMethodError: type=singleton(::A), method=no_such_method_in_module
   no_such_method_in_module
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -224,6 +224,7 @@ end
 
 class Module
   def block_given?: -> untyped
+  def attr_reader: (*Symbol) -> void
 end
 
 class String

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -986,7 +986,7 @@ module Steep end
           for_module.module_context.implement_name
         )
         assert_equal parse_type("::Steep & ::Object"), for_module.module_context.instance_type
-        assert_equal parse_type("::Module & singleton(::Steep)"), for_module.module_context.module_type
+        assert_equal parse_type("singleton(::Steep)"), for_module.module_context.module_type
       end
     end
   end
@@ -3923,6 +3923,45 @@ alias foo bar
 
         assert_empty typing.errors
         assert_equal parse_type("untyped"), typing.type_of(node: source.node)
+      end
+    end
+  end
+
+  def test_module_singleton_method_type
+    with_checker <<-EOF do |checker|
+module WithSingleton
+  def self.bar: (Integer) -> void
+end
+    EOF
+      source = parse_ruby(<<-EOF)
+module WithSingleton
+  def self.bar(x)
+    x + 1
+  end
+end
+      EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_empty typing.errors
+      end
+    end
+  end
+
+  def test_module_self_call
+    with_checker <<-EOF do |checker|
+module Module1
+end
+    EOF
+      source = parse_ruby(<<-EOF)
+module Module1
+  attr_reader :foo
+end
+      EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_empty typing.errors
       end
     end
   end

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -298,6 +298,35 @@ FOO
     end
   end
 
+  def test_interface_module
+    with_factory({ "foo.rbs" => <<FOO }) do |factory|
+module Subject[X]
+  def self.foo: () -> void
+  def bar: () -> X
+end
+FOO
+
+      factory.type(parse_type("::Subject[bool]")).yield_self do |type|
+        factory.interface(type, private: true).yield_self do |interface|
+          assert_instance_of Steep::Interface::Interface, interface
+          assert_equal type, interface.type
+
+          assert_overload_with interface.methods[:bar], "() -> bool"
+        end
+      end
+
+      factory.type(parse_type("singleton(::Subject)")).yield_self do |type|
+        factory.interface(type, private: true).yield_self do |interface|
+          assert_instance_of Steep::Interface::Interface, interface
+          assert_equal type, interface.type
+
+          assert_overload_with interface.methods[:foo], "() -> void"
+          assert_overload_with interface.methods[:attr_reader], "(*(::String | ::Symbol)) -> ::NilClass"
+        end
+      end
+    end
+  end
+
   def test_literal_type
     with_factory() do |factory|
       factory.type(parse_type("3")).yield_self do |type|


### PR DESCRIPTION
The type of module itself was `Module & singleton(:FooModule)`, which cannot be resolved to interface and method types. This caused the problem of typing singleton methods of the module.

This patch gives the module itself `singleton(:FooModule)`, which includes `Module` in its *ancestors*.