### PR TITLE
Add exe/rbs and exe/ruby-signature

### DIFF
--- a/exe/rbs
+++ b/exe/rbs
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+load File.join(__dir__, "../vendor/ruby-signature/exe/ruby-signature")

--- a/exe/ruby-signature
+++ b/exe/ruby-signature
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+load File.join(__dir__, "../vendor/ruby-signature/exe/ruby-signature")


### PR DESCRIPTION
So that users can run the ruby-signature commands:

```
$ bundle exec rbs
$ bundle exec ruby-signature
```