### PR TITLE
Relax method name syntax in annotation

### DIFF
--- a/lib/steep/annotation_parser.rb
+++ b/lib/steep/annotation_parser.rb
@@ -2,7 +2,7 @@ module Steep
   class AnnotationParser
     VAR_NAME = /[a-z][A-Za-z0-9_]*/
     METHOD_NAME = Regexp.union(
-      /[A-Za-z][A-Za-z0-9_]*[?!]?/
+      /[^.:\s]+/
     )
     CONST_NAME = Regexp.union(
       /(::)?([A-Z][A-Za-z0-9_]*::)*[A-Z][A-Za-z0-9_]*/

--- a/test/annotation_parsing_test.rb
+++ b/test/annotation_parsing_test.rb
@@ -143,12 +143,13 @@ class AnnotationParsingTest < Minitest::Test
 
   def test_dynamic
     with_factory do |factory|
-      annot = parse_annotation("@dynamic foo, self.bar, self?.baz", factory: factory)
+      annot = parse_annotation("@dynamic foo, self.bar, self?.baz, self.current=", factory: factory)
       assert_instance_of Annotation::Dynamic, annot
 
       assert_equal Annotation::Dynamic::Name.new(name: :foo, kind: :instance), annot.names[0]
       assert_equal Annotation::Dynamic::Name.new(name: :bar, kind: :module), annot.names[1]
       assert_equal Annotation::Dynamic::Name.new(name: :baz, kind: :module_instance), annot.names[2]
+      assert_equal Annotation::Dynamic::Name.new(name: :current=, kind: :module), annot.names[3]
     end
   end
 


### PR DESCRIPTION
To allow annotations like:

```rb
# @dynamic name=
```