### PR TITLE
Let jumps have bottom type

### DIFF
--- a/lib/steep/ast/builtin.rb
+++ b/lib/steep/ast/builtin.rb
@@ -88,6 +88,14 @@ module Steep
         AST::Types::Boolean.new
       end
 
+      def self.bottom_type
+        AST::Types::Bot.new
+      end
+
+      def self.top_type
+        AST::Types::Top.new
+      end
+
       def self.optional(type)
         AST::Types::Union.build(types: [type, nil_type])
       end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -744,7 +744,7 @@ module Steep
               end
             end
 
-            typing.add_typing(node, AST::Builtin.any_type, context)
+            typing.add_typing(node, AST::Builtin.bottom_type, context)
           end
 
         when :break
@@ -770,7 +770,7 @@ module Steep
             typing.add_error Errors::UnexpectedJump.new(node: node)
           end
 
-          typing.add_typing(node, AST::Builtin.any_type, context)
+          typing.add_typing(node, AST::Builtin.bottom_type, context)
 
         when :next
           value = node.children[0]
@@ -795,13 +795,13 @@ module Steep
             typing.add_error Errors::UnexpectedJump.new(node: node)
           end
 
-          typing.add_typing(node, AST::Builtin.any_type, context)
+          typing.add_typing(node, AST::Builtin.bottom_type, context)
 
         when :retry
           unless break_context
             typing.add_error Errors::UnexpectedJump.new(node: node)
           end
-          typing.add_typing(node, AST::Builtin.any_type, context)
+          typing.add_typing(node, AST::Builtin.bottom_type, context)
 
         when :arg, :kwarg, :procarg0
           yield_self do

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4098,4 +4098,19 @@ b = 123
       end
     end
   end
+
+  def test_return_type
+    with_checker do |checker|
+      source = parse_ruby(<<-EOF)
+return 3
+      EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_empty typing.errors
+
+        assert_instance_of Steep::AST::Types::Bot, typing.type_of(node: source.node)
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4113,4 +4113,21 @@ return 3
       end
     end
   end
+
+  def test_begin_void
+    with_checker do |checker|
+      source = parse_ruby(<<-EOF)
+1+2
+return 3
+x = 4
+      EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_empty typing.errors
+
+        assert_instance_of Steep::AST::Types::Bot, typing.type_of(node: source.node)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Let control-flow operators like `return` and `break` have `bottom` type. This change allows the type checker to reason more about control-flow.