### PR TITLE
Clean type env

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1694,36 +1694,6 @@ module Steep
       end
     end
 
-    def type_assignment(var, rhs, node, hint: nil)
-      if rhs
-        result = synthesize(rhs, hint: type_env.lvar_types[var.name] || hint)
-        expand_alias(result.type) do |rhs_type|
-          node_type = assign_type_to_variable(var, rhs_type, node)
-          add_typing(node, type: node_type)
-        end
-      else
-        raise
-        lhs_type = variable_type(var)
-
-        if lhs_type
-          add_typing(node, type: lhs_type)
-        else
-          fallback_to_any node
-        end
-      end
-    end
-
-    def assign_type_to_variable(var, type, node)
-      name = var.name
-      type_env.assign(lvar: name, type: type, self_type: self_type) do |result|
-        var_type = type_env.get(lvar: name)
-        typing.add_error(Errors::IncompatibleAssignment.new(node: node,
-                                                            lhs_type: var_type,
-                                                            rhs_type: type,
-                                                            result: result))
-      end
-    end
-
     def type_ivasgn(name, rhs, node)
       rhs_type = synthesize(rhs, hint: type_env.get(ivar: name) { fallback_to_any(node) }).type
       ivar_type = type_env.assign(ivar: name, type: rhs_type, self_type: self_type) do |error|

--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -2,7 +2,6 @@ module Steep
   module TypeInference
     class TypeEnv
       attr_reader :subtyping
-      attr_reader :lvar_types
       attr_reader :const_types
       attr_reader :gvar_types
       attr_reader :ivar_types
@@ -10,7 +9,6 @@ module Steep
 
       def initialize(subtyping:, const_env:)
         @subtyping = subtyping
-        @lvar_types = {}
         @const_types = {}
         @gvar_types = {}
         @ivar_types = {}
@@ -19,7 +17,6 @@ module Steep
 
       def initialize_copy(other)
         @subtyping = other.subtyping
-        @lvar_types = other.lvar_types.dup
         @const_types = other.const_types.dup
         @gvar_types = other.gvar_types.dup
         @ivar_types = other.ivar_types.dup
@@ -28,9 +25,6 @@ module Steep
 
       def self.build(annotations:, signatures:, subtyping:, const_env:)
         new(subtyping: subtyping, const_env: const_env).tap do |env|
-          annotations.lvar_types.each do |name, type|
-            env.set(lvar: name, type: type)
-          end
           annotations.ivar_types.each do |name, type|
             env.set(ivar: name, type: type)
           end
@@ -44,9 +38,8 @@ module Steep
         end
       end
 
-      def with_annotations(lvar_types: {}, ivar_types: {}, const_types: {}, gvar_types: {}, self_type:, &block)
+      def with_annotations(ivar_types: {}, const_types: {}, gvar_types: {}, self_type:, &block)
         dup.tap do |env|
-          merge!(original_env: env.lvar_types, override_env: lvar_types, self_type: self_type, &block)
           merge!(original_env: env.ivar_types, override_env: ivar_types, self_type: self_type, &block)
           merge!(original_env: env.gvar_types, override_env: gvar_types, self_type: self_type, &block)
 
@@ -64,44 +57,11 @@ module Steep
         end
       end
 
-      def join!(envs)
-        lvars = {}
-
-        common_vars = envs.map {|env| Set.new(env.lvar_types.keys) }.inject {|a, b| a & b }
-
-        envs.each do |env|
-          env.lvar_types.each do |name, type|
-            unless lvar_types.key?(name)
-              lvars[name] = [] unless lvars[name]
-              lvars[name] << type
-            end
-          end
-        end
-
-        lvars.each do |name, types|
-          if lvar_types.key?(name) || common_vars.member?(name)
-            set(lvar: name, type: AST::Types::Union.build(types: types))
-          else
-            set(lvar: name, type: AST::Types::Union.build(types: types + [AST::Types::Nil.new]))
-          end
-        end
-      end
-
       # @type method assert: (const: Names::Module) { () -> void } -> AST::Type
       #                    | (gvar: Symbol) { () -> void } -> AST::Type
       #                    | (ivar: Symbol) { () -> void } -> AST::Type
-      #                    | (lvar: Symbol) { () -> AST::Type | nil } -> AST::Type
-      def get(lvar: nil, const: nil, gvar: nil, ivar: nil)
+      def get(const: nil, gvar: nil, ivar: nil)
         case
-        when lvar
-          lvar_name(lvar).yield_self do |name|
-            if lvar_types.key?(name)
-              lvar_types[name]
-            else
-              ty = yield
-              lvar_types[name] = ty || AST::Types::Any.new
-            end
-          end
         when const
           if const_types.key?(const)
             const_types[const]
@@ -127,12 +87,8 @@ module Steep
         end
       end
 
-      def set(lvar: nil, const: nil, gvar: nil, ivar: nil, type:)
+      def set(const: nil, gvar: nil, ivar: nil, type:)
         case
-        when lvar
-          lvar_name(lvar).yield_self do |name|
-            lvar_types[name] = type
-          end
         when const
           const_types[const] = type
         else
@@ -145,19 +101,8 @@ module Steep
       # @type method assign: (const: Names::Module, type: AST::Type) { (Subtyping::Result::Failure | nil) -> void } -> AST::Type
       #                    | (gvar: Symbol, type: AST::Type) { (Subtyping::Result::Failure | nil) -> void } -> AST::Type
       #                    | (ivar: Symbol, type: AST::Type) { (Subtyping::Result::Failure | nil) -> void } -> AST::Type
-      #                    | (lvar: Symbol | LabeledName, type: AST::Type) { (Subtyping::Result::Failure) -> void } -> AST::Type
-      def assign(lvar: nil, const: nil, gvar: nil, ivar: nil, type:, self_type:, &block)
+      def assign(const: nil, gvar: nil, ivar: nil, type:, self_type:, &block)
         case
-        when lvar
-          yield_self do
-            name = lvar_name(lvar)
-            var_type = lvar_types[name]
-            if var_type
-              assert_assign(var_type: var_type, lhs_type: type, self_type: self_type, &block)
-            else
-              lvar_types[name] = type
-            end
-          end
         when const
           yield_self do
             const_type = const_types[const] || const_env.lookup(const)
@@ -186,15 +131,6 @@ module Steep
           yield ivar, ivar_types
         when gvar
           yield gvar, gvar_types
-        end
-      end
-
-      def lvar_name(lvar)
-        case lvar
-        when Symbol
-          lvar
-        when ASTUtils::Labeling::LabeledName
-          lvar.name
         end
       end
 


### PR DESCRIPTION
* Drop methods related to local variables from `TypeEnv`
* Fix `opasgn` typing