### PR TITLE
Add type checking configuration to dsl

### DIFF
--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -56,9 +56,13 @@ module Steep
                   source_file.errors.reject do |error|
                     case
                     when error.is_a?(Errors::FallbackAny)
-                      !target.options.fallback_any_is_error
+                      target.options.allow_fallback_any
                     when error.is_a?(Errors::MethodDefinitionMissing)
                       target.options.allow_missing_definitions
+                    when error.is_a?(Errors::NoMethod)
+                      target.options.allow_unknown_method_calls
+                    when error.is_a?(Errors::UnknownConstantAssigned)
+                      target.options.allow_unknown_constant_assignment
                     end
                   end.each do |error|
                     error.print_to stdout

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -53,7 +53,14 @@ module Steep
               status.type_check_sources.each do |source_file|
                 case source_file.status
                 when Project::SourceFile::TypeCheckStatus
-                  source_file.errors.each do |error|
+                  source_file.errors.reject do |error|
+                    case
+                    when error.is_a?(Errors::FallbackAny)
+                      !target.options.fallback_any_is_error
+                    when error.is_a?(Errors::MethodDefinitionMissing)
+                      target.options.allow_missing_definitions
+                    end
+                  end.each do |error|
                     error.print_to stdout
                   end
                 when Project::SourceFile::TypeCheckErrorStatus

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -9,6 +9,7 @@ module Steep
         attr_reader :ignored_sources
         attr_reader :no_builtin
         attr_reader :vendor_dir
+        attr_reader :strictness_level
 
         def initialize(name, sources: [], libraries: [], signatures: [], ignored_sources: [])
           @name = name
@@ -17,6 +18,7 @@ module Steep
           @signatures = signatures
           @ignored_sources = ignored_sources
           @vendor_dir = nil
+          @strictness_level = :default
         end
 
         def initialize_copy(other)
@@ -26,6 +28,7 @@ module Steep
           @signatures = other.signatures.dup
           @ignored_sources = other.ignored_sources.dup
           @vendor_dir = other.vendor_dir
+          @strictness_level = other.strictness_level
         end
 
         def check(*args)
@@ -38,6 +41,10 @@ module Steep
 
         def library(*args)
           libraries.push(*args)
+        end
+
+        def typing_options(level)
+          @strictness_level = level
         end
 
         def signature(*args)
@@ -113,6 +120,13 @@ module Steep
           signature_patterns: target.signatures,
           options: Options.new.tap do |options|
             options.libraries.push(*target.libraries)
+
+            case target.strictness_level
+            when :strict
+              options.apply_strict_typing_options!
+            when :lenient
+              options.apply_lenient_typing_options!
+            end
 
             case target.vendor_dir
             when Array

--- a/lib/steep/project/file.rb
+++ b/lib/steep/project/file.rb
@@ -31,14 +31,6 @@ module Steep
         case status
         when TypeCheckStatus
           status.typing.errors
-          # errors.reject do |error|
-          #   case
-          #   when error.is_a?(Errors::FallbackAny)
-          #     !options.fallback_any_is_error
-          #   when error.is_a?(Errors::MethodDefinitionMissing)
-          #     options.allow_missing_definitions
-          #   end
-          # end
         else
           []
         end

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -1,19 +1,41 @@
 module Steep
   class Project
     class Options
-      attr_accessor :fallback_any_is_error
+      attr_accessor :allow_fallback_any
       attr_accessor :allow_missing_definitions
+      attr_accessor :allow_unknown_constant_assignment
+      attr_accessor :allow_unknown_method_calls
       attr_accessor :vendored_stdlib_path
       attr_accessor :vendored_gems_path
       attr_reader :libraries
 
       def initialize
-        self.fallback_any_is_error = false
-        self.allow_missing_definitions = true
+        apply_default_typing_options!
         self.vendored_gems_path = nil
         self.vendored_stdlib_path = nil
 
         @libraries = []
+      end
+
+      def apply_default_typing_options!
+        self.allow_fallback_any = true
+        self.allow_missing_definitions = true
+        self.allow_unknown_constant_assignment = false
+        self.allow_unknown_method_calls = false
+      end
+
+      def apply_strict_typing_options!
+        self.allow_fallback_any = false
+        self.allow_missing_definitions = false
+        self.allow_unknown_constant_assignment = false
+        self.allow_unknown_method_calls = false
+      end
+
+      def apply_lenient_typing_options!
+        self.allow_fallback_any = true
+        self.allow_missing_definitions = true
+        self.allow_unknown_constant_assignment = true
+        self.allow_unknown_method_calls = true
       end
     end
   end

--- a/smoke/alias/Steepfile
+++ b/smoke/alias/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/and/Steepfile
+++ b/smoke/and/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/array/Steepfile
+++ b/smoke/array/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/block/Steepfile
+++ b/smoke/block/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/case/Steepfile
+++ b/smoke/case/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/class/Steepfile
+++ b/smoke/class/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/const/Steepfile
+++ b/smoke/const/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/dstr/Steepfile
+++ b/smoke/dstr/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/ensure/Steepfile
+++ b/smoke/ensure/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/enumerator/Steepfile
+++ b/smoke/enumerator/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/extension/Steepfile
+++ b/smoke/extension/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/hash/Steepfile
+++ b/smoke/hash/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/hello/Steepfile
+++ b/smoke/hello/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/if/Steepfile
+++ b/smoke/if/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/implements/Steepfile
+++ b/smoke/implements/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/initialize/Steepfile
+++ b/smoke/initialize/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/integer/Steepfile
+++ b/smoke/integer/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/interface/Steepfile
+++ b/smoke/interface/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/kwbegin/Steepfile
+++ b/smoke/kwbegin/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/lambda/Steepfile
+++ b/smoke/lambda/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/literal/Steepfile
+++ b/smoke/literal/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/map/Steepfile
+++ b/smoke/map/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/method/Steepfile
+++ b/smoke/method/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/module/Steepfile
+++ b/smoke/module/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/regexp/Steepfile
+++ b/smoke/regexp/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/regression/Steepfile
+++ b/smoke/regression/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
   library "set"

--- a/smoke/rescue/Steepfile
+++ b/smoke/rescue/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/self/Steepfile
+++ b/smoke/self/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/skip/Steepfile
+++ b/smoke/skip/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/stdout/Steepfile
+++ b/smoke/stdout/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/super/Steepfile
+++ b/smoke/super/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/type_case/Steepfile
+++ b/smoke/type_case/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/yield/Steepfile
+++ b/smoke/yield/Steepfile
@@ -1,4 +1,5 @@
 target :test do
+  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -15,6 +15,7 @@ class SteepfileDSLTest < Minitest::Test
 
       Project::DSL.parse(project, <<EOF)
 target :app do
+  typing_options :strict
   check "app"
   ignore "app/views"
   vendor
@@ -40,6 +41,7 @@ EOF
         assert_equal ["set", "strong_json"], target.options.libraries
         assert_equal Pathname("vendor/sigs/stdlib"), target.options.vendored_stdlib_path
         assert_equal Pathname("vendor/sigs/gems"), target.options.vendored_gems_path
+        assert_equal false, target.options.allow_missing_definitions
       end
 
       project.targets.find {|target| target.name == :Gemfile }.tap do |target|
@@ -50,6 +52,7 @@ EOF
         assert_equal ["gemfile"], target.options.libraries
         assert_nil target.options.vendored_stdlib_path
         assert_equal Pathname("vendor/signatures/gems"), target.options.vendored_gems_path
+        assert_equal true, target.options.allow_missing_definitions
       end
     end
   end


### PR DESCRIPTION
From the commit message:
> This allows the project owner to specify the strictness of type
> checks in their project. The naming of the new options draws upon
> the structure of similar options in mypy[0] and the naming of the
> typing errors themselves.
> 
> These two errors are very common ones that arise when trying to add
> steep to an existing untyped project.
> 
> [0] https://mypy.readthedocs.io/en/stable/config_file.html

I tried adding steep to a few projects just to see what the process of adding types to an existing project was. These two typing errors came up regularly, and could be an impediment to adding typing gradually to an existing project.