### PR TITLE
Type check optarg with hint

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -943,7 +943,9 @@ module Steep
             var = node.children[0]
             rhs = node.children[1]
 
-            node_type, constr = synthesize(rhs, hint: hint)
+            type = context.lvar_env[var.name]
+
+            node_type, constr = synthesize(rhs, hint: type)
 
             constr_ = constr.update_lvar_env do |env|
               env.assign(var.name, node: node, type: node_type) do |declared_type, type, result|

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -530,6 +530,26 @@ end
     end
   end
 
+  def test_def_optional_param
+    with_checker <<RBS do |checker|
+class TestDefOptional
+  def foo: (?Array[String], ?b: Hash[Symbol, Integer]) -> void
+end
+RBS
+      source = parse_ruby(<<-RUBY)
+class TestDefOptional
+  def foo(a = [], b: {})
+  end
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_block
     with_checker do |checker|
       source = parse_ruby(<<-EOF)


### PR DESCRIPTION
Method optarg/kwoptard type check didn't use method type as a hint, which caused a `FallbackAny` error with the following code.

```rb
def foo(array = [])
end
```

This PR fixes the issue.