### PR TITLE
Support Heredoc

### DIFF
--- a/lib/steep/typing.rb
+++ b/lib/steep/typing.rb
@@ -154,7 +154,7 @@ module Steep
       child = self.class.new(source: source,
                              parent: self,
                              root_context: root_context,
-                             contexts: TypeInference::ContextArray.new(buffer: contexts.buffer, range: range))
+                             contexts: TypeInference::ContextArray.new(buffer: contexts.buffer, range: range, context: nil))
       @should_update = true
 
       if block_given?

--- a/test/context_array_test.rb
+++ b/test/context_array_test.rb
@@ -6,44 +6,47 @@ class ContextArrayTest < Minitest::Test
   include FactoryHelper
 
   ContextArray = Steep::TypeInference::ContextArray
+  AST = Steep::AST
 
-  def test_array
+  def dump(array, entry = array.root, prefix: "")
+    puts "#{prefix}#{entry.range} => #{entry.context}"
+    entry.sub_entries.each do |sub|
+      dump array, sub, prefix: "#{prefix}  "
+    end
+  end
+
+  def test_array_1
     with_factory do
-      source = parse_ruby(<<EOF)
-foo { }
-bar do |x|
-  foo
-end
+      buffer = AST::Buffer.new(name: :buf, content: <<EOF)
+01234567890123456789
 EOF
 
-      array = ContextArray.from_source(source: source)
+      array = ContextArray.new(buffer: buffer, context: :root)
+      array.insert_context 1..10, context: :context1
+      array.insert_context 5..8, context: :context2
+      array.insert_context 3..8, context: :context3
 
-      assert_nil array[0]
+      assert_equal :root, array[0]
+      assert_equal :root, array[11]
+      assert_equal :context1, array[1]
+      assert_equal :context1, array[10]
+      assert_equal :context2, array[5]
+      assert_equal :context2, array[8]
+      assert_equal :context3, array[3]
+    end
+  end
 
-      array.insert_context(5..6, context: :context1)
+  def test_array_2
+    with_factory do
+      buffer = AST::Buffer.new(name: :buf, content: <<EOF)
+01234567890123456789
+EOF
 
-      array.insert_context(
-        dig(source.node, 1, 1).loc.end.end_pos..dig(source.node, 1).loc.end.begin_pos,
-        context: :context2
-      )
+      array = ContextArray.new(buffer: buffer, context: :root)
+      array.insert_context 1..5, context: :context1
+      array.insert_context 5..8, context: :context2
 
-      assert_nil array[4]
       assert_equal :context1, array[5]
-      assert_equal :context1, array[6]
-      assert_nil array[7]
-
-      assert_nil array.at(line: 1, column: 4)
-      assert_equal :context1, array.at(line: 1, column: 5)
-      assert_equal :context1, array.at(line: 1, column: 6)
-      assert_nil array.at(line: 1, column: 7)
-
-      assert_nil array.at(line: 2, column: 9)
-      assert_equal :context2, array.at(line: 2, column: 10)
-      assert_equal :context2, array.at(line: 3, column: 3)
-      assert_equal :context2, array.at(line: 4, column: 0)
-      assert_nil array.at(line: 4, column: 1)
-
-      assert_nil array.at(line: 4, column: 3)
     end
   end
 
@@ -68,7 +71,7 @@ EOF
       assert_equal :context2, array[range3.begin]
       assert_equal :context2, array[range3.end]
 
-      ContextArray.new(buffer: array.buffer, range: range2).tap do |sub|
+      ContextArray.new(buffer: array.buffer, range: range2, context: nil).tap do |sub|
         sub.insert_context(range3, context: :context3)
 
         assert_nil sub[range2.begin]

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -77,7 +77,14 @@ end
     context = Context.new(
       block_context: nil,
       method_context: nil,
-      module_context: nil,
+      module_context: Context::ModuleContext.new(
+        instance_type: nil,
+        module_type: nil,
+        implement_name: nil,
+        current_namespace: Namespace.root,
+        const_env: const_env,
+        class_name: nil
+      ),
       break_context: nil,
       self_type: self_type,
       type_env: type_env,
@@ -1947,7 +1954,7 @@ def f(x)
   if x
     x = "forever"
     x + ""
-  end 
+  end
 end
       RUBY
 
@@ -4339,7 +4346,7 @@ b = 123
         # a = ...
         typing.context_at(line: 0, column: 0).tap do |ctx|
           assert_instance_of Context, ctx
-          assert_nil ctx.module_context
+          assert_equal construction.module_context, ctx.module_context
           assert_nil ctx.method_context
           assert_nil ctx.block_context
           assert_nil ctx.break_context
@@ -4530,6 +4537,23 @@ EOF
 
         assert_equal parse_type("::Integer?"), context.lvar_env[:x]
         assert_equal parse_type("::Integer"), context.lvar_env[:y]
+      end
+    end
+  end
+
+  def test_heredoc
+    with_checker do |checker|
+      source = parse_ruby(<<'EOF')
+q = <<-QUERY
+  #{[1].map { "" }}
+QUERY
+q
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
       end
     end
   end


### PR DESCRIPTION
Heredoc breaks our assumption about relations between context ranges.

```rb
a = foo(<<EOF)       # [].map { } is sub node of foo call, but the location is not. 🤔 
  #{ [].map { } }
EOF
puts a
```

This PR is to introduce tree structure to manage the contexts and to makes context insertions more flexible.