### PR TITLE
Fix constant resolution

### DIFF
--- a/lib/steep/project/file.rb
+++ b/lib/steep/project/file.rb
@@ -42,7 +42,7 @@ module Steep
 
       def self.type_check(source, subtyping:)
         annotations = source.annotations(block: source.node, factory: subtyping.factory, current_module: AST::Namespace.root)
-        const_env = TypeInference::ConstantEnv.new(factory: subtyping.factory, context: nil)
+        const_env = TypeInference::ConstantEnv.new(factory: subtyping.factory, context: [AST::Namespace.root])
         type_env = TypeInference::TypeEnv.build(annotations: annotations,
                                                 subtyping: subtyping,
                                                 const_env: const_env,

--- a/lib/steep/server/code_worker.rb
+++ b/lib/steep/server/code_worker.rb
@@ -84,7 +84,7 @@ module Steep
             loc = error.location_to_str
 
             LSP::Interface::Diagnostic.new(
-              message: StringIO.new.tap {|io| error.print_to(io) }.string.gsub(/\A#{loc}: /, "").chomp,
+              message: StringIO.new.tap {|io| error.print_to(io) }.string.gsub(/\A#{Regexp.escape(loc)}: /, "").chomp,
               severity: LSP::Constant::DiagnosticSeverity::ERROR,
               range: LSP::Interface::Range.new(
                 start: LSP::Interface::Position.new(

--- a/lib/steep/type_inference/constant_env.rb
+++ b/lib/steep/type_inference/constant_env.rb
@@ -15,26 +15,18 @@ module Steep
         @table = RBS::ConstantTable.new(builder: factory.definition_builder)
       end
 
-      def namespace
-        @namespace ||= if context
-                         context.namespace.append(context.name)
-                       else
-                         AST::Namespace.root
-                       end
-      end
-
       def lookup(name)
         cache[name] ||= begin
           constant = table.resolve_constant_reference(
             factory.type_name_1(name),
-            context: factory.namespace_1(namespace)
+            context: context.map {|namespace| factory.namespace_1(namespace) }
           )
 
           if constant
             factory.type(constant.type)
           end
         rescue => exn
-          Steep.logger.error "Looking up a constant failed: name=#{name}, context=#{context}, error=#{exn.inspect}"
+          Steep.logger.error "Looking up a constant failed: name=#{name}, context=[#{context.join(", ")}], error=#{exn.inspect}"
           nil
         end
       end

--- a/lib/steep/type_inference/context.rb
+++ b/lib/steep/type_inference/context.rb
@@ -48,6 +48,7 @@ module Steep
         attr_reader :defined_module_methods
         attr_reader :const_env
         attr_reader :implement_name
+        attr_reader :namespaces
         attr_reader :current_namespace
         attr_reader :class_name
         attr_reader :instance_definition

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "listen", "~> 3.1"
   spec.add_runtime_dependency "pry", "~> 0.12.2"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.14.0.2"
-  spec.add_runtime_dependency "rbs", "~> 0.2.0"
+  spec.add_runtime_dependency "rbs", "~> 0.3.1"
 end

--- a/test/code_worker_test.rb
+++ b/test/code_worker_test.rb
@@ -316,13 +316,13 @@ class Hello
   1 + ""
 end
 RUBY
-      target.add_source Pathname("lib/ruby_syntax_error.rb"), <<RUBY
-class Hello
-RUBY
 
       worker = Server::CodeWorker.new(project: project, reader: worker_reader, writer: worker_writer)
 
-      worker.typecheck_file Pathname("lib/success.rb"), project.targets[0]
+      Thread.start do
+        worker.typecheck_file Pathname("lib/success.rb"), project.targets[0]
+      end
+
       master_reader.read do |response|
         uri = response[:params][:uri]
         diagnostics = response[:params][:diagnostics]

--- a/test/constant_env_test.rb
+++ b/test/constant_env_test.rb
@@ -49,7 +49,7 @@ end
   end
 
   def test_from_toplevel
-    with_constant_env(context: nil) do |env|
+    with_constant_env(context: [Steep::AST::Namespace.root]) do |env|
       assert_equal parse_type("singleton(::BasicObject)"),
                    env.lookup(Names::Module.parse("BasicObject"))
       assert_equal parse_type("singleton(::Kernel)"),
@@ -58,7 +58,7 @@ end
   end
 
   def test_from_module
-    with_constant_env({ "foo.rbs" => <<-EOS }, context: Names::Module.parse("::A")) do |env|
+    with_constant_env({ "foo.rbs" => <<-EOS }, context: [Names::Module.parse("::A")]) do |env|
 module A end
 module A::String end
     EOS

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ require "tmpdir"
 require 'minitest/hooks/test'
 require "lsp_double"
 
+Rainbow.enabled = false
+
 module Steep::AST::Types::Name
   def self.new_module(location: nil, name:, args: [])
     name = Steep::Names::Module.parse(name.to_s) unless name.is_a?(Steep::Names::Module)

--- a/test/type_env_test.rb
+++ b/test/type_env_test.rb
@@ -124,7 +124,7 @@ class TypeEnvTest < Minitest::Test
 
   def test_const_without_annotation
     with_checker do |checker|
-      const_env = ConstantEnv.new(factory: checker.factory, context: nil)
+      const_env = ConstantEnv.new(factory: checker.factory, context: [AST::Namespace.root])
       type_env = TypeEnv.new(subtyping: checker, const_env: const_env)
 
       # When constant type is known from const env
@@ -307,7 +307,7 @@ class TypeEnvTest < Minitest::Test
 
   def test_with_annotation_const
     with_checker do |checker|
-      const_env = ConstantEnv.new(factory: checker.factory, context: nil)
+      const_env = ConstantEnv.new(factory: checker.factory, context: [AST::Namespace.root])
       original_env = TypeEnv.new(subtyping: checker, const_env: const_env)
 
       union_type = AST::Types::Union.build(types: [


### PR DESCRIPTION
Fix broken constant lookup through outer module definition.

```rb
class A::B
  C = foo()        # Fixed to resolve to A::B::C
  B.bar()          # Fixed to resolve to A::B
end
```