### PR TITLE
Fix watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ## master
 
+* Fix `steep watch` ([#147](https://github.com/soutaro/steep/pull/147))
+
 ## 0.16.2 (2020-05-27)
 
-* Update gems ([144](https://github.com/soutaro/steep/pull/144), [145](https://github.com/soutaro/steep/pull/145))
+* Update gems ([#144](https://github.com/soutaro/steep/pull/144), [#145](https://github.com/soutaro/steep/pull/145))
 
 ## 0.16.1 (2020-05-22)
 
 * Fix constant resolution ([#143](https://github.com/soutaro/steep/pull/143))
-* Fix RBS diagnostics line number in LSP ([142](https://github.com/soutaro/steep/pull/142))
-* Fix crash caused by hover on `def` in LSP ([140](https://github.com/soutaro/steep/pull/140)) 
+* Fix RBS diagnostics line number in LSP ([#142](https://github.com/soutaro/steep/pull/142))
+* Fix crash caused by hover on `def` in LSP ([#140](https://github.com/soutaro/steep/pull/140)) 
 
 ## 0.16.0 (2020-05-19)
 

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -24,7 +24,7 @@ module Steep
         project = load_config()
 
         loader = Project::FileLoader.new(project: project)
-        loader.load_sources([])
+        loader.load_sources(dirs)
         loader.load_signatures()
 
         client_read, server_write = IO.pipe
@@ -36,7 +36,7 @@ module Steep
         server_reader = LanguageServer::Protocol::Transport::Io::Reader.new(server_read)
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
-        interaction_worker = Server::InteractionWorker.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
+        interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
         signature_worker = Server::WorkerProcess.spawn_worker(:signature, name: "signature", steepfile: project.steepfile_path)
         code_workers = Server::WorkerProcess.spawn_code_workers(steepfile: project.steepfile_path)
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class CLITest < Minitest::Test
   include ShellHelper
+  include TestHelper
 
   def dirs
     @dirs ||= []
@@ -62,6 +63,64 @@ end
       stdout, _ = sh!(*steep, "validate")
 
       assert_equal "", stdout
+    end
+  end
+
+  def test_watch
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "app"
+  signature "sig"
+end
+      EOF
+
+      (current_dir + "app").mkdir
+      (current_dir + "app/lib").mkdir
+      (current_dir + "app/models").mkdir
+      (current_dir + "sig").mkdir
+
+      (current_dir + "app/models/person.rb").write <<RUBY
+# steep watch won't type check this file.
+class Person
+end
+
+"hello" + 3
+RUBY
+
+      r, w = IO.pipe
+      pid = spawn(*steep.push("watch", "app/lib"), out: w, chdir: current_dir.to_s)
+      w.close
+
+      begin
+        stdout = ""
+        Thread.new do
+          while line = r.gets
+            stdout << line
+          end
+        end
+
+        finally_holds do
+          assert_equal <<EOF, stdout
+👀 Watching directories, Ctrl-C to stop.
+EOF
+        end
+
+        (current_dir + "app/lib/foo.rb").write <<RUBY
+1 + ""
+RUBY
+
+        finally_holds do
+          assert_equal <<EOF, stdout
+👀 Watching directories, Ctrl-C to stop.
+🔬 Type checking updated files...
+app/lib/foo.rb:1:0: UnresolvedOverloading: receiver=::Integer, method_name=+, method_types=(::Integer) -> ::Integer | (::Float) -> ::Float | (::Rational) -> ::Rational | (::Complex) -> ::Complex (1 + "")
+EOF
+        end
+      ensure
+        Process.kill(:INT, pid)
+        Process.waitpid pid
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -450,4 +450,4 @@ module LSPTestHelper
 end
 
 
-TestHelper.timeout = ENV["CI"] ? 30 : 10
+TestHelper.timeout = ENV["CI"] ? 50 : 10


### PR DESCRIPTION
Fix the following errors:

* `steep watch` raises `NoMethodError` on `InteractionWorker`.
* `steep watch` watches all of the source files, ignoring the list of directories given as the command line parameters.