### PR TITLE
Remove Pry 🙏 

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -8,10 +8,10 @@ require "logger"
 require "active_support/tagged_logging"
 require "rainbow"
 require "listen"
-require 'pry'
 require 'language_server-protocol'
 require "etc"
 require "open3"
+require "stringio"
 
 require "rbs"
 

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", ">= 5.1"
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.1"
-  spec.add_runtime_dependency "pry", ">= 0.12.2"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.14.0.2"
   spec.add_runtime_dependency "rbs", "~> 0.3.1"
 end


### PR DESCRIPTION
Steep no longer uses the gem, which was used in `steep watch` command. 👋 