### PR TITLE
Fix typing of union collections

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1256,7 +1256,7 @@ module Steep
                       end
                     end
                   else
-                    [select_super_type(synthesize(e).type, element_hint)]
+                    [select_super_type(synthesize(e, hint: element_hint).type, element_hint)]
                   end
                 end
                 array_type = AST::Builtin::Array.instance_type(AST::Types::Union.build(types: element_types))

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1037,10 +1037,10 @@ module Steep
               case child.type
               when :pair
                 key, value = child.children
-                key_types << synthesize(key).type.yield_self do |type|
+                key_types << synthesize(key, hint: key_hint).type.yield_self do |type|
                   select_super_type(type, key_hint)
                 end
-                value_types << synthesize(value).type.yield_self do |type|
+                value_types << synthesize(value, hint: value_hint).type.yield_self do |type|
                   select_super_type(type, value_hint)
                 end
               when :kwsplat

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3682,6 +3682,27 @@ EOF
     end
   end
 
+  def test_array_union
+    with_checker <<EOF do |checker|
+class Animal
+end
+
+type animal = :dog | :cat
+Animal::ALL: Array[animal]
+EOF
+
+      source = parse_ruby(<<EOF)
+Animal::ALL = [:dog, :cat]
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_passing_empty_block
     with_checker do |checker|
       source = parse_ruby(<<EOF)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4068,6 +4068,27 @@ EOF
     end
   end
 
+  def test_hash_union
+    with_checker <<EOF do |checker|
+class Animal
+end
+
+type animal = :dog | :cat
+Animal::ALL: Hash[Symbol, animal]
+EOF
+
+      source = parse_ruby(<<EOF)
+Animal::ALL = { :dog => :dog, :cat => :cat }
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_polymorphic_method
     with_checker <<-EOF do |checker|
 interface _Ref[X]


### PR DESCRIPTION
Array and Hash typing were broken. The `synthesize` for their elements should pass type _hints_.