### PR TITLE
Filter error messages based on options in LSP

### DIFF
--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -53,18 +53,7 @@ module Steep
               status.type_check_sources.each do |source_file|
                 case source_file.status
                 when Project::SourceFile::TypeCheckStatus
-                  source_file.errors.reject do |error|
-                    case
-                    when error.is_a?(Errors::FallbackAny)
-                      target.options.allow_fallback_any
-                    when error.is_a?(Errors::MethodDefinitionMissing)
-                      target.options.allow_missing_definitions
-                    when error.is_a?(Errors::NoMethod)
-                      target.options.allow_unknown_method_calls
-                    when error.is_a?(Errors::UnknownConstantAssigned)
-                      target.options.allow_unknown_constant_assignment
-                    end
-                  end.each do |error|
+                  source_file.errors.select {|error| target.options.error_to_report?(error) }.each do |error|
                     error.print_to stdout
                   end
                 when Project::SourceFile::TypeCheckErrorStatus

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -37,6 +37,21 @@ module Steep
         self.allow_unknown_constant_assignment = true
         self.allow_unknown_method_calls = true
       end
+
+      def error_to_report?(error)
+        case
+        when error.is_a?(Errors::FallbackAny)
+          !allow_fallback_any
+        when error.is_a?(Errors::MethodDefinitionMissing)
+          !allow_missing_definitions
+        when error.is_a?(Errors::NoMethod)
+          !allow_unknown_method_calls
+        when error.is_a?(Errors::UnknownConstantAssigned)
+          !allow_unknown_constant_assignment
+        else
+          true
+        end
+      end
     end
   end
 end

--- a/lib/steep/server/code_worker.rb
+++ b/lib/steep/server/code_worker.rb
@@ -47,7 +47,7 @@ module Steep
 
         Steep.logger.info "Finished type checking: #{path}@#{target.name}"
 
-        diagnostics = source_diagnostics(source)
+        diagnostics = source_diagnostics(source, target.options)
 
         writer.write(
           method: :"textDocument/publishDiagnostics",
@@ -58,7 +58,7 @@ module Steep
         )
       end
 
-      def source_diagnostics(source)
+      def source_diagnostics(source, options)
         case status = source.status
         when Project::SourceFile::ParseErrorStatus
           []
@@ -80,7 +80,7 @@ module Steep
             )
           ]
         when Project::SourceFile::TypeCheckStatus
-          status.typing.errors.map do |error|
+          status.typing.errors.select {|error| options.error_to_report?(error) }.map do |error|
             loc = error.location_to_str
 
             LSP::Interface::Diagnostic.new(

--- a/test/code_worker_test.rb
+++ b/test/code_worker_test.rb
@@ -307,6 +307,7 @@ end
 target :lib do
   check "lib"
   signature "sig"
+  typing_options :lenient
 end
 EOF
 
@@ -314,6 +315,7 @@ EOF
       target.add_source Pathname("lib/success.rb"), <<RUBY
 class Hello
   1 + ""
+  1.hello_world
 end
 RUBY
 


### PR DESCRIPTION
This caused a problem that `steep check` and `steep watch` generate different error messages. 😢 