### PR TITLE
Allow rbs v0.4

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.1"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.14.0.2"
-  spec.add_runtime_dependency "rbs", "~> 0.3.1"
+  spec.add_runtime_dependency "rbs", ">= 0.3.1", '< 0.5.0'
 end


### PR DESCRIPTION
Thanks for releasing rbs v0.4.0 :tada:

But unfortunately, I couldn't use it because steep restricts rbs version. So this pull request relaxes the restriction to allow rbs v0.4.0.
I guess steep will work well with rbs v0.4.0 because `rake test` passes.


