### PR TITLE
Sort result of Pathname#glob

### DIFF
--- a/lib/steep/project/file_loader.rb
+++ b/lib/steep/project/file_loader.rb
@@ -20,7 +20,7 @@ module Steep
                       Pathname.glob(absolute_path)
                     end
 
-            files.each do |source_path|
+            files.sort.each do |source_path|
               yield project.relative_path(source_path)
             end
           end


### PR DESCRIPTION
This pull request sorts the result of Pathname#glob.
Because Pathname#glob's order depends on the environment.
See https://bugs.ruby-lang.org/issues/8709


The not sorted paths introduce confusing behavior. Steep may display different results with not-sorted paths between different environments.
So I think it it better if the paths are sorted. 

By the way, I found the not-sorted paths with a confusing behavior of steep, I guess it is a bug. So I'll report it as another issue.