### PR TITLE
Add "require 'uri'" for LSP

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -12,6 +12,7 @@ require 'language_server-protocol'
 require "etc"
 require "open3"
 require "stringio"
+require 'uri'
 
 require "rbs"
 


### PR DESCRIPTION
Steep langserver uses uri library but it isn't required.


```bash
$ git grep URI
lib/steep/drivers/watch.rb:              uri = URI.parse(response[:params][:uri])
lib/steep/server/code_worker.rb:            uri: URI.parse(project.absolute_path(path).to_s).tap {|uri| uri.scheme = "file"},
lib/steep/server/code_worker.rb:            paths = request[:params][:arguments].map {|arg| source_path(URI.parse(arg)) }
lib/steep/server/code_worker.rb:          path = source_path(URI.parse(request[:params][:textDocument][:uri]))
lib/steep/server/interaction_worker.rb:          uri = URI.parse(request[:params][:textDocument][:uri])
lib/steep/server/interaction_worker.rb:          uri = URI.parse(params[:textDocument][:uri])
lib/steep/server/master.rb:          uri = URI.parse(message[:params][:textDocument][:uri])
lib/steep/server/signature_worker.rb:        path = source_path(URI.parse(request[:params][:textDocument][:uri]))
lib/steep/server/signature_worker.rb:              uri: URI.parse(project.absolute_path(path).to_s).tap {|uri| uri.scheme = "file"},
lib/steep/server/utils.rb:        path = source_path(URI.parse(request[:params][:textDocument][:uri]))
test/code_worker_test.rb:        assert_equal Pathname("lib/success.rb"), project.relative_path(Pathname(URI.parse(uri).path))
test/code_worker_test.rb:        assert_equal Pathname("lib/annotation_syntax_error.rb"), project.relative_path(Pathname(URI.parse(uri).path))
test/code_worker_test.rb:        assert_equal Pathname("lib/ruby_syntax_error.rb"), project.relative_path(Pathname(URI.parse(uri).path))
```


So the langserver raises an error.


This pull request fixes this problem by adding a `require`.