### PR TITLE
Allow typing_options DSL to specify each option

### DIFF
--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -10,6 +10,7 @@ module Steep
         attr_reader :no_builtin
         attr_reader :vendor_dir
         attr_reader :strictness_level
+        attr_reader :typing_option_hash
 
         def initialize(name, sources: [], libraries: [], signatures: [], ignored_sources: [])
           @name = name
@@ -19,6 +20,7 @@ module Steep
           @ignored_sources = ignored_sources
           @vendor_dir = nil
           @strictness_level = :default
+          @typing_option_hash = {}
         end
 
         def initialize_copy(other)
@@ -29,6 +31,7 @@ module Steep
           @ignored_sources = other.ignored_sources.dup
           @vendor_dir = other.vendor_dir
           @strictness_level = other.strictness_level
+          @typing_option_hash = other.typing_option_hash
         end
 
         def check(*args)
@@ -43,8 +46,9 @@ module Steep
           libraries.push(*args)
         end
 
-        def typing_options(level)
+        def typing_options(level = @strictness_level, **hash)
           @strictness_level = level
+          @typing_option_hash = hash
         end
 
         def signature(*args)
@@ -127,6 +131,8 @@ module Steep
             when :lenient
               options.apply_lenient_typing_options!
             end
+
+            options.merge!(target.typing_option_hash)
 
             case target.vendor_dir
             when Array

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -52,6 +52,13 @@ module Steep
           true
         end
       end
+
+      def merge!(hash)
+        self.allow_fallback_any = hash[:allow_fallback_any] if hash.key?(:allow_fallback_any)
+        self.allow_missing_definitions = hash[:allow_missing_definitions] if hash.key?(:allow_missing_definitions)
+        self.allow_unknown_constant_assignment = hash[:allow_unknown_constant_assignment] if hash.key?(:allow_unknown_constant_assignment)
+        self.allow_unknown_method_calls = hash[:allow_unknown_method_calls] if hash.key?(:allow_unknown_method_calls)
+      end
     end
   end
 end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -57,6 +57,33 @@ EOF
     end
   end
 
+  def test_config_typing_options
+    in_tmpdir do
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<RUBY)
+target :app do
+  check "app"
+  ignore "app/views"
+  vendor
+
+  typing_options :strict,
+                 allow_missing_definitions: true,
+                 allow_fallback_any: true
+end
+RUBY
+
+      assert_equal 1, project.targets.size
+
+      target = project.targets[0]
+
+      assert_operator target.options, :allow_missing_definitions
+      assert_operator target.options, :allow_fallback_any
+      refute_operator target.options, :allow_unknown_constant_assignment
+      refute_operator target.options, :allow_unknown_method_calls
+    end
+  end
+
   def test_invalid_template
     in_tmpdir do
       project = Project.new(steepfile_path: current_dir + "Steepfile")


### PR DESCRIPTION
Example:

```rb
target :lib do
  typing_options :strict,
                 allow_missing_definitions: true,
                 allow_fallback_any: true
end
```