### PR TITLE
Nominal Subtyping

### DIFF
--- a/smoke/class/a.rbs
+++ b/smoke/class/a.rbs
@@ -18,7 +18,6 @@ class D
   def foo: -> untyped
 end
 
-class E
-  def initialize: () -> untyped
+interface _E
   def foo: -> untyped
 end

--- a/smoke/class/f.rb
+++ b/smoke/class/f.rb
@@ -1,8 +1,10 @@
-# @type var e: E
+# @type var e: _E
 # @type var d: D
 
 e = (_ = nil)
 d = (_ = nil)
 
 e = d
+
+# !expects IncompatibleAssignment: lhs_type=::D, rhs_type=::_E
 d = e

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.1"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.14.0.2"
-  spec.add_runtime_dependency "rbs", ">= 0.6.0", '< 0.7.0'
+  spec.add_runtime_dependency "rbs", "~> 0.7.0"
 end

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -121,33 +121,33 @@ end
 
   def test_interface
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: -> Integer
 end
 
-class B
+interface _B
   def foo: -> untyped
 end
     EOS
 
-      assert_success_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
-      assert_success_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
     end
   end
 
   def test_interface2
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: -> Integer
   def bar: -> untyped
 end
 
-class B
+interface _B
   def foo: -> untyped
 end
     EOS
-      assert_success_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
-      assert_fail_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+      assert_success_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_fail_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::MethodMissingError, result.error
         assert_equal :bar, result.error.name
       end
@@ -156,35 +156,34 @@ end
 
   def test_interface3
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: -> Integer
 end
 
-class B
+interface _B
   def foo: -> String
 end
     EOS
 
-      assert_fail_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
-        assert_equal :to_str, result.error.name
+      assert_fail_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
   end
 
   def test_interface4
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: () -> Integer
 end
 
-class B
+interface _B
   def foo: (?Integer, ?foo: Symbol) -> untyped
 end
     EOS
 
-      assert_success_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
-      assert_fail_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+      assert_success_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_fail_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::ParameterMismatchError, result.error
         assert_equal :foo, result.error.name
       end
@@ -193,40 +192,40 @@ end
 
   def test_interface5
     with_checker(<<-EOS) do |checker|
-class A
+interface _A
   def foo: [A] () -> A
 end
 
-class B
+interface _B
   def foo: () -> Integer
 end
     EOS
-      assert_fail_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+      assert_fail_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::PolyMethodSubtyping, result.error
         assert_equal :foo, result.error.name
       end
 
-      assert_success_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
     end
   end
 
   def test_interface51
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: [X] (X) -> X
 end
 
-class B
+interface _B
   def foo: (String) -> Integer
 end
     EOS
 
-      assert_fail_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+      assert_fail_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::PolyMethodSubtyping, result.error
         assert_equal :foo, result.error.name
       end
 
-      assert_fail_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+      assert_fail_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::PolyMethodSubtyping, result.error
         assert_equal :foo, result.error.name
       end
@@ -235,21 +234,20 @@ end
 
   def test_interface52
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: [X] (X) -> Object
 end
 
-class B
+interface _B
   def foo: (String) -> Integer
 end
     EOS
-      assert_fail_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+      assert_fail_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::PolyMethodSubtyping, result.error
       end
 
-      assert_fail_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
-        assert_equal :to_int, result.error.name
+      assert_fail_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
   end
@@ -286,56 +284,54 @@ end
 
   def test_interface6
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: [A, B] (A) -> B
 end
 
-class B
+interface _B
   def foo: [X, Y] (X) -> Y
 end
     EOS
-      assert_success_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
-      assert_success_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
     end
   end
 
   def test_interface7
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: (Integer) -> Integer
          | (untyped) -> untyped
 end
 
-class B
+interface _B
   def foo: (String) -> String
 end
     EOS
 
-      assert_success_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
 
-      assert_fail_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
-        assert_equal :to_str, result.error.name
+      assert_fail_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
   end
 
   def test_interface8
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: () { () -> Object } -> String
 end
 
-class B
+interface _B
   def foo: () { () -> String } -> Object
 end
     EOS
 
-      assert_success_result checker.check(parse_relation("::A", "::B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::_A", "::_B", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
 
-      assert_fail_result checker.check(parse_relation("::B", "::A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
-        assert_equal :to_str, result.error.name
+      assert_fail_result checker.check(parse_relation("::_B", "::_A", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
   end
@@ -349,8 +345,7 @@ end
       end
 
       assert_fail_result checker.check(parse_relation(":foo", "::Integer", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
-        assert_equal :to_int, result.error.name
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
   end
@@ -406,7 +401,7 @@ end
       assert_success_check checker, "::String", "::Object | ::String"
 
       assert_fail_check checker, "::Object | ::Integer", "::String" do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
 
@@ -438,11 +433,11 @@ end
       assert_success_check checker, "::String", "::Object & ::String"
 
       assert_fail_check checker, "::Object", "::Integer & ::String" do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
+        assert_instance_of Failure::UnknownPairError, result.error
       end
 
       assert_fail_check checker, "::Object & ::Integer", "::String" do |result|
-        assert_instance_of Failure::MethodMissingError, result.error
+        assert_instance_of Failure::UnknownPairError, result.error
       end
     end
   end
@@ -478,18 +473,18 @@ end
 
   def test_constraints_01
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: -> Integer
 end
 
-class B[A]
+interface _B[A]
   def foo: -> A
 end
     EOS
 
       assert_success_check checker,
-                           "::A",
-                           parse_type("::B[X]", checker: checker, variables: [:X]),
+                           "::_A",
+                           parse_type("::_B[X]", checker: checker, variables: [:X]),
                            constraints: Constraints.new(unknowns: [:X]) do |result|
         assert_operator result.constraints, :unknown?, :X
         assert_instance_of AST::Types::Top, result.constraints.upper_bound(:X)
@@ -498,18 +493,18 @@ end
     end
 
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: (Integer) -> void
 end
 
-class B[A]
+interface _B[A]
   def foo: (A) -> void
 end
     EOS
 
       assert_success_check checker,
-                           "::A",
-                           parse_type("::B[X]", checker: checker, variables: [:X]),
+                           "::_A",
+                           parse_type("::_B[X]", checker: checker, variables: [:X]),
                            constraints: Constraints.new(unknowns: [:X]) do |result|
         assert_operator result.constraints, :unknown?, :X
         assert_equal "::Integer", result.constraints.upper_bound(:X).to_s
@@ -518,18 +513,18 @@ end
     end
 
     with_checker <<-EOS do |checker|
-class A
+interface _A
   def foo: (Integer) -> Integer
 end
 
-class B[A]
+interface _B[A]
   def foo: (A) -> A
 end
     EOS
 
       assert_success_check checker,
-                           "::A",
-                           parse_type("::B[X]", checker: checker, variables: [:X]),
+                           "::_A",
+                           parse_type("::_B[X]", checker: checker, variables: [:X]),
                            constraints: Constraints.new(unknowns: [:X]) do |result|
         assert_operator result.constraints, :unknown?, :X
         assert_equal "::Integer", result.constraints.upper_bound(:X).to_s
@@ -540,20 +535,20 @@ end
 
   def test_constraints2
     with_checker <<-EOS do |checker|
-class A[X]
+interface _A[X]
   def get: -> X
   def set: (X) -> self
 end
 
-class B
+interface _B
   def get: -> String
   def set: (String) -> self
 end
     EOS
 
       assert_success_check checker,
-                           parse_type("::A[T]", checker: checker, variables: [:T]),
-                           "::B",
+                           parse_type("::_A[T]", checker: checker, variables: [:T]),
+                           "::_B",
                            constraints: Constraints.new(unknowns: [:T]) do |result|
         assert_equal "::String", result.constraints.upper_bound(:T).to_s
         assert_equal "::String", result.constraints.lower_bound(:T).to_s
@@ -631,16 +626,147 @@ end
 class Object < BasicObject
 end
 
-class Int
+interface _Int
   def clamp: [A] () -> (self | A)
 end
 
-class Ratio
+interface _Ratio
   def clamp: [A] () -> (self | A)
 end
     EOF
 
-      assert_success_check checker, "::Int", "::Ratio"
+      assert_success_check checker, "::_Int", "::_Ratio"
+    end
+  end
+
+  def test_instance_super_types
+    with_checker <<-EOF do |checker|
+class Object
+  include Kernel
+end
+
+interface _Hashing
+end
+
+class SuperString < String
+  include _Hashing
+end
+
+module Foo[X, Y]
+end
+
+class Set[X] < Array[X]
+  include Foo[String, X]
+end
+    EOF
+
+      parse_type("::Object", checker: checker).tap do |type|
+        super_types = checker.instance_super_types(type.name, args: type.args)
+
+        assert_equal [
+                       parse_type("::BasicObject", checker: checker),
+                       parse_type("::Kernel", checker: checker)
+                     ], super_types
+      end
+
+      parse_type("::SuperString", checker: checker).tap do |type|
+        super_types = checker.instance_super_types(type.name, args: type.args)
+
+        assert_equal [
+                       parse_type("::String", checker: checker),
+                       parse_type("::_Hashing", checker: checker)
+                     ], super_types
+      end
+
+      parse_type("::Set[::String]", checker: checker).tap do |type|
+        super_types = checker.instance_super_types(type.name, args: type.args)
+
+        assert_equal [
+                       parse_type("::Array[::String]", checker: checker),
+                       parse_type("::Foo[::String, ::String]", checker: checker)
+                     ], super_types
+      end
+    end
+  end
+
+  def test_singleton_super_types
+    with_checker <<-EOF do |checker|
+class Object
+  include Kernel
+end
+
+class SuperString < String
+  include _Hashing
+  extend Foo[String, Integer]
+end
+
+module Foo[X, Y]
+end
+    EOF
+
+      parse_type("singleton(::Object)", checker: checker).tap do |type|
+        super_types = checker.singleton_super_types(type.name)
+
+        assert_equal [
+                       parse_type("singleton(::BasicObject)", checker: checker)
+                     ], super_types
+      end
+
+      parse_type("singleton(::SuperString)", checker: checker).tap do |type|
+        super_types = checker.singleton_super_types(type.name)
+
+        assert_equal [
+                       parse_type("singleton(::String)", checker: checker),
+                       parse_type("::Foo[::String, ::Integer]", checker: checker)
+                     ], super_types
+      end
+    end
+  end
+
+  def test_nominal_typing
+    with_checker <<-EOF do |checker|
+class Object
+  include Kernel
+end
+
+class String
+  def to_s: (Integer) -> String
+end
+    EOF
+      assert_success_check checker, "::String", "::Object"
+      assert_success_check checker, "::String", "::Kernel"
+      assert_success_check checker, "::String", "::BasicObject"
+
+      assert_fail_check checker, "::Object", "::String" do |result|
+        assert_instance_of Failure::UnknownPairError, result.error
+      end
+    end
+  end
+
+  def test_nominal_typing2
+    with_checker <<-EOF do |checker|
+class Collection[out X]
+  def get: () -> X
+end
+
+class SuperCollection[out X] < Collection[X]
+end
+    EOF
+      assert_success_check checker, "::Collection[::String]", "::Object"
+      assert_success_check checker, "::Collection[::String]", "::Collection[::Object]"
+      assert_fail_check checker, "::Collection[::Object]", "::Collection[::String]"
+
+      assert_success_check(checker,
+                           "::Collection[::String]",
+                           parse_type("::Collection[X]", checker: checker, variables: [:X]),
+                           constraints: Constraints.new(unknowns: [:X])) do |result|
+        assert_operator result.constraints, :unknown?, :X
+        assert_instance_of AST::Types::Top, result.constraints.upper_bound(:X)
+        assert_equal parse_type("::String", checker: checker), result.constraints.lower_bound(:X)
+      end
+
+      assert_success_check checker, "::SuperCollection[::String]", "::Collection[::String]"
+      assert_success_check checker, "::SuperCollection[::String]", "::Collection[::Object]"
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -254,6 +254,8 @@ class Numeric
 end
 
 class Integer < Numeric
+  def +: (Integer) -> Integer
+       | (Numeric) -> Numeric
 end
 
 class Symbol

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1604,7 +1604,7 @@ y = x + ""
 
         assert_equal 1, typing.errors.size
         assert_any typing.errors do |error|
-          error.is_a?(Steep::Errors::ArgumentTypeMismatch)
+          error.is_a?(Steep::Errors::UnresolvedOverloading)
         end
       end
     end
@@ -1887,7 +1887,7 @@ a ||= a + "foo"
 
         assert_equal 1, typing.errors.size
         assert_any typing.errors do |error|
-          error.is_a?(Steep::Errors::ArgumentTypeMismatch)
+          error.is_a?(Steep::Errors::UnresolvedOverloading)
         end
       end
     end
@@ -2625,8 +2625,8 @@ EOF
       with_standard_construction(checker, source) do |construction, typing|
         pair = construction.synthesize(source.node)
 
-        assert_empty typing.errors
-        assert_equal parse_type("::Numeric | ::String | ::Symbol"), pair.type
+        assert_no_error typing
+        assert_equal parse_type("::Integer | ::String | ::Symbol"), pair.type
         assert_equal parse_type("::String | ::Integer | ::Symbol | nil"), pair.context.lvar_env[:x]
       end
     end
@@ -2651,7 +2651,7 @@ EOF
         pair = construction.synthesize(source.node)
 
         assert_no_error typing
-        assert_equal parse_type("::String | ::Numeric | ::Integer"), pair.type
+        assert_equal parse_type("::String | ::Integer"), pair.type
       end
     end
   end
@@ -2676,8 +2676,8 @@ EOF
         pair = construction.synthesize(source.node)
 
         assert_no_error typing
-        assert_equal parse_type("::Integer | ::Numeric"), pair.type
-        assert_equal parse_type("::Integer | ::Numeric"), pair.constr.context.lvar_env[:y]
+        assert_equal parse_type("::Integer"), pair.type
+        assert_equal parse_type("::Integer"), pair.constr.context.lvar_env[:y]
       end
     end
   end
@@ -2983,8 +2983,8 @@ EOF
 
         assert_no_error typing
 
-        assert_equal parse_type("::Numeric?"), pair.constr.context.lvar_env[:y]
-        assert_equal parse_type("::Numeric?"), pair.constr.context.lvar_env[:z]
+        assert_equal parse_type("::Integer?"), pair.constr.context.lvar_env[:y]
+        assert_equal parse_type("::Integer?"), pair.constr.context.lvar_env[:z]
       end
     end
   end
@@ -3937,7 +3937,7 @@ EOF
         pair = construction.synthesize(source.node)
 
         assert_no_error typing
-        assert_equal "^(::Integer, untyped) -> ::Numeric", pair.context.lvar_env[:l].to_s
+        assert_equal "^(::Integer, untyped) -> ::Integer", pair.context.lvar_env[:l].to_s
 
         lambda_context = typing.context_at(line: 3, column: 3)
         assert_equal parse_type("::Integer"), lambda_context.lvar_env[:x]
@@ -4251,7 +4251,7 @@ end
 
         assert_equal 1, typing.errors.size
         assert_any typing.errors do |error|
-          error.is_a?(Steep::Errors::ArgumentTypeMismatch)
+          error.is_a?(Steep::Errors::UnresolvedOverloading)
         end
       end
     end
@@ -4479,7 +4479,7 @@ AssignTest.new.foo(a = 1, b = a+1)
         assert_no_error typing
 
         assert_equal parse_type("::Integer"), context.lvar_env[:a]
-        assert_equal parse_type("::Numeric"), context.lvar_env[:b]
+        assert_equal parse_type("::Integer"), context.lvar_env[:b]
       end
     end
   end


### PR DESCRIPTION
The subtyping relationship between class/module types is now defined with inheritance/mixin relationships (nominal subtyping). (Subtyping between interface types is still defined structurally.)

```rb
class A
  def hello: (String) -> void
end

class B < A
end

class C < A
  def hello: (Integer) -> void
end

# @type var a: A
# @type var b: B
# @type var c: C

a = b     # Ok
a = c     # Ok even though hello types are incompatible (was an error). Because incompatible methods are so common in Ruby.
b = c     # Error while they are compatible structurally (was ok).
```