### PR TITLE
Allow `./` prefix for signature pattern

### DIFF
--- a/lib/steep/project/target.rb
+++ b/lib/steep/project/target.rb
@@ -79,6 +79,7 @@ module Steep
       def self.test_pattern(patterns, path, ext:)
         patterns.any? do |pattern|
           p = pattern.end_with?(File::Separator) ? pattern : pattern + File::Separator
+          p.delete_prefix!('./')
           (path.to_s.start_with?(p) && path.extname == ext) || File.fnmatch(pattern, path.to_s)
         end
       end

--- a/test/target_test.rb
+++ b/test/target_test.rb
@@ -7,6 +7,7 @@ module Steep
     def test_test_pattern
       assert Project::Target.test_pattern(["lib/*"], Pathname("lib/foo.rb"), ext: ".rb")
       assert Project::Target.test_pattern(["lib"], Pathname("lib/foo.rb"), ext: ".rb")
+      assert Project::Target.test_pattern(["./lib"], Pathname("lib/foo.rb"), ext: ".rb")
       refute Project::Target.test_pattern(["lib"], Pathname("test/foo_test.rb"), ext: ".rb")
     end
 


### PR DESCRIPTION
# Problem

Currently Steep ignores signature if the pattern starts with `./`.
For example:

```ruby
# Steepfile
target :app do
  signature './sig' # it doesn't work
end
```

Because `Steep::Project::Target.test_pattern` receives a relative path, and the relative path doesn't include `./`. So they never match.

# Solution

Remove `./` from patterns.