### PR TITLE
Make exit code success when Steep has unreported type errors

### DIFF
--- a/lib/steep/project/target.rb
+++ b/lib/steep/project/target.rb
@@ -205,7 +205,7 @@ module Steep
       def errors
         case status
         when TypeCheckStatus
-          source_files.each_value.flat_map(&:errors)
+          source_files.each_value.flat_map(&:errors).select { |error | options.error_to_report?(error) }
         else
           []
         end

--- a/test/target_test.rb
+++ b/test/target_test.rb
@@ -102,6 +102,29 @@ end
       end
     end
 
+    def test_success_type_check_with_unreported_errors
+      target = Project::Target.new(
+        name: :foo,
+        options: Project::Options.new.tap { |o| o.apply_lenient_typing_options! },
+        source_patterns: ["lib"],
+        ignore_patterns: [],
+        signature_patterns: ["sig"]
+      )
+
+      target.add_source Pathname("lib/foo.rb"), <<-EOF
+Foo = 1
+      EOF
+
+      target.type_check
+
+      assert_equal Project::Target::TypeCheckStatus, target.status.class
+      assert_empty target.errors
+      target.source_files[Pathname("lib/foo.rb")].tap do |file|
+        assert_equal Project::SourceFile::TypeCheckStatus, file.status.class
+        refute_empty file.status.typing.errors
+      end
+    end
+
     def test_signature_syntax_error
       target = Project::Target.new(
         name: :foo,


### PR DESCRIPTION
Probably it fixes #158


# problem

Steep exits with status code 1 unexpectedly. The cause is type-checking options. 
Steep CLI filters type errors by this option.
https://github.com/soutaro/steep/blob/33f507b4d520859b6df60a186c6c6de78967174f/lib/steep/drivers/check.rb#L56

But the option does not affect the exit status code.
Becuase it checks `target.errors.empty?` but `target.errors` contains unreported type errors.
https://github.com/soutaro/steep/blob/33f507b4d520859b6df60a186c6c6de78967174f/lib/steep/drivers/check.rb#L67



# solution


Remove unreported type errors from `Steep::Project::Target#errors`.

