### PR TITLE
Boolean literal may have type of `true` or `false`

### DIFF
--- a/lib/steep/ast/types/literal.rb
+++ b/lib/steep/ast/types/literal.rb
@@ -49,6 +49,10 @@ module Steep
                     Builtin::String
                   when Symbol
                     Builtin::Symbol
+                  when true
+                    Builtin::TrueClass
+                  when false
+                    Builtin::FalseClass
                   else
                     raise "Unexpected literal type: #{value.inspect}"
                   end

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -369,6 +369,23 @@ module Steep
                             trace: trace,
                             constraints: constraints)
 
+          when relation.super_type.is_a?(AST::Types::Literal)
+            case
+            when relation.super_type.value == true && AST::Builtin::TrueClass.instance_type?(relation.sub_type)
+              success(constraints: constraints)
+            when relation.super_type.value == false && AST::Builtin::FalseClass.instance_type?(relation.sub_type)
+              success(constraints: constraints)
+            else
+              failure(error: Result::Failure::UnknownPairError.new(relation: relation),
+                      trace: trace)
+            end
+
+          when relation.super_type.is_a?(AST::Types::Nil) && AST::Builtin::NilClass.instance_type?(relation.sub_type)
+            success(constraints: constraints)
+
+          when relation.sub_type.is_a?(AST::Types::Nil) && AST::Builtin::NilClass.instance_type?(relation.super_type)
+            success(constraints: constraints)
+
           else
             failure(error: Result::Failure::UnknownPairError.new(relation: relation),
                     trace: trace)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1094,7 +1094,13 @@ module Steep
           end
 
         when :true, :false
-          add_typing(node, type: AST::Types::Boolean.new)
+          ty = node.type == :true ? AST::Types::Literal.new(value: true) : AST::Types::Literal.new(value: false)
+
+          if hint && check_relation(sub_type: ty, super_type: hint).success?
+            add_typing(node, type: hint)
+          else
+            add_typing(node, type: AST::Types::Boolean.new)
+          end
 
         when :hash
           yield_self do

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -336,7 +336,7 @@ end
     end
   end
 
-  def test_literal0
+  def test_literal
     with_checker do |checker|
       assert_success_result checker.check(parse_relation("123", "::Integer", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
 
@@ -347,6 +347,23 @@ end
       assert_fail_result checker.check(parse_relation(":foo", "::Integer", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty) do |result|
         assert_instance_of Failure::UnknownPairError, result.error
       end
+    end
+  end
+
+  def test_literal_bidirectional
+    with_checker do |checker|
+      assert_success_result checker.check(parse_relation("true", "::TrueClass", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::TrueClass", "true", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+
+      assert_success_result checker.check(parse_relation("false", "::FalseClass", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::FalseClass", "false", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+    end
+  end
+
+  def test_nil_type
+    with_checker do |checker|
+      assert_success_result checker.check(parse_relation("nil", "::NilClass", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
+      assert_success_result checker.check(parse_relation("::NilClass", "nil", checker: checker), self_type: parse_type("self", checker: checker), constraints: Constraints.empty)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -299,6 +299,12 @@ class Proc
   def yield: (*untyped) -> untyped
   def arity: -> Integer
 end
+
+class TrueClass
+end
+class FalseClass
+end	
+
   EOS
 
   def checker

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -2656,6 +2656,26 @@ EOF
     end
   end
 
+  def test_string_or_true_false
+    with_checker do |checker|
+      source = parse_ruby(<<EOF)
+# @type var x: String | FalseClass
+x = false
+
+# @type var y: String | true
+y = true
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+        assert_equal parse_type("::String | ::FalseClass"), context.lvar_env[:x]
+        assert_equal parse_type("::String | true"), context.lvar_env[:y]
+      end
+    end
+  end
+
   def test_type_case_case_when
     with_checker do |checker|
       source = parse_ruby(<<EOF)


### PR DESCRIPTION
@tadd reported a case that returning `false` in a method with type of `String | false` got a type error while we are expecting no error for it.

```ruby
# @type method read_string: () -> (String | false)
def read_string
  return false if has_value?
  some_value
end
```

This PR is to fix the issue by using `hint` to infer if the expected type of `false` literal is `false` (not `bool`).