### PR TITLE
Earlier shutdown with interruption while `steep watch`

### DIFF
--- a/lib/steep/server/base_worker.rb
+++ b/lib/steep/server/base_worker.rb
@@ -12,6 +12,7 @@ module Steep
         @project = project
         @reader = reader
         @writer = writer
+        @shutdown = false
       end
 
       def handle_request(request)
@@ -28,7 +29,7 @@ module Steep
           Steep.logger.formatter.push_tags(*tags)
           Steep.logger.tagged "background" do
             while job = queue.pop
-              handle_job(job)
+              handle_job(job) unless @shutdown
             end
           end
         end
@@ -38,11 +39,11 @@ module Steep
             reader.read do |request|
               case request[:method]
               when "shutdown"
-                # nop
+                @shutdown = true
               when "exit"
                 break
               else
-                handle_request(request)
+                handle_request(request) unless @shutdown
               end
             end
           ensure

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -23,6 +23,7 @@ module Steep
         @signature_worker = signature_worker
         @code_workers = code_workers
         @worker_to_paths = {}
+        @shutdown = false
       end
 
       def start
@@ -59,7 +60,7 @@ module Steep
         end
 
         while job = queue.pop
-          writer.write(job)
+          writer.write(job) unless @shutdown
         end
 
         writer.io.close
@@ -154,6 +155,7 @@ module Steep
 
         when "shutdown"
           queue << { id: id, result: nil }
+          @shutdown = true
 
         when "exit"
           queue << nil


### PR DESCRIPTION
When I run `steep watch` by mistake, it took a long time to stop the steep process. This PR tries to make it shorter.

## Current Status of `master`

For example, if I run `steep watch` in a large project directory like [Mastodon](https://github.com/tootsuite/mastodon), it takes about **40 seconds** currently to stop the watching process with `Ctrl+C`:

```sh
$ time bundle exec steep --log-level=fatal watch app/models/
[deprecation warnings omitted]
👀 Watching directories, Ctrl-C to stop.
^CShutting down workers... # I typed Ctrl+C immediately after 👀 printed

real	0m40.593s
user	0m48.878s
sys	0m1.637s
```

## After PR Applied

It takes only **4 seconds** if this PR applied.

```sh
$ time bundle exec steep --log-level=error watch app/models/
[deprecation warnings omitted]
👀 Watching directories, Ctrl-C to stop.
^CShutting down workers...

real	0m4.045s
user	0m6.723s
sys	0m1.438s
```
