### PR TITLE
Insert a delay before running analyses

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -13,6 +13,7 @@ require "etc"
 require "open3"
 require "stringio"
 require 'uri'
+require "concurrent"
 
 require "rbs"
 

--- a/lib/steep/server/code_worker.rb
+++ b/lib/steep/server/code_worker.rb
@@ -18,7 +18,7 @@ module Steep
       def enqueue_type_check(target:, path:, version: target_files[path])
         Steep.logger.info "Enqueueing type check: #{path}(#{version})@#{target.name}..."
         target_files[path] = version
-        queue << [path, version, target]
+        enqueue [path, version, target]
       end
 
       def each_type_check_subject(path:, version:)

--- a/lib/steep/server/signature_worker.rb
+++ b/lib/steep/server/signature_worker.rb
@@ -22,9 +22,9 @@ module Steep
       end
 
       def enqueue_target(target:, timestamp:)
-        Steep.logger.debug "queueing target #{target.name}@#{timestamp}"
+        Steep.logger.info "Queueing target #{target.name}@#{timestamp}"
         last_target_validated_at[target] = timestamp
-        queue << [target, timestamp]
+        enqueue [target, timestamp]
       end
 
       def handle_request(request)
@@ -108,6 +108,9 @@ module Steep
                             )
                           end
                         end
+                      when Project::Target::SignatureOtherErrorStatus
+                        Steep.log_error(status.error)
+                        {}
                       when Project::Target::TypeCheckStatus
                         target.signature_files.each_key.with_object({}) do |path, hash|
                           hash[path] = []

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "listen", "~> 3.1"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.14.0.2"
   spec.add_runtime_dependency "rbs", "~> 0.7.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.6"
 end

--- a/test/code_worker_test.rb
+++ b/test/code_worker_test.rb
@@ -109,6 +109,7 @@ EOF
                                       reader: worker_reader,
                                       writer: worker_writer,
                                       queue: [])
+      worker.queue_delay = 0
 
       assert_empty worker.target_files.keys
 
@@ -236,6 +237,7 @@ EOF
                                       reader: worker_reader,
                                       writer: worker_writer,
                                       queue: [])
+      worker.queue_delay = 0
 
       assert_empty worker.target_files.keys
 

--- a/test/signature_worker_test.rb
+++ b/test/signature_worker_test.rb
@@ -77,6 +77,7 @@ end
 EOF
 
       worker = Server::SignatureWorker.new(project: project, reader: worker_reader, writer: worker_writer, queue: [])
+      worker.queue_delay = 0
 
       lib_target = project.targets[0]
       test_target = project.targets[1]


### PR DESCRIPTION
It would make the time shorter for the diagnostics for the latest source code.