### PR TITLE
Fix literal type subtyping

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -180,15 +180,6 @@ module Steep
               constraints: constraints
             )
 
-          when relation.sub_type.is_a?(AST::Types::Literal)
-            check(
-              Relation.new(sub_type: relation.sub_type.back_type, super_type: relation.super_type),
-              self_type: self_type,
-              assumption: assumption,
-              trace: trace,
-              constraints: constraints
-            )
-
           when relation.sub_type.is_a?(AST::Types::Union)
             results = relation.sub_type.types.map do |sub_type|
               check(Relation.new(sub_type: sub_type, super_type: relation.super_type),
@@ -385,6 +376,15 @@ module Steep
 
           when relation.sub_type.is_a?(AST::Types::Nil) && AST::Builtin::NilClass.instance_type?(relation.super_type)
             success(constraints: constraints)
+
+          when relation.sub_type.is_a?(AST::Types::Literal)
+            check(
+              Relation.new(sub_type: relation.sub_type.back_type, super_type: relation.super_type),
+              self_type: self_type,
+              assumption: assumption,
+              trace: trace,
+              constraints: constraints
+            )
 
           else
             failure(error: Result::Failure::UnknownPairError.new(relation: relation),

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -786,4 +786,19 @@ end
       assert_success_check checker, "::SuperCollection[::String]", "::Collection[::Object]"
     end
   end
+
+  def test_literal_alias_union
+    with_checker <<-EOF do |checker|
+type a = 1 | 2 | 3
+type b = "x" | "y" | "z"
+
+type c = a | b
+    EOF
+      assert_success_check checker, "1", "::a"
+      assert_success_check checker, '"x"', "::b"
+
+      assert_success_check checker, "1", "::c"
+      assert_success_check checker, '"z"', "::c"
+    end
+  end
 end


### PR DESCRIPTION
Fix subtyping to let `1 <: 1 | 2 | 3` hold.