### PR TITLE
Fix tuple typing

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -318,16 +318,17 @@ module Steep
                       trace: trace)
             end
 
-          when relation.sub_type.is_a?(AST::Types::Tuple) && relation.super_type.is_a?(AST::Types::Name::Base)
-            tuple_interface = factory.interface(relation.sub_type, private: false)
-            type_interface = factory.interface(relation.super_type, private: false)
+          when relation.sub_type.is_a?(AST::Types::Tuple) && AST::Builtin::Array.instance_type?(relation.super_type)
+            tuple_element_type = AST::Types::Union.build(
+              types: relation.sub_type.types,
+              location: relation.sub_type.location
+            )
 
-            check_interface(tuple_interface,
-                            type_interface,
-                            self_type: self_type,
-                            assumption: assumption,
-                            trace: trace,
-                            constraints: constraints)
+            check(Relation.new(sub_type: tuple_element_type, super_type: relation.super_type.args[0]),
+                  self_type: self_type,
+                  assumption: assumption,
+                  trace: trace,
+                  constraints: constraints)
 
           when relation.sub_type.is_a?(AST::Types::Record) && relation.super_type.is_a?(AST::Types::Record)
             if Set.new(relation.sub_type.elements.keys).superset?(Set.new(relation.super_type.elements.keys))

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -580,7 +580,7 @@ end
   def test_tuple_subtyping
     with_checker do |checker|
       assert_success_check checker, "[::Integer, ::String]", "::Array[::Integer | ::String]"
-      assert_fail_check checker, "[1, 2, 3]", "::Array[::Integer]"
+      assert_success_check checker, "[1, 2, 3]", "::Array[::Integer]"
       assert_success_check checker, "[::Integer, ::String]", "::String | ::Array[untyped]"
       assert_success_check checker, "[::Integer, ::String]", "[untyped, untyped]"
       assert_fail_check checker, "[1, 2, 3]", "[::Integer, ::Integer, ::Integer]"

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -2155,7 +2155,7 @@ b = [*a, *["foo"]]
       with_standard_construction(checker, source) do |construction, typing|
         pair = construction.synthesize(source.node)
 
-        assert_empty typing.errors
+        assert_no_error typing
         assert_equal parse_type("::Array[::Integer|::Symbol|::String]"), pair.context.lvar_env[:b]
       end
     end
@@ -3723,7 +3723,7 @@ EOF
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
 
-        assert_empty typing.errors
+        assert_no_error typing
       end
     end
   end
@@ -4794,6 +4794,33 @@ type c = a | b
 
 c = 1
 c = "x"
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_tuple_typing
+    with_checker <<-'RBS' do |checker|
+type t = [String]
+    RBS
+      source = parse_ruby(<<-'RUBY')
+# @type var a: [Integer]?
+a = [1]
+
+# @type var b: t
+b = ["a"]
+
+# @type var c: t?
+c = ["b"]
+
+# @type var d: [Integer] | t
+d = ["a"]
+d = [1]
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|


### PR DESCRIPTION
This PR is to relax tuple typing which seems too restrictive because it doesn't allow the following:

```ruby
# @type var a: [Integer, Integer, Integer]?
a = [1,2,3]
```

The hint for array literal should be expanded and then tested if it can be a tuple type.