### PR TITLE
Fix massign support

### DIFF
--- a/lib/steep/type_inference/logic.rb
+++ b/lib/steep/type_inference/logic.rb
@@ -47,6 +47,37 @@ module Steep
             f.merge([node])
           ]
 
+        when :masgn
+          lhs, rhs = node.children
+
+          lt, lf = nodes(node: lhs)
+          rt, rf = nodes(node: rhs)
+
+          [
+            (lt + rt).merge([node]),
+            (lf + rf).merge([node])
+          ]
+
+        when :mlhs
+          nodes = [node]
+
+          node.children.each do |child|
+            case child.type
+            when :lvasgn
+              nodes << child
+            when :splat
+              if node.children[0].type == :lvasgn
+                nodes << child
+                nodes << child.children[0]
+              end
+            end
+          end
+
+          [
+            Result.new(nodes),
+            Result.new(nodes)
+          ]
+
         when :and
           lhs, rhs = node.children
 

--- a/test/logic_test.rb
+++ b/test/logic_test.rb
@@ -57,6 +57,40 @@ class LogicTest < Minitest::Test
     end
   end
 
+  def test_node_masgn
+    with_checker do |checker|
+      source = parse_ruby("x,y,*z = foo && bar")
+      logic = Logic.new(subtyping: checker)
+
+      t, f = logic.nodes(node: dig(source.node))
+
+      assert_equal(Set[].compare_by_identity.merge(
+        [
+          dig(source.node),
+          dig(source.node, 0),
+          dig(source.node, 0, 0),
+          dig(source.node, 0, 1),
+          dig(source.node, 0, 2),
+          dig(source.node, 0, 2, 0),
+          dig(source.node, 1),
+          dig(source.node, 1, 0),
+          dig(source.node, 1, 1)
+        ]
+      ), t.nodes)
+      assert_equal(Set[].compare_by_identity.merge(
+        [
+          dig(source.node),
+          dig(source.node, 0),
+          dig(source.node, 0, 0),
+          dig(source.node, 0, 1),
+          dig(source.node, 0, 2),
+          dig(source.node, 0, 2, 0),
+          dig(source.node, 1)
+        ]
+      ), f.nodes)
+    end
+  end
+
   def test_node_and
     with_checker do |checker|
       source = parse_ruby("x = 1; y = 1; z = 2; x && y && z")

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1652,6 +1652,31 @@ a, b = x = tuple
     end
   end
 
+  def test_masgn_optional_conditional
+    with_checker do |checker|
+      source = parse_ruby(<<-RUBY)
+# @type var tuple: [Integer, String]?
+tuple = nil
+if (a, b = x = tuple)
+  a + 1
+  b + "a"
+else
+  return
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("::Integer"), context.lvar_env[:a]
+        assert_equal parse_type("::String"), context.lvar_env[:b]
+        assert_equal parse_type("[::Integer, ::String]"), context.lvar_env[:x]
+      end
+    end
+  end
+
   def test_union_send_error
     with_checker do |checker|
       source = parse_ruby(<<-RUBY)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1604,7 +1604,7 @@ a, b = x
 
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
-        
+
         assert_no_error typing
       end
     end
@@ -1628,6 +1628,26 @@ a, *b, c = x
         assert_equal parse_type("::Integer?"), context.lvar_env[:a]
         assert_equal parse_type("::Array[::Integer]"), context.lvar_env[:b]
         assert_equal parse_type("::Integer?"), context.lvar_env[:c]
+      end
+    end
+  end
+
+  def test_masgn_optional
+    with_checker do |checker|
+      source = parse_ruby(<<-EOF)
+# @type var tuple: [Integer, String]?
+tuple = nil
+a, b = x = tuple
+      EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("::Integer?"), context.lvar_env[:a]
+        assert_equal parse_type("::String?"), context.lvar_env[:b]
+        assert_equal parse_type("[::Integer, ::String]?"), context.lvar_env[:x]
       end
     end
   end


### PR DESCRIPTION
It allows splats included in lhs.

```ruby
a, *b, c = [1,"2",1.2,:foo]          # ok!

# a: Integer
# b: Array[String | Float]
# c: Symbol
```