### PR TITLE
Fix alias node handling

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1910,7 +1910,10 @@ module Steep
             fallback_to_any node
           end
 
-        when :splat, :sclass, :alias
+        when :alias
+          add_typing node, type: AST::Builtin.nil_type
+
+        when :splat
           yield_self do
             Steep.logger.warn { "Unsupported node #{node.type} (#{node.location.expression.source_buffer.name}:#{node.location.expression.line})" }
 

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1101,7 +1101,7 @@ module Steep end
       end
     end
   end
-
+  1
   def test_module_constructor_without_signature
     with_checker <<-EOF do |checker|
 module Rails end
@@ -4476,7 +4476,7 @@ y = x || []
     end
   end
 
-  def test_skip_alias
+  def test_alias
     with_checker do |checker|
       source = parse_ruby(<<-EOF)
 alias foo bar
@@ -4486,7 +4486,7 @@ alias foo bar
         construction.synthesize(source.node)
 
         assert_empty typing.errors
-        assert_equal parse_type("untyped"), typing.type_of(node: source.node)
+        assert_equal parse_type("nil"), typing.type_of(node: source.node)
       end
     end
   end


### PR DESCRIPTION
Skip type checking for `alias` node.