### PR TITLE
Fix arg typing without method type

### DIFF
--- a/lib/steep/ast/types/union.rb
+++ b/lib/steep/ast/types/union.rb
@@ -29,7 +29,10 @@ module Steep
               type
             end
           end.compact.uniq.yield_self do |tys|
-            if tys.length == 1
+            case tys.length
+            when 0
+              AST::Types::Bot.new
+            when 1
               tys.first
             else
               new(types: tys.sort_by(&:hash), location: location)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -828,7 +828,7 @@ module Steep
             new.typing.add_context_for_body(node, context: new.context)
 
             each_child_node(args_node) do |arg|
-              new.synthesize(arg)
+              _, new = new.synthesize(arg)
             end
 
             body_pair = if body_node
@@ -1016,13 +1016,17 @@ module Steep
           yield_self do
             var = node.children[0]
             type = context.lvar_env[var.name]
-            unless type
+
+            if type
+              add_typing(node, type: type)
+            else
               type = AST::Builtin.any_type
               if context&.method_context&.method_type
                 Steep.logger.error { "Unknown arg type: #{node}" }
               end
+
+              lvasgn(node, type)
             end
-            add_typing(node, type: type)
           end
 
         when :optarg, :kwoptarg

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5091,4 +5091,24 @@ end
       end
     end
   end
+
+  def test_flown_sensitive_untyped
+    with_checker do |checker|
+      source = parse_ruby(<<-RUBY)
+def preserve_empty_line(prev, decl)
+  decl = 1 unless prev
+
+  prev.foo
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_all!(typing.errors) do |error|
+          assert_instance_of Steep::Errors::FallbackAny, error
+        end
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4950,9 +4950,8 @@ end
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
 
-        assert_equal 2, typing.errors.size
+        assert_equal 1, typing.errors.size
         assert_instance_of Steep::Errors::MethodArityMismatch, typing.errors[0]
-        assert_instance_of Steep::Errors::FallbackAny, typing.errors[1]
       end
     end
   end


### PR DESCRIPTION
It skips adding argument types if method type is not given. This causes errors on _flow-sensitive_ analyses.