### PR TITLE
Add specialized #first and #last type for tuples

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -468,6 +468,36 @@ module Steep
                     incompatible: false
                   )
                 end
+
+                array_interface.methods[:first] = array_interface.methods[:first].yield_self do |first|
+                  Interface::Interface::Combination.overload(
+                    [
+                      Interface::MethodType.new(
+                        type_params: [],
+                        params: Interface::Params.empty,
+                        block: nil,
+                        return_type: type.types[0] || AST::Builtin.nil_type,
+                        location: nil
+                      )
+                    ],
+                    incompatible: false
+                  )
+                end
+
+                array_interface.methods[:last] = array_interface.methods[:last].yield_self do |last|
+                  Interface::Interface::Combination.overload(
+                    [
+                      Interface::MethodType.new(
+                        type_params: [],
+                        params: Interface::Params.empty,
+                        block: nil,
+                        return_type: type.types.last || AST::Builtin.nil_type,
+                        location: nil
+                      )
+                    ],
+                    incompatible: false
+                  )
+                end
               end
             end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -287,6 +287,9 @@ class Array[A]
   def zip: [B] (Array[B]) -> Array[A | B]
   def each_with_object: [B] (B) { (A, B) -> untyped } -> B
   def map: [X] { (A) -> X } -> Array[X]
+
+  def first: () -> A?
+  def last: () -> A?
 end
 
 class Hash[A, B]

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3741,6 +3741,27 @@ EOF
     end
   end
 
+  def test_tuple_first_last
+    with_checker do |checker|
+      source = parse_ruby(<<EOF)
+# @type var x: [Integer, String]
+x = (_=[])
+
+a = x.first
+b = x.last
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type('::Integer'), context.lvar_env[:a]
+        assert_equal parse_type('::String'), context.lvar_env[:b]
+      end
+    end
+  end
+
   def test_hash_tuple
     with_checker do |checker|
       source = parse_ruby(<<EOF)


### PR DESCRIPTION
We know the `#first` and `#last` returns first and last elements of an tuple. So, let's give it a precise type.

```ruby
# @type var tuple: [Integer, String]
tuple = [1, ""]

a = tuple.first     # Integer
b = tuple.last      # String
```