### PR TITLE
Make tuple types covariant

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -302,10 +302,9 @@ module Steep
           when relation.sub_type.is_a?(AST::Types::Tuple) && relation.super_type.is_a?(AST::Types::Tuple)
             if relation.sub_type.types.size >= relation.super_type.types.size
               pairs = relation.sub_type.types.take(relation.super_type.types.size).zip(relation.super_type.types)
-              results = pairs.flat_map do |t1, t2|
+              results = pairs.map do |t1, t2|
                 relation = Relation.new(sub_type: t1, super_type: t2)
-                [check(relation, self_type: self_type, assumption: assumption, trace: trace, constraints: constraints),
-                 check(relation.flip, self_type: self_type, assumption: assumption, trace: trace, constraints: constraints)]
+                check(relation, self_type: self_type, assumption: assumption, trace: trace, constraints: constraints)
               end
 
               if results.all?(&:success?)

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -583,7 +583,7 @@ end
       assert_success_check checker, "[1, 2, 3]", "::Array[::Integer]"
       assert_success_check checker, "[::Integer, ::String]", "::String | ::Array[untyped]"
       assert_success_check checker, "[::Integer, ::String]", "[untyped, untyped]"
-      assert_fail_check checker, "[1, 2, 3]", "[::Integer, ::Integer, ::Integer]"
+      assert_success_check checker, "[1, 2, 3]", "[::Integer, ::Integer, ::Integer]"
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -264,6 +264,12 @@ class Integer < Numeric
        | (Numeric) -> Numeric
 end
 
+class Float < Numeric
+  def +: (Float) -> Float
+       | (Integer) -> Float
+       | (Numeric) -> Numeric
+end
+
 class Symbol
   def id2name: -> String
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5190,4 +5190,20 @@ a[1] &&= 4
       end
     end
   end
+
+  def test_numbers_numeric
+    with_checker do |checker|
+      source = parse_ruby(<<-RUBY)
+# @type var x: [Numeric]
+x = [1]
+x = [1.0]
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
To give `[1.0]` type of `[Numeric]`.

The tuple types have been _invariant_ because letting them be _covariant_ makes the type checking _unsound_.

```rb
# @type var numbers: [Integer, Float]
numbers = [1, 2]

# @type var objects: [Object, Object]
objects = numbers       # This assignment is allowed if tuple types are covariant.

objects[0] = "string"   # This is allowed.

numbers[0] + 1          # Type checker cannot detect the runtime error raised here.
```

I'm making the tuples to be covariant because `Array[T]` is covariant already, even though it is incorrect.

* Closes https://github.com/soutaro/steep/issues/192