### PR TITLE
Bye Name::Class type

### DIFF
--- a/lib/steep/ast/builtin.rb
+++ b/lib/steep/ast/builtin.rb
@@ -16,7 +16,7 @@ module Steep
         end
 
         def module_type
-          Types::Name::Module.new(name: module_name)
+          Types::Name::Singleton.new(name: module_name)
         end
 
         def instance_type?(type, args: nil)
@@ -33,7 +33,7 @@ module Steep
         end
 
         def module_type?(type)
-          if type.is_a?(Types::Name::Module)
+          if type.is_a?(Types::Name::Singleton)
             type.name == module_name
           else
             false

--- a/lib/steep/ast/builtin.rb
+++ b/lib/steep/ast/builtin.rb
@@ -15,10 +15,6 @@ module Steep
           Types::Name::Instance.new(name: module_name, args: args)
         end
 
-        def class_type(constructor: nil)
-          Types::Name::Class.new(name: module_name, constructor: constructor)
-        end
-
         def module_type
           Types::Name::Module.new(name: module_name)
         end
@@ -30,20 +26,6 @@ module Steep
               type.name == module_name && type.args == args
             else
               type.name == module_name && type.args.size == arity
-            end
-          else
-            false
-          end
-        end
-
-        NONE = ::Object.new
-
-        def class_type?(type, constructor: NONE)
-          if type.is_a?(Types::Name::Class)
-            unless constructor.equal?(NONE)
-              type.name == module_name && type.name.constructor == constructor
-            else
-              type.name == module_name
             end
           else
             false

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -44,7 +44,7 @@ module Steep
             Var.new(name: type.name, location: nil)
           when RBS::Types::ClassSingleton
             type_name = type_name(type.name)
-            Name::Module.new(name: type_name, location: nil)
+            Name::Singleton.new(name: type_name, location: nil)
           when RBS::Types::ClassInstance
             type_name = type_name(type.name)
             args = type.args.map {|arg| type(arg) }
@@ -102,7 +102,7 @@ module Steep
             RBS::Types::Bases::Nil.new(location: nil)
           when Var
             RBS::Types::Variable.new(name: type.name, location: nil)
-          when Name::Module
+          when Name::Singleton
             RBS::Types::ClassSingleton.new(name: type_name_1(type.name), location: nil)
           when Name::Instance
             RBS::Types::ClassInstance.new(
@@ -372,7 +372,7 @@ module Steep
               end
             end
 
-          when Name::Module
+          when Name::Singleton
             Interface::Interface.new(type: self_type, private: private).tap do |interface|
               definition = definition_builder.build_singleton(type_name_1(type.name))
 

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -44,7 +44,7 @@ module Steep
             Var.new(name: type.name, location: nil)
           when RBS::Types::ClassSingleton
             type_name = type_name(type.name)
-            Name::Class.new(name: type_name, location: nil, constructor: nil)
+            Name::Module.new(name: type_name, location: nil)
           when RBS::Types::ClassInstance
             type_name = type_name(type.name)
             args = type.args.map {|arg| type(arg) }
@@ -102,7 +102,7 @@ module Steep
             RBS::Types::Bases::Nil.new(location: nil)
           when Var
             RBS::Types::Variable.new(name: type.name, location: nil)
-          when Name::Class, Name::Module
+          when Name::Module
             RBS::Types::ClassSingleton.new(name: type_name_1(type.name), location: nil)
           when Name::Instance
             RBS::Types::ClassInstance.new(
@@ -372,7 +372,7 @@ module Steep
               end
             end
 
-          when Name::Class, Name::Module
+          when Name::Module
             Interface::Interface.new(type: self_type, private: private).tap do |interface|
               definition = definition_builder.build_singleton(type_name_1(type.name))
 

--- a/lib/steep/ast/types/name.rb
+++ b/lib/steep/ast/types/name.rb
@@ -79,58 +79,6 @@ module Steep
           end
         end
 
-        class Class < Base
-          attr_reader :constructor
-
-          def initialize(name:, constructor:, location: nil)
-            raise "Name should be a module name: #{name.inspect}" unless name.is_a?(Names::Module)
-            super(name: name, location: location)
-            @constructor = constructor
-          end
-
-          def ==(other)
-            other.class == self.class &&
-              other.name == name &&
-              other.constructor == constructor
-          end
-
-          alias eql? ==
-
-          def hash
-            self.class.hash ^ name.hash ^ constructor.hash
-          end
-
-          def to_s
-            k = case constructor
-                when true
-                  " constructor"
-                when false
-                  " noconstructor"
-                when nil
-                  ""
-                end
-            "singleton(#{name.to_s})"
-          end
-
-          def with_location(new_location)
-            self.class.new(name: name, constructor: constructor, location: new_location)
-          end
-
-          def to_instance(*args)
-            Instance.new(name: name, args: args)
-          end
-
-          NOTHING = ::Object.new
-
-          def updated(constructor: NOTHING)
-            if NOTHING == constructor
-              constructor = self.constructor
-            end
-
-            self.class.new(name: name, constructor: constructor, location: location)
-          end
-        end
-
         class Module < Base
           def ==(other)
             other.class == self.class &&
@@ -153,10 +101,6 @@ module Steep
         end
 
         class Instance < Applying
-          def to_class(constructor:)
-            Class.new(name: name, location: location, constructor: constructor)
-          end
-
           def to_module
             Module.new(name: name, location: location)
           end

--- a/lib/steep/ast/types/name.rb
+++ b/lib/steep/ast/types/name.rb
@@ -79,7 +79,7 @@ module Steep
           end
         end
 
-        class Module < Base
+        class Singleton < Base
           def ==(other)
             other.class == self.class &&
               other.name == name
@@ -102,7 +102,7 @@ module Steep
 
         class Instance < Applying
           def to_module
-            Module.new(name: name, location: location)
+            Singleton.new(name: name, location: location)
           end
         end
 

--- a/lib/steep/project/completion_provider.rb
+++ b/lib/steep/project/completion_provider.rb
@@ -234,7 +234,7 @@ module Steep
                      when AST::Types::Name::Instance
                        type_name = subtyping.factory.type_name_1(type.name)
                        subtyping.factory.definition_builder.build_instance(type_name)
-                     when AST::Types::Name::Module
+                     when AST::Types::Name::Singleton
                        type_name = subtyping.factory.type_name_1(type.name)
                        subtyping.factory.definition_builder.build_singleton(type_name)
                      when AST::Types::Name::Interface

--- a/lib/steep/project/completion_provider.rb
+++ b/lib/steep/project/completion_provider.rb
@@ -234,7 +234,7 @@ module Steep
                      when AST::Types::Name::Instance
                        type_name = subtyping.factory.type_name_1(type.name)
                        subtyping.factory.definition_builder.build_instance(type_name)
-                     when AST::Types::Name::Class, AST::Types::Name::Module
+                     when AST::Types::Name::Module
                        type_name = subtyping.factory.type_name_1(type.name)
                        subtyping.factory.definition_builder.build_singleton(type_name)
                      when AST::Types::Name::Interface

--- a/lib/steep/project/hover_content.rb
+++ b/lib/steep/project/hover_content.rb
@@ -92,7 +92,7 @@ module Steep
                                                 method_definition
                                               ]
                                             end
-                                          when AST::Types::Name::Module
+                                          when AST::Types::Name::Singleton
                                             method_definition = method_definition_for(factory, receiver_type.name, singleton_method: method_name)
                                             if method_definition&.defined_in
                                               owner_name = factory.type_name(method_definition.defined_in)

--- a/lib/steep/project/hover_content.rb
+++ b/lib/steep/project/hover_content.rb
@@ -92,7 +92,7 @@ module Steep
                                                 method_definition
                                               ]
                                             end
-                                          when AST::Types::Name::Class
+                                          when AST::Types::Name::Module
                                             method_definition = method_definition_for(factory, receiver_type.name, singleton_method: method_name)
                                             if method_definition&.defined_in
                                               owner_name = factory.type_name(method_definition.defined_in)

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -42,9 +42,8 @@ module Steep
               )
             end
           when RBS::Definition::Ancestor::Singleton
-            AST::Types::Name::Class.new(
+            AST::Types::Name::Module.new(
               name: name,
-              constructor: nil,
               location: nil
             )
           end
@@ -78,9 +77,8 @@ module Steep
               )
             end
           when RBS::Definition::Ancestor::Singleton
-            AST::Types::Name::Class.new(
+            AST::Types::Name::Module.new(
               name: name,
-              constructor: nil,
               location: nil
             )
           end
@@ -266,7 +264,7 @@ module Steep
               possible_sub_types = case relation.sub_type
                                    when AST::Types::Name::Instance
                                      instance_super_types(relation.sub_type.name, args: relation.sub_type.args)
-                                   when AST::Types::Name::Class
+                                   when AST::Types::Name::Module
                                      singleton_super_types(relation.sub_type.name)
                                    else
                                      []
@@ -399,7 +397,7 @@ module Steep
         case type
         when AST::Types::Name::Instance
           factory.definition_builder.build_instance(type_name)
-        when AST::Types::Name::Class
+        when AST::Types::Name::Module
           factory.definition_builder.build_singleton(type_name)
         when AST::Types::Name::Interface
           factory.definition_builder.build_interface(type_name)
@@ -483,10 +481,6 @@ module Steep
         when sub_type.is_a?(AST::Types::Name::Alias) && super_type.is_a?(AST::Types::Name::Alias)
           if sub_type.name == super_type.name && sub_type.args.size == super_type.args.size
             sub_type.args.zip(super_type.args)
-          end
-        when sub_type.is_a?(AST::Types::Name::Class) && super_type.is_a?(AST::Types::Name::Class)
-          if sub_type.name == super_type.name
-            []
           end
         when sub_type.is_a?(AST::Types::Name::Module) && super_type.is_a?(AST::Types::Name::Module)
           if sub_type.name == super_type.name

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -42,7 +42,7 @@ module Steep
               )
             end
           when RBS::Definition::Ancestor::Singleton
-            AST::Types::Name::Module.new(
+            AST::Types::Name::Singleton.new(
               name: name,
               location: nil
             )
@@ -77,7 +77,7 @@ module Steep
               )
             end
           when RBS::Definition::Ancestor::Singleton
-            AST::Types::Name::Module.new(
+            AST::Types::Name::Singleton.new(
               name: name,
               location: nil
             )
@@ -264,7 +264,7 @@ module Steep
               possible_sub_types = case relation.sub_type
                                    when AST::Types::Name::Instance
                                      instance_super_types(relation.sub_type.name, args: relation.sub_type.args)
-                                   when AST::Types::Name::Module
+                                   when AST::Types::Name::Singleton
                                      singleton_super_types(relation.sub_type.name)
                                    else
                                      []
@@ -397,7 +397,7 @@ module Steep
         case type
         when AST::Types::Name::Instance
           factory.definition_builder.build_instance(type_name)
-        when AST::Types::Name::Module
+        when AST::Types::Name::Singleton
           factory.definition_builder.build_singleton(type_name)
         when AST::Types::Name::Interface
           factory.definition_builder.build_interface(type_name)
@@ -482,7 +482,7 @@ module Steep
           if sub_type.name == super_type.name && sub_type.args.size == super_type.args.size
             sub_type.args.zip(super_type.args)
           end
-        when sub_type.is_a?(AST::Types::Name::Module) && super_type.is_a?(AST::Types::Name::Module)
+        when sub_type.is_a?(AST::Types::Name::Singleton) && super_type.is_a?(AST::Types::Name::Singleton)
           if sub_type.name == super_type.name
             []
           end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -308,7 +308,7 @@ module Steep
           ].compact
         )
 
-        module_type = AST::Types::Name::Module.new(name: module_name)
+        module_type = AST::Types::Name::Singleton.new(name: module_name)
       end
 
       if annots.instance_type
@@ -379,7 +379,7 @@ module Steep
         module_def = checker.factory.definition_builder.build_singleton(type_name_)
 
         instance_type = AST::Types::Name::Instance.new(name: class_name, args: class_args)
-        module_type = AST::Types::Name::Module.new(name: class_name)
+        module_type = AST::Types::Name::Singleton.new(name: class_name)
       end
 
       if annots.instance_type
@@ -443,7 +443,7 @@ module Steep
                       end
 
       module_type = case instance_type
-                    when AST::Types::Name::Module
+                    when AST::Types::Name::Singleton
                       type_name = checker.factory.type_name_1(instance_type.name)
 
                       case checker.factory.env.class_decls[type_name]
@@ -462,7 +462,7 @@ module Steep
                     end
 
       instance_definition = case instance_type
-                            when AST::Types::Name::Module
+                            when AST::Types::Name::Singleton
                               type_name = checker.factory.type_name_1(instance_type.name)
                               checker.factory.definition_builder.build_singleton(type_name)
                             when AST::Types::Name::Instance
@@ -471,7 +471,7 @@ module Steep
                             end
 
       module_definition = case module_type
-                          when AST::Types::Name::Module
+                          when AST::Types::Name::Singleton
                             type_name = checker.factory.type_name_1(instance_type.name)
                             checker.factory.definition_builder.build_singleton(type_name)
                           else
@@ -694,8 +694,8 @@ module Steep
           yield_self do
             if self_class?(node)
               module_type = expand_alias(module_context.module_type)
-              type = if module_type.is_a?(AST::Types::Name::Module)
-                       AST::Types::Name::Module.new(name: module_type.name)
+              type = if module_type.is_a?(AST::Types::Name::Singleton)
+                       AST::Types::Name::Singleton.new(name: module_type.name)
                      else
                        module_type
                      end
@@ -710,8 +710,8 @@ module Steep
           yield_self do
             pair = if self_class?(node)
                      module_type = expand_alias(module_context.module_type)
-                     type = if module_type.is_a?(AST::Types::Name::Module)
-                              AST::Types::Name::Module.new(name: module_type.name)
+                     type = if module_type.is_a?(AST::Types::Name::Singleton)
+                              AST::Types::Name::Singleton.new(name: module_type.name)
                             else
                               module_type
                             end
@@ -890,7 +890,7 @@ module Steep
                          when AST::Types::Name::Instance
                            name = checker.factory.type_name_1(self_type.name)
                            checker.factory.definition_builder.build_singleton(name)
-                         when AST::Types::Name::Module
+                         when AST::Types::Name::Singleton
                            name = checker.factory.type_name_1(self_type.name)
                            checker.factory.definition_builder.build_singleton(name)
                          end
@@ -1521,7 +1521,7 @@ module Steep
                 test_types << expand_alias(type)
               end
 
-              if var_names && var_types && test_types.all? {|ty| ty.is_a?(AST::Types::Name::Module) }
+              if var_names && var_types && test_types.all? {|ty| ty.is_a?(AST::Types::Name::Singleton) }
                 var_types_in_body = test_types.flat_map do |test_type|
                   filtered_types = var_types.select do |var_type|
                     var_type.is_a?(AST::Types::Name::Base) && var_type.name == test_type.name
@@ -1647,7 +1647,7 @@ module Steep
                 instance_types = exn_types.map do |type|
                   type = expand_alias(type)
                   case
-                  when type.is_a?(AST::Types::Name::Module)
+                  when type.is_a?(AST::Types::Name::Singleton)
                     to_instance_type(type)
                   else
                     AST::Builtin.any_type
@@ -3312,7 +3312,7 @@ module Steep
 
     def to_instance_type(type, args: nil)
       args = args || case type
-                     when AST::Types::Name::Module
+                     when AST::Types::Name::Singleton
                        checker.factory.env.class_decls[checker.factory.type_name_1(type.name)].type_params.each.map { AST::Builtin.any_type }
                      else
                        raise "unexpected type to to_instance_type: #{type}"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,13 +17,13 @@ Rainbow.enabled = false
 module Steep::AST::Types::Name
   def self.new_module(location: nil, name:, args: [])
     name = Steep::Names::Module.parse(name.to_s) unless name.is_a?(Steep::Names::Module)
-    Steep::AST::Types::Name::Module.new(name: name, location: location)
+    Steep::AST::Types::Name::Singleton.new(name: name, location: location)
   end
 
   def self.new_class(location: nil, name:, constructor:, args: [])
     name = Steep::Names::Module.parse(name.to_s) unless name.is_a?(Steep::Names::Module)
-    Steep::AST::Types::Name::Module.new(location: location,
-                                       name: name)
+    Steep::AST::Types::Name::Singleton.new(location: location,
+                                           name: name)
   end
 
   def self.new_instance(location: nil, name:, args: [])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,9 +22,8 @@ module Steep::AST::Types::Name
 
   def self.new_class(location: nil, name:, constructor:, args: [])
     name = Steep::Names::Module.parse(name.to_s) unless name.is_a?(Steep::Names::Module)
-    Steep::AST::Types::Name::Class.new(location: location,
-                                       name: name,
-                                       constructor: constructor)
+    Steep::AST::Types::Name::Module.new(location: location,
+                                       name: name)
   end
 
   def self.new_instance(location: nil, name:, args: [])

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -59,7 +59,7 @@ class TypeFactoryTest < Minitest::Test
       end
 
       factory.type(parse_type("singleton(::Object)")).yield_self do |type|
-        assert_instance_of Types::Name::Module, type
+        assert_instance_of Types::Name::Singleton, type
         assert_equal "::Object", type.name.to_s
       end
 

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -59,7 +59,7 @@ class TypeFactoryTest < Minitest::Test
       end
 
       factory.type(parse_type("singleton(::Object)")).yield_self do |type|
-        assert_instance_of Types::Name::Class, type
+        assert_instance_of Types::Name::Module, type
         assert_equal "::Object", type.name.to_s
       end
 


### PR DESCRIPTION
This PR deprecates the `Name::Class` type, unifying to `Name::Module` type.

The difference between the two types is the `constructor` attribute, however it is no longer used. So, there is no reason to have two identical types.