### PR TITLE
Better union typing

### DIFF
--- a/lib/steep/ast/types/union.rb
+++ b/lib/steep/ast/types/union.rb
@@ -38,29 +38,28 @@ module Steep
             when 1
               tys.first
             else
-              new(types: tys.sort_by(&:hash), location: location)
+              new(types: tys, location: location)
             end
           end
         end
 
         def ==(other)
           other.is_a?(Union) &&
-            other.types == types
+            Set.new(other.types) == Set.new(types)
         end
 
         def hash
-          self.class.hash ^ types.hash
+          @hash ||= self.class.hash ^ types.sort_by(&:to_s).hash
         end
 
         alias eql? ==
 
         def subst(s)
-          self.class.build(location: location,
-                           types: types.map {|ty| ty.subst(s) })
+          self.class.build(location: location, types: types.map {|ty| ty.subst(s) })
         end
 
         def to_s
-          "(#{types.map(&:to_s).sort.join(" | ")})"
+          "(#{types.map(&:to_s).join(" | ")})"
         end
 
         def free_variables

--- a/lib/steep/interface/interface.rb
+++ b/lib/steep/interface/interface.rb
@@ -1,72 +1,15 @@
 module Steep
   module Interface
     class Interface
-      class Combination
-        attr_reader :operator
-        attr_reader :types
+      class Entry
+        attr_reader :method_types
 
-        def initialize(operator:, types:)
-          @types = types
-          @operator = operator
-          @incompatible = false
-        end
-
-        def overload?
-          operator == :overload
-        end
-
-        def union?
-          operator == :union
-        end
-
-        def intersection?
-          operator == :intersection
-        end
-
-        def self.overload(types, incompatible:)
-          new(operator: :overload, types: types).incompatible!(incompatible)
-        end
-
-        def incompatible?
-          @incompatible
-        end
-
-        def incompatible!(value)
-          @incompatible = value
-          self
-        end
-
-        def self.union(types)
-          case types.size
-          when 0
-            raise "Combination.union called with zero types"
-          when 1
-            types.first
-          else
-            new(operator: :union, types: types)
-          end
-        end
-
-        def self.intersection(types)
-          case types.size
-          when 0
-            raise "Combination.intersection called with zero types"
-          when 1
-            types.first
-          else
-            new(operator: :intersection, types: types)
-          end
+        def initialize(method_types:)
+          @method_types = method_types
         end
 
         def to_s
-          case operator
-          when :overload
-            "{ #{types.map(&:to_s).join(" | ")} }"
-          when :union
-            "[#{types.map(&:to_s).join(" | ")}]"
-          when :intersection
-            "[#{types.map(&:to_s).join(" & ")}]"
-          end
+          "{ #{method_types.join(" || ")} }"
         end
       end
 

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -83,6 +83,12 @@ module Steep
           other.rest_keywords == rest_keywords
       end
 
+      alias eql? ==
+
+      def hash
+        required.hash ^ optional.hash ^ rest.hash ^ required_keywords.hash ^ optional_keywords.hash ^ rest_keywords.hash
+      end
+
       def flat_unnamed_params
         required.map {|p| [:required, p] } + optional.map {|p| [:optional, p] }
       end
@@ -713,6 +719,12 @@ module Steep
         other.is_a?(self.class) && other.type == type && other.optional == optional
       end
 
+      alias eql? ==
+
+      def hash
+        type.hash ^ optional.hash
+      end
+
       def closed?
         type.closed?
       end
@@ -779,6 +791,12 @@ module Steep
           other.block == block &&
           other.return_type == return_type &&
           (!other.location || !location || other.location == location)
+      end
+
+      alias eql? ==
+
+      def hash
+        type_params.hash ^ params.hash ^ block.hash ^ return_type.hash
       end
 
       def free_variables

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -529,29 +529,24 @@ module Steep
 
       def check_method(name, sub_method, super_method, self_type:, assumption:, trace:, constraints:)
         trace.method name, sub_method, super_method do
-          case
-          when sub_method.overload? && super_method.overload?
-            super_method.types.map do |super_type|
-              sub_method.types.map do |sub_type|
-                check_generic_method_type name,
-                                          sub_type,
-                                          super_type,
-                                          self_type: self_type,
-                                          assumption: assumption,
-                                          trace: trace,
-                                          constraints: constraints
-              end.yield_self do |results|
-                results.find(&:success?) || results[0]
-              end
+          super_method.method_types.map do |super_type|
+            sub_method.method_types.map do |sub_type|
+              check_generic_method_type name,
+                                        sub_type,
+                                        super_type,
+                                        self_type: self_type,
+                                        assumption: assumption,
+                                        trace: trace,
+                                        constraints: constraints
             end.yield_self do |results|
-              if results.all?(&:success?) || sub_method.incompatible?
-                success constraints: constraints
-              else
-                results.select(&:failure?).last
-              end
+              results.find(&:success?) || results[0]
             end
-          else
-            raise "aaaaaaaaaaaaaa"
+          end.yield_self do |results|
+            if results.all?(&:success?)
+              success constraints: constraints
+            else
+              results.select(&:failure?).last
+            end
           end
         end
       end

--- a/smoke/alias/a.rb
+++ b/smoke/alias/a.rb
@@ -1,7 +1,7 @@
 # @type var x: foo
 x = ""
 
-# !expects ArgumentTypeMismatch: receiver=(::Integer | ::String), expected=::string, actual=::Integer
+# !expects* UnresolvedOverloading: receiver=(::String | ::Integer), method_name=+,
 x + 123
 
 # @type var y: bar

--- a/smoke/case/a.rb
+++ b/smoke/case/a.rb
@@ -1,6 +1,6 @@
 # @type var a: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Array[::String] | ::Integer | ::String | nil)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Integer | ::Array[::String] | nil | ::String)
 a = case 1
     when 2
       1

--- a/smoke/if/a.rb
+++ b/smoke/if/a.rb
@@ -13,7 +13,7 @@ else
   "baz"
 end
 
-# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::Integer | ::String)
+# !expects IncompatibleAssignment: lhs_type=::String, rhs_type=(::String | ::Integer)
 a = if z
       "foofoo"
     else

--- a/smoke/rescue/a.rb
+++ b/smoke/rescue/a.rb
@@ -1,6 +1,6 @@
 # @type var a: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Integer | ::String)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Integer)
 a = begin
       'foo'
     rescue
@@ -9,12 +9,12 @@ a = begin
 
 # @type var b: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Integer | ::String)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Integer)
 b = 'foo' rescue 1
 
 # @type var c: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Integer | ::String | ::Symbol)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::String | ::Symbol | ::Integer)
 c = begin
       'foo'
     rescue RuntimeError
@@ -25,7 +25,7 @@ c = begin
 
 # @type var e: Integer
 
-# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Array[::Integer] | ::Integer | ::Symbol)
+# !expects IncompatibleAssignment: lhs_type=::Integer, rhs_type=(::Array[::Integer] | ::Symbol | ::Integer)
 e = begin
       'foo'
     rescue RuntimeError

--- a/test/block_params_test.rb
+++ b/test/block_params_test.rb
@@ -158,6 +158,46 @@ proc {|a, b=1, *c, d|
     end
   end
 
+  def test_zip_missing_required_params
+    with_factory do
+      type = Params.new(
+        required: [parse_type("::Integer"), parse_type("::Object")],
+        optional: [],
+        rest: nil,
+        required_keywords: {},
+        optional_keywords: {},
+        rest_keywords: nil
+      )
+
+      block_params("proc { }") do |params|
+        zip = params.zip(type)
+
+        assert_empty zip
+      end
+    end
+  end
+
+  def test_zip_with_extra_params
+    with_factory do
+      type = Params.new(
+        required: [parse_type("::Object")],
+        optional: [],
+        rest: nil,
+        required_keywords: {},
+        optional_keywords: {},
+        rest_keywords: nil
+      )
+
+      block_params("proc {|x, y| }") do |params|
+        zip = params.zip(type)
+
+        assert_equal 2, zip.size
+        assert_equal [params.params[0], parse_type("::Object")], zip[0]
+        assert_equal [params.params[1], parse_type("nil")], zip[1]
+      end
+    end
+  end
+
   def test_zip_expand_array
     with_factory do
       type = Params.new(

--- a/test/interface_test.rb
+++ b/test/interface_test.rb
@@ -98,7 +98,7 @@ class InterfaceTest < Minitest::Test
                    parse_method_type("(foo: String) -> untyped").params & parse_method_type("(foo: Integer) -> untyped").params
 
       # req:opt
-      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+      assert_equal parse_method_type("(foo: Integer & String) -> untyped").params,
                    parse_method_type("(foo: String) -> untyped").params & parse_method_type("(?foo: Integer) -> untyped").params
 
       # req:none
@@ -136,11 +136,11 @@ class InterfaceTest < Minitest::Test
                    parse_method_type("() -> untyped").params & parse_method_type("(**Integer) -> untyped").params
 
       # rest:req
-      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+      assert_equal parse_method_type("(foo: Integer & String) -> untyped").params,
                    parse_method_type("(**String) -> untyped").params & parse_method_type("(foo: Integer) -> untyped").params
 
       # rest:opt
-      assert_equal parse_method_type("(?foo: String & Integer) -> untyped").params,
+      assert_equal parse_method_type("(?foo: Integer & String) -> untyped").params,
                    parse_method_type("(**String) -> untyped").params & parse_method_type("(?foo: Integer) -> untyped").params
 
       # rest:none

--- a/test/interface_test.rb
+++ b/test/interface_test.rb
@@ -4,59 +4,334 @@ class InterfaceTest < Minitest::Test
   include TestHelper
   include FactoryHelper
 
-  def test_method_type_params_union
-    with_factory do |factory|
+  def test_method_type_params_plus
+    with_factory do
       assert_equal parse_method_type("(String | Integer) -> untyped").params,
-                   parse_method_type("(String) -> untyped").params | parse_method_type("(Integer) -> untyped").params
+                   parse_method_type("(String) -> untyped").params + parse_method_type("(Integer) -> untyped").params
 
       assert_equal parse_method_type("(?String | Integer) -> untyped").params,
-                   parse_method_type("(?String) -> untyped").params | parse_method_type("(Integer) -> untyped").params
+                   parse_method_type("(?String) -> untyped").params + parse_method_type("(Integer) -> untyped").params
 
       assert_equal parse_method_type("(?String) -> untyped").params,
-                   parse_method_type("(String) -> untyped").params | parse_method_type("() -> untyped").params
+                   parse_method_type("(String) -> untyped").params + parse_method_type("() -> untyped").params
 
       assert_equal parse_method_type("(?String | Symbol, *Symbol) -> untyped").params,
-                   parse_method_type("(String) -> untyped").params | parse_method_type("(*Symbol) -> untyped").params
+                   parse_method_type("(String) -> untyped").params + parse_method_type("(*Symbol) -> untyped").params
 
       assert_equal parse_method_type("(?String | Symbol, *Symbol) -> void").params,
-                   parse_method_type("(String) -> params").params | parse_method_type("(*Symbol) -> void").params
+                   parse_method_type("(String) -> params").params + parse_method_type("(*Symbol) -> void").params
 
       assert_equal parse_method_type("(name: String | Symbol, ?email: String | Array, ?age: Integer | Object, **Array | Object) -> void").params,
-                   parse_method_type("(name: String, email: String, **Object) -> void").params | parse_method_type("(name: Symbol, age: Integer, **Array) -> void").params
+                   parse_method_type("(name: String, email: String, **Object) -> void").params + parse_method_type("(name: Symbol, age: Integer, **Array) -> void").params
 
       assert_equal parse_method_type("() ?{ (String | Integer) -> (Array | Hash) } -> void").params,
-                   parse_method_type("() ?{ (String) -> Array } -> void").params | parse_method_type("() { (Integer) -> Hash } -> void").params
+                   parse_method_type("() ?{ (String) -> Array } -> void").params + parse_method_type("() { (Integer) -> Hash } -> void").params
     end
   end
 
   def test_method_type_params_intersection
-    with_factory do |factory|
+    with_factory do
+      # req, none, opt, rest
+
+      # required:required
       assert_equal parse_method_type("(String & Integer) -> untyped").params,
                    parse_method_type("(String) -> untyped").params & parse_method_type("(Integer) -> untyped").params
 
-      assert_equal parse_method_type("(String & Integer) -> untyped").params,
-                   parse_method_type("(?String) -> untyped").params & parse_method_type("(Integer) -> untyped").params
+      # required:none
+      assert_nil parse_method_type("(String) -> untyped").params & parse_method_type("() -> untyped").params
 
+      # required:optional
+      assert_equal parse_method_type("(String & Integer) -> untyped").params,
+                   parse_method_type("(String) -> untyped").params & parse_method_type("(?Integer) -> untyped").params
+
+      # required:rest
       assert_equal parse_method_type("(String & Integer) -> untyped").params,
                    parse_method_type("(String) -> untyped").params & parse_method_type("(*Integer) -> untyped").params
 
-      assert_equal parse_method_type("(bot) -> untyped").params,
-                   (parse_method_type("(String) -> untyped").params & parse_method_type("() -> untyped").params)
+      # none:required
+      assert_nil parse_method_type("() -> untyped").params & parse_method_type("(String) -> void").params
 
+      # none:optional
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("() -> untyped").params & parse_method_type("(?Integer) -> untyped").params
+
+      # none:rest
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("() -> untyped").params & parse_method_type("(*Integer) -> untyped").params
+
+      # opt:required
+      assert_equal parse_method_type("(String & Integer) -> untyped").params,
+                   parse_method_type("(?String) -> untyped").params & parse_method_type("(Integer) -> untyped").params
+
+      # opt:none
       assert_equal parse_method_type("() -> untyped").params,
                    parse_method_type("(?String) -> untyped").params & parse_method_type("() -> untyped").params
 
-      assert_equal parse_method_type("(String & Symbol) -> untyped").params,
-                   parse_method_type("(String) -> untyped").params & parse_method_type("(*Symbol) -> untyped").params
-
+      # opt:opt
       assert_equal parse_method_type("(?String & Integer) -> untyped").params,
                    parse_method_type("(?String) -> untyped").params & parse_method_type("(?Integer) -> untyped").params
 
-      assert_equal parse_method_type("(String & Symbol) -> void").params,
-                   parse_method_type("(String) -> params").params & parse_method_type("(*Symbol) -> void").params
+      # opt:rest
+      assert_equal parse_method_type("(?String & Integer) -> untyped").params,
+                   parse_method_type("(?String) -> untyped").params & parse_method_type("(*Integer) -> untyped").params
 
-      assert_equal parse_method_type("(name: String & Symbol, email: String & Array, age: Integer & Object, **Array & Object) -> void").params,
-                   (parse_method_type("(name: String, email: String, **Object) -> void").params & parse_method_type("(name: Symbol, age: Integer, **Array) -> void").params)
+      # rest:required
+      assert_equal parse_method_type("(String & Integer) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params & parse_method_type("(Integer) -> untyped").params
+
+      # rest:none
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params & parse_method_type("() -> untyped").params
+
+      # rest:opt
+      assert_equal parse_method_type("(?String & Integer) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params & parse_method_type("(?Integer) -> untyped").params
+
+      # rest:rest
+      assert_equal parse_method_type("(*String & Integer) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params & parse_method_type("(*Integer) -> untyped").params
+
+      ## Keywords
+
+      # req:req
+      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params & parse_method_type("(foo: Integer) -> untyped").params
+
+      # req:opt
+      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params & parse_method_type("(?foo: Integer) -> untyped").params
+
+      # req:none
+      assert_nil parse_method_type("(foo: String) -> untyped").params & parse_method_type("() -> untyped").params
+
+      # req:rest
+      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params & parse_method_type("(**Integer) -> untyped").params
+
+      # opt:req
+      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params & parse_method_type("(foo: Integer) -> untyped").params
+
+      # opt:opt
+      assert_equal parse_method_type("(?foo: String & Integer) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params & parse_method_type("(?foo: Integer) -> untyped").params
+
+      # opt:none
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params & parse_method_type("() -> untyped").params
+
+      # opt:rest
+      assert_equal parse_method_type("(?foo: String & Integer) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params & parse_method_type("(**Integer) -> untyped").params
+
+      # none:req
+      assert_nil parse_method_type("() -> untyped").params & parse_method_type("(foo: String) -> untyped").params
+
+      # none:opt
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("() -> untyped").params & parse_method_type("(?foo: Integer) -> untyped").params
+
+      # none:rest
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("() -> untyped").params & parse_method_type("(**Integer) -> untyped").params
+
+      # rest:req
+      assert_equal parse_method_type("(foo: String & Integer) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params & parse_method_type("(foo: Integer) -> untyped").params
+
+      # rest:opt
+      assert_equal parse_method_type("(?foo: String & Integer) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params & parse_method_type("(?foo: Integer) -> untyped").params
+
+      # rest:none
+      assert_equal parse_method_type("() -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params & parse_method_type("() -> untyped").params
+
+      # rest:rest
+      assert_equal parse_method_type("(**String & Integer) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params & parse_method_type("(**Integer) -> untyped").params
+    end
+  end
+
+  def test_method_type_params_union
+    with_factory do
+      # required:required
+      assert_equal parse_method_type("(String | Integer) -> untyped").params,
+                   parse_method_type("(String) -> untyped").params | parse_method_type("(Integer) -> untyped").params
+
+      # required:none
+      assert_equal parse_method_type("(?String) -> void").params,
+                   parse_method_type("(String) -> untyped").params | parse_method_type("() -> untyped").params
+
+      # required:optional
+      assert_equal parse_method_type("(?String | Integer) -> untyped").params,
+                   parse_method_type("(String) -> untyped").params | parse_method_type("(?Integer) -> untyped").params
+
+      # required:rest
+      assert_equal parse_method_type("(?String | Integer) -> untyped").params,
+                   parse_method_type("(String) -> untyped").params | parse_method_type("(*Integer) -> untyped").params
+
+      # none:required
+      assert_equal parse_method_type("(?String) -> untyped").params,
+                   parse_method_type("() -> untyped").params | parse_method_type("(String) -> untyped").params
+
+      # none:optional
+      assert_equal parse_method_type("(?Integer) -> untyped").params,
+                   parse_method_type("() -> untyped").params | parse_method_type("(?Integer) -> untyped").params
+
+      # none:rest
+      assert_equal parse_method_type("(*Integer) -> untyped").params,
+                   parse_method_type("() -> untyped").params | parse_method_type("(*Integer) -> untyped").params
+
+      # opt:required
+      assert_equal parse_method_type("(?String | Integer) -> untyped").params,
+                   parse_method_type("(?String) -> untyped").params | parse_method_type("(Integer) -> untyped").params
+
+      # opt:none
+      assert_equal parse_method_type("(?String) -> untyped").params,
+                   parse_method_type("(?String) -> untyped").params | parse_method_type("() -> untyped").params
+
+      # opt:opt
+      assert_equal parse_method_type("(?String | Integer) -> untyped").params,
+                   parse_method_type("(?String) -> untyped").params | parse_method_type("(?Integer) -> untyped").params
+
+      # opt:rest
+      assert_equal parse_method_type("(?String | Integer) -> untyped").params,
+                   parse_method_type("(?String) -> untyped").params | parse_method_type("(*Integer) -> untyped").params
+
+      # rest:required
+      assert_equal parse_method_type("(?String | Integer) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params | parse_method_type("(Integer) -> untyped").params
+
+      # rest:none
+      assert_equal parse_method_type("(*String) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params | parse_method_type("() -> untyped").params
+
+      # rest:opt
+      assert_equal parse_method_type("(?String | Integer, *String) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params | parse_method_type("(?Integer) -> untyped").params
+
+      # rest:rest
+      assert_equal parse_method_type("(*String | Integer) -> untyped").params,
+                   parse_method_type("(*String) -> untyped").params | parse_method_type("(*Integer) -> untyped").params
+
+      ## Keywords
+
+      # req:req
+      assert_equal parse_method_type("(foo: String | Integer) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params | parse_method_type("(foo: Integer) -> untyped").params
+
+      # req:opt
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params | parse_method_type("(?foo: Integer) -> untyped").params
+
+      # req:none
+      assert_equal parse_method_type("(?foo: String) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params | parse_method_type("() -> untyped").params
+
+      # req:rest
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(foo: String) -> untyped").params | parse_method_type("(**Integer) -> untyped").params
+
+      # opt:req
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params | parse_method_type("(foo: Integer) -> untyped").params
+
+      # opt:opt
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params | parse_method_type("(?foo: Integer) -> untyped").params
+
+      # opt:none
+      assert_equal parse_method_type("(?foo: String) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params | parse_method_type("() -> untyped").params
+
+      # opt:rest
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(?foo: String) -> untyped").params | parse_method_type("(**Integer) -> untyped").params
+
+      # none:req
+      assert_equal parse_method_type("(?foo: String) -> untyped").params,
+                   parse_method_type("() -> untyped").params | parse_method_type("(foo: String) -> untyped").params
+
+      # none:opt
+      assert_equal parse_method_type("(?foo: Integer) -> untyped").params,
+                   parse_method_type("() -> untyped").params | parse_method_type("(?foo: Integer) -> untyped").params
+
+      # none:rest
+      assert_equal parse_method_type("(**Integer) -> untyped").params,
+                   parse_method_type("() -> untyped").params | parse_method_type("(**Integer) -> untyped").params
+
+      # rest:req
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params | parse_method_type("(foo: Integer) -> untyped").params
+
+      # rest:opt
+      assert_equal parse_method_type("(?foo: String | Integer) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params | parse_method_type("(?foo: Integer) -> untyped").params
+
+      # rest:none
+      assert_equal parse_method_type("(**String) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params | parse_method_type("() -> untyped").params
+
+      # rest:rest
+      assert_equal parse_method_type("(**String | Integer) -> untyped").params,
+                   parse_method_type("(**String) -> untyped").params | parse_method_type("(**Integer) -> untyped").params
+    end
+  end
+
+  def test_method_type_union
+    with_factory do
+      assert_equal parse_method_type("(String & Integer) -> (String | Symbol)"),
+                   parse_method_type("(String) -> String") | parse_method_type("(Integer) -> Symbol")
+
+      assert_nil parse_method_type("() -> String") | parse_method_type("(Integer) -> untyped")
+      assert_equal parse_method_type("() -> bool"),
+                   parse_method_type("() -> bot") | parse_method_type("() -> bool")
+      assert_equal parse_method_type("() -> untyped"),
+                   parse_method_type("() -> untyped") | parse_method_type("() -> String")
+
+      assert_equal parse_method_type("() { (String | Integer) -> (Integer & Float) } -> (String | Symbol)"),
+                   parse_method_type("() { (String) -> Integer } -> String") | parse_method_type("() { (Integer) -> Float } -> Symbol")
+
+      assert_equal parse_method_type("() { (String | Integer, ?String) -> void } -> void"),
+                   parse_method_type("() { (String, String) -> void } -> void") | parse_method_type("() { (Integer) -> void } -> void")
+
+      assert_equal parse_method_type("() { (String | Integer) -> (Integer & Float) } -> (String | Symbol)"),
+                   parse_method_type("() ?{ (String) -> Integer } -> String") | parse_method_type("() { (Integer) -> Float } -> Symbol")
+
+      assert_equal parse_method_type("() ?{ (String) -> Integer } -> (String | Symbol)"),
+                   parse_method_type("() ?{ (String) -> Integer } -> String") | parse_method_type("() -> Symbol")
+    end
+  end
+
+  def test_method_type_union_poly
+    skip
+    assert_equal parse_method_type("[A, A_1, B] (Array[A] & Hash[A_1, B]) -> (String | Symbol)"),
+                 parse_method_type("[A] (Array[A]) -> String") | parse_method_type("[A, B] (Hash[A, B]) -> Symbol")
+  end
+
+  def test_method_type_intersection
+    with_factory do
+      assert_equal parse_method_type("(String | Integer) -> (String & Symbol)"),
+                   parse_method_type("(String) -> String") & parse_method_type("(Integer) -> Symbol")
+
+      assert_equal parse_method_type("(?Integer) -> untyped"),
+                   parse_method_type("() -> String") & parse_method_type("(Integer) -> untyped")
+
+      assert_equal parse_method_type("() -> bot"),
+                   parse_method_type("() -> bot") & parse_method_type("() -> bool")
+      assert_equal parse_method_type("() -> untyped"),
+                   parse_method_type("() -> untyped") & parse_method_type("() -> String")
+
+      assert_equal parse_method_type("() { (String & Integer) -> (Integer | Float) } -> (String & Symbol)"),
+                   parse_method_type("() { (String) -> Integer } -> String") & parse_method_type("() { (Integer) -> Float } -> Symbol")
+
+      assert_nil parse_method_type("() { (String, String) -> void } -> void") & parse_method_type("() { (Integer) -> void } -> void")
+
+      assert_equal parse_method_type("() ?{ (String & Integer) -> (Integer | Float) } -> (String & Symbol)"),
+                   parse_method_type("() ?{ (String) -> Integer } -> String") & parse_method_type("() { (Integer) -> Float } -> Symbol")
+
+
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,8 +22,7 @@ module Steep::AST::Types::Name
 
   def self.new_class(location: nil, name:, constructor:, args: [])
     name = Steep::Names::Module.parse(name.to_s) unless name.is_a?(Steep::Names::Module)
-    Steep::AST::Types::Name::Singleton.new(location: location,
-                                           name: name)
+    Steep::AST::Types::Name::Singleton.new(location: location, name: name)
   end
 
   def self.new_instance(location: nil, name:, args: [])


### PR DESCRIPTION
Improves typing of method calls with block on _union_ type receivers. This gives better types for:

```rb
a = [1, ""].sample    # a: Integer | String
a.yield_self do       # This cannot type blocks well because of the receiver is union type. 😢 
  ...
end
```

This PR is to introduce union and intersection of _method types_ and using them solves the problem above.