### PR TITLE
Add UnsupportedSyntax error on masgn in block params

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2683,6 +2683,17 @@ module Steep
         if block_params && method_type.block
           block_annotations = source.annotations(block: node, factory: checker.factory, current_module: current_namespace)
           block_params_ = TypeInference::BlockParams.from_node(block_params, annotations: block_annotations)
+
+          unless block_params_
+            return [
+              Errors::UnsupportedSyntax.new(
+                node: block_params,
+                message: "Unsupported block params pattern, probably masgn?"
+              ),
+              constr
+            ]
+          end
+
           pairs = block_params_.zip(method_type.block.type.params)
 
           unless pairs

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -56,6 +56,11 @@ module Steep
 
         node.children.each do |arg|
           var = arg.children.first
+
+          if var.is_a?(::AST::Node)
+            return
+          end
+
           type = annotations.var_type(lvar: var.name)
 
           case arg.type

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5453,4 +5453,24 @@ end
       end
     end
   end
+
+  def test_block_param_masgn
+    with_checker(<<-RBS) do |checker|
+class BlockParamTuple
+  def foo: () { ([Integer, String]) -> void } -> void
+end
+    RBS
+      source = parse_ruby(<<-RUBY)
+BlockParamTuple.new.foo do |(x, y)|
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_equal 1, typing.errors.size
+        assert_instance_of Steep::Errors::UnsupportedSyntax, typing.errors[0]
+      end
+    end
+  end
 end


### PR DESCRIPTION
While I have a plan to support this, it's not supported for now.

```rb
foo.each {|(x, y), z| ... }   # Masgn in block parameters are not supported.

foo.each {|pair, z|           # You can rewrite like this.
  x, y = pair
  ...
}
```