### PR TITLE
Add typing_options: strict to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Edit the `Steepfile`:
 
 ```rb
 target :app do
+  typing_options :strict
   check "lib"
   signature "sig"
 


### PR DESCRIPTION
Without this, MethodDefinitionMissing won't occur with steep 0.29.0.

In addition, I'd like to read descriptions about `typing_options` in README.