### PR TITLE
Attribute definition raises error

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -344,41 +344,43 @@ module Steep
             defined_in = method_def.defined_in
             member = method_def.member
 
-            case
-            when defined_in == RBS::BuiltinNames::Object.name && member.instance?
-              case method_name
-              when :is_a?, :kind_of?, :instance_of?
-                return method_type.with(
-                  return_type: AST::Types::Logic::ReceiverIsArg.new(location: method_type.return_type.location)
-                )
-              when :nil?
-                return method_type.with(
-                  return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.return_type.location)
-                )
-              end
+            if member.is_a?(RBS::AST::Members::MethodDefinition)
+              case
+              when defined_in == RBS::BuiltinNames::Object.name && member.instance?
+                case method_name
+                when :is_a?, :kind_of?, :instance_of?
+                  return method_type.with(
+                    return_type: AST::Types::Logic::ReceiverIsArg.new(location: method_type.return_type.location)
+                  )
+                when :nil?
+                  return method_type.with(
+                    return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.return_type.location)
+                  )
+                end
 
-            when defined_in == AST::Builtin::NilClass.module_name && member.instance?
-              case method_name
-              when :nil?
-                return method_type.with(
-                  return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.return_type.location)
-                )
-              end
+              when defined_in == AST::Builtin::NilClass.module_name && member.instance?
+                case method_name
+                when :nil?
+                  return method_type.with(
+                    return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.return_type.location)
+                  )
+                end
 
-            when defined_in == RBS::BuiltinNames::BasicObject.name && member.instance?
-              case method_name
-              when :!
-                return method_type.with(
-                  return_type: AST::Types::Logic::Not.new(location: method_type.return_type.location)
-                )
-              end
+              when defined_in == RBS::BuiltinNames::BasicObject.name && member.instance?
+                case method_name
+                when :!
+                  return method_type.with(
+                    return_type: AST::Types::Logic::Not.new(location: method_type.return_type.location)
+                  )
+                end
 
-            when defined_in == RBS::BuiltinNames::Module.name && member.instance?
-              case method_name
-              when :===
-                return method_type.with(
-                  return_type: AST::Types::Logic::ArgIsReceiver.new(location: method_type.return_type.location)
-                )
+              when defined_in == RBS::BuiltinNames::Module.name && member.instance?
+                case method_name
+                when :===
+                  return method_type.with(
+                    return_type: AST::Types::Logic::ArgIsReceiver.new(location: method_type.return_type.location)
+                  )
+                end
               end
             end
           end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -662,7 +662,7 @@ end
       source = parse_ruby(<<-EOF)
 x = [M1.new, M2.new][0]
 
-x.foo do |a| 
+x.foo do |a|
   nil
 end
 
@@ -5184,7 +5184,7 @@ end
 
       source = parse_ruby(<<-RUBY)
 OptionalBlockParam.new.foo do |x|
-  next unless x  
+  next unless x
   x + 1
 end
       RUBY
@@ -5796,6 +5796,23 @@ x = begin
     rescue
       [2, ""]
     end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_module_attribute
+    with_checker(<<-RBS) do |checker|
+class Module
+  attr_accessor hello: String
+end
+    RBS
+      source = parse_ruby(<<-RUBY)
+Object.new
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|


### PR DESCRIPTION
Attribute definition in `Module` caused an error.

```
Unexpected error in #type_send: undefined method `instance?' for #<RBS::AST::Members::AttrAccessor:0x00007f83c0543468>
```

This is a bug introduced in 0.29.0. 