### PR TITLE
Run type checker for interactions without unrelated defs

### DIFF
--- a/lib/steep/project/completion_provider.rb
+++ b/lib/steep/project/completion_provider.rb
@@ -29,11 +29,13 @@ module Steep
         @subtyping = subtyping
       end
 
-      def type_check!(text)
+      def type_check!(text, line:, column:)
         @modified_text = text
 
         Steep.measure "parsing" do
-          @source = SourceFile.parse(text, path: path, factory: subtyping.factory)
+          @source = SourceFile
+                      .parse(text, path: path, factory: subtyping.factory)
+                      .without_unrelated_defs(line: line, column: column)
         end
 
         Steep.measure "typechecking" do
@@ -53,7 +55,7 @@ module Steep
         begin
           Steep.logger.tagged "completion_provider#run(line: #{line}, column: #{column})" do
             Steep.measure "type_check!" do
-              type_check!(source_text)
+              type_check!(source_text, line: line, column: column)
             end
           end
 
@@ -66,11 +68,11 @@ module Steep
           case possible_trigger
           when "."
             source_text[index-1] = " "
-            type_check!(source_text)
+            type_check!(source_text, line: line, column: column)
             items_for_dot(position: position)
           when "@"
             source_text[index-1] = " "
-            type_check!(source_text)
+            type_check!(source_text, line: line, column: column)
             items_for_atmark(position: position)
           else
             []

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -351,7 +351,7 @@ module Steep
     end
 
     def without_unrelated_defs(line:, column:)
-      nodes = find_nodes(line: line, column: column)
+      nodes = find_nodes(line: line, column: column) || []
       defs = Set[].compare_by_identity.merge(nodes.select {|node| node.type == :def || node.type == :defs })
 
       node_ = Source.delete_defs(node, defs)

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -276,6 +276,18 @@ module Steep
       end
     end
 
+    def self.map_child_nodes(node)
+      children = node.children.map do |child|
+        if child.is_a?(::AST::Node)
+          yield child
+        else
+          child
+        end
+      end
+
+      node.updated(nil, children)
+    end
+
     def annotations(block:, factory:, current_module:)
       AST::Annotation::Collection.new(
         annotations: mapping[block.__id__] || [],
@@ -314,6 +326,51 @@ module Steep
 
           parents
         end
+      end
+    end
+
+    def self.delete_defs(node, allow_list)
+      case node.type
+      when :def
+        if allow_list.include?(node)
+          node
+        else
+          node.updated(:nil, [])
+        end
+      when :defs
+        if allow_list.include?(node)
+          node
+        else
+          delete_defs(node.children[0], allow_list)
+        end
+      else
+        map_child_nodes(node) do |child|
+          delete_defs(child, allow_list)
+        end
+      end
+    end
+
+    def without_unrelated_defs(line:, column:)
+      nodes = find_nodes(line: line, column: column)
+      defs = Set[].compare_by_identity.merge(nodes.select {|node| node.type == :def || node.type == :defs })
+
+      node_ = Source.delete_defs(node, defs)
+
+      Source.new(path: path, node: node_, mapping: mapping)
+    end
+
+    def compact_siblings(node)
+      case node
+      when :def
+        node.updated(:nil, [])
+      when :defs
+        node.children[0]
+      when :class
+        node.updated(:class, [node.children[0], node.children[1], nil])
+      when :module
+        node.updated(:module, [node.children[0], nil])
+      else
+        node
       end
     end
   end


### PR DESCRIPTION
Type checking of a `def` in Steep is independent of other `def`s. We can just stop type checking for other `def`s for faster response on hover or completions.

```rb
class Foo
  def foo
    1+"     # Assume user triggers completion/hover here. 🈁
  end

  def bar
    2+3     # The type checking of this method is not used at all for the completion/hover above.
  end

  def baz
    :xyz    # We can delete these defs. 🔪 
  end
end
```

The test on my computer resulted in 4 times speedup of completion, from 2 seconds to 0.5 seconds. This is a huge performance improvement that 2 seconds is clearly too slow, but 0.5 seconds would be acceptable.