### PR TITLE
Listen ~> 3.0 to allow installing on Ruby 3

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ast_utils", "~> 0.3.0"
   spec.add_runtime_dependency "activesupport", ">= 5.1"
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
-  spec.add_runtime_dependency "listen", "~> 3.1"
+  spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.15.0.1"
   spec.add_runtime_dependency "rbs", "~> 0.12.0"
 end


### PR DESCRIPTION
It's already [fixed in Listen repo](https://github.com/guard/listen/commit/819604fe69ca416d1797ccacb5508395ad896175) but not released yet. Fixes #233.