### PR TITLE
Support if-then-else

### DIFF
--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -107,7 +107,7 @@ module Steep
 
             if node.children[1]
               if node.loc.keyword.source == "if" || node.loc.keyword.source == "elsif"
-                then_start = node.loc.begin&.loc&.last_line || node.children[0].loc.last_line
+                then_start = node.loc.begin&.last_line || node.children[0].loc.last_line
                 then_end = node.children[2] ? node.loc.else.line : node.loc.last_line
               else
                 then_start = node.loc.else.last_line

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -202,6 +202,16 @@ y + "foo" unless bar
     end
   end
 
+  def test_if_then_else
+    with_factory do |factory|
+      source = Steep::Source.parse(<<-EOF, path: Pathname("foo.rb"), factory: factory)
+x = if test then 1 else 2 end
+      EOF
+
+      source.annotations(block: source.node, factory: factory, current_module: Namespace.root)
+    end
+  end
+
   def test_while
     with_factory do |factory|
       source = Steep::Source.parse(<<-EOF, path: Pathname("foo.rb"), factory: factory)
@@ -469,14 +479,14 @@ class A < X
 
     class <<self
       define_method :hogehoge do
-        1+2 
+        1+2
       end
     end
   end
 
   C = Struct.new(:x, :y) do
     def test
-    end 
+    end
   end
 end
       EOF
@@ -497,7 +507,7 @@ class A < X
 
     class <<self
       define_method :hogehoge do
-        1+2 
+        1+2
       end
     end
   end


### PR DESCRIPTION
`if` with `then` caused an error. 😢 

```rb
if foo() then bar() else baz() end    # => Unexpected error: #<NoMethodError: undefined method `loc' for #<Parser::Source::Range:0x00007f8987c09758>>
```