### PR TITLE
Attribute assignments have rhs type

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2339,6 +2339,14 @@ module Steep
                                                                               receiver_type: receiver_type,
                                                                               topdown_hint: true)
 
+
+                             case method_name.to_s
+                             when "[]=", /\w=\Z/
+                               if typing.has_type?(arguments.last)
+                                 return_type = typing.type_of(node: arguments.last)
+                               end
+                             end
+
                              add_typing node, type: return_type, constr: constr
                            else
                              fallback_to_any node do

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5881,4 +5881,25 @@ end
       end
     end
   end
+
+  def test_assignment_call
+    with_checker(<<-RBS) do |checker|
+class Fun
+  def foo=: (Integer) -> String
+  def []=: (Integer, String) -> Symbol
+end
+    RBS
+      source = parse_ruby(<<-RUBY)
+# @type var x: Integer
+x = Fun.new.foo = 30
+# @type var y: String
+y = Fun.new[1] = "hoge"
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
Attribute assignments evaluate to the rhs values regardless the return value of the method.

```
foo.bar = :foo      # Always :foo
foo[1] = :bar       # Always :bar
```

So the type of these nodes should be the type of rhs nodes.