### PR TITLE
Fix method call typing

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -71,6 +71,7 @@ require "steep/type_inference/type_env"
 require "steep/type_inference/local_variable_type_env"
 require "steep/type_inference/logic"
 require "steep/type_inference/logic_type_interpreter"
+require "steep/type_inference/method_call"
 require "steep/ast/types"
 
 require "steep/server/utils"

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -16,6 +16,7 @@ require 'uri'
 
 require "rbs"
 
+require "steep/method_name"
 require "steep/ast/types/helper"
 require "steep/ast/types/any"
 require "steep/ast/types/instance"

--- a/lib/steep/annotation_parser.rb
+++ b/lib/steep/annotation_parser.rb
@@ -68,7 +68,7 @@ module Steep
           name = match[:name]
           type = match[:type]
 
-          method_type = factory.method_type(RBS::Parser.parse_method_type(type), self_type: AST::Types::Self.new)
+          method_type = factory.method_type(RBS::Parser.parse_method_type(type), self_type: AST::Types::Self.new, method_decls: Set[])
 
           AST::Annotation::MethodType.new(name: name.to_sym,
                                           type: method_type,

--- a/lib/steep/errors.rb
+++ b/lib/steep/errors.rb
@@ -101,20 +101,6 @@ module Steep
       end
     end
 
-    class IncompatibleBlockParameters < Base
-      attr_reader :node
-      attr_reader :method_type
-
-      def initialize(node:, method_type:)
-        super(node: node)
-        @method_type = method_type
-      end
-
-      def to_s
-        "#{location_to_str}: IncompatibleBlockParameters: method_type=#{method_type}"
-      end
-    end
-
     class BlockParameterTypeMismatch < Base
       attr_reader :expected
       attr_reader :actual
@@ -186,7 +172,7 @@ module Steep
       end
 
       def to_s
-        "#{location_to_str}: RequiredBlockMissing: method_type=#{method_type.location&.source}"
+        "#{location_to_str}: RequiredBlockMissing: method_type=#{method_type.to_s}"
       end
     end
 
@@ -555,6 +541,24 @@ module Steep
       def to_s
         msg = message || "#{node.type} is not supported"
         "#{location_to_str}: UnsupportedSyntax: #{msg}"
+      end
+    end
+
+    class UnexpectedError < Base
+      attr_reader :message
+      attr_reader :error
+
+      def initialize(node:, error:)
+        super(node: node)
+        @error = error
+        @message = error.message
+      end
+
+      def to_s
+        <<-MESSAGE
+#{location_to_str}: UnexpectedError: #{error.class}
+>> #{message}
+        MESSAGE
       end
     end
   end

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -774,16 +774,14 @@ module Steep
       attr_reader :params
       attr_reader :block
       attr_reader :return_type
-      attr_reader :location
-      attr_reader :method_def
+      attr_reader :method_decls
 
-      def initialize(type_params:, params:, block:, return_type:, location:, method_def:)
+      def initialize(type_params:, params:, block:, return_type:, method_decls:)
         @type_params = type_params
         @params = params
         @block = block
         @return_type = return_type
-        @location = location
-        @method_def = method_def
+        @method_decls = method_decls
       end
 
       def ==(other)
@@ -791,9 +789,7 @@ module Steep
           other.type_params == type_params &&
           other.params == params &&
           other.block == block &&
-          other.return_type == return_type &&
-          (!other.method_def || !method_def || other.method_def == method_def) &&
-          (!other.location || !location || other.location == location)
+          other.return_type == return_type
       end
 
       alias eql? ==
@@ -824,8 +820,7 @@ module Steep
           params: params.subst(s_),
           block: block&.subst(s_),
           return_type: return_type.subst(s_),
-          method_def: method_def,
-          location: location
+          method_decls: method_decls
         )
       end
 
@@ -847,17 +842,15 @@ module Steep
                        params: params.subst(s),
                        block: block&.subst(s),
                        return_type: return_type.subst(s),
-                       location: location,
-                       method_def: method_def)
+                       method_decls: method_decls)
       end
 
-      def with(type_params: self.type_params, params: self.params, block: self.block, return_type: self.return_type, location: self.location,  method_def: self.method_def)
+      def with(type_params: self.type_params, params: self.params, block: self.block, return_type: self.return_type, method_decls: self.method_decls)
         self.class.new(type_params: type_params,
                        params: params,
                        block: block,
                        return_type: return_type,
-                       method_def: method_def,
-                       location: location)
+                       method_decls: method_decls)
       end
 
       def to_s
@@ -873,8 +866,7 @@ module Steep
                        params: params.map_type(&block),
                        block: self.block&.yield_self {|blk| blk.map_type(&block) },
                        return_type: yield(return_type),
-                       location: location,
-                       method_def: method_def)
+                       method_decls: method_decls)
       end
 
       # Returns a new method type which can be used for the method implementation type of both `self` and `other`.
@@ -902,8 +894,7 @@ module Steep
           return_type: AST::Types::Union.build(
             types: [return_type.subst(s1),other.return_type.subst(s2)]
           ),
-          method_def: method_def,
-          location: nil
+          method_decls: method_decls + other.method_decls
         )
       end
 
@@ -958,8 +949,7 @@ module Steep
           block: block,
           return_type: return_type,
           type_params: type_params,
-          method_def: nil,
-          location: nil
+          method_decls: method_decls + other.method_decls
         )
       end
 
@@ -1006,8 +996,7 @@ module Steep
           block: block,
           return_type: return_type,
           type_params: type_params,
-          method_def: nil,
-          location: nil
+          method_decls: method_decls + other.method_decls
         )
       end
     end

--- a/lib/steep/method_name.rb
+++ b/lib/steep/method_name.rb
@@ -1,0 +1,28 @@
+module Steep
+  InstanceMethodName = Struct.new(:type_name, :method_name, keyword_init: true) do
+    def to_s
+      "#{type_name}##{method_name}"
+    end
+  end
+
+  SingletonMethodName = Struct.new(:type_name, :method_name, keyword_init: true) do
+    def to_s
+      "#{type_name}.#{method_name}"
+    end
+  end
+
+  module ::Kernel
+    def MethodName(string)
+      case string
+      when /#/
+        type_name, method_name = string.split(/#/, 2)
+        InstanceMethodName.new(type_name: TypeName(type_name), method_name: method_name.to_sym)
+      when /\./
+        type_name, method_name = string.split(/\./, 2)
+        SingletonMethodName.new(type_name: TypeName(type_name), method_name: method_name.to_sym)
+      else
+        raise "Unexpected method name: #{string}"
+      end
+    end
+  end
+end

--- a/lib/steep/project/source_file.rb
+++ b/lib/steep/project/source_file.rb
@@ -66,7 +66,8 @@ module Steep
           break_context: nil,
           self_type: AST::Builtin::Object.instance_type,
           type_env: type_env,
-          lvar_env: lvar_env
+          lvar_env: lvar_env,
+          call_context: TypeInference::MethodCall::TopLevelContext.new
         )
 
         typing = Typing.new(source: source, root_context: context)

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -196,7 +196,7 @@ HOVER
             ),
             documentation: item.comment&.string,
             insert_text_format: LanguageServer::Protocol::Constant::InsertTextFormat::SNIPPET,
-            sort_text: item.inherited_method ? 'z' : 'a' # Ensure language server puts non-inherited methods before inherited methods
+            sort_text: item.inherited? ? 'z' : 'a' # Ensure language server puts non-inherited methods before inherited methods
           )
         when Project::CompletionProvider::InstanceVariableItem
           label = "#{item.identifier}: #{item.type}"

--- a/lib/steep/subtyping/variable_occurrence.rb
+++ b/lib/steep/subtyping/variable_occurrence.rb
@@ -29,6 +29,8 @@ module Steep
             returns << var
           end
         end
+
+        params.subtract(returns)
       end
 
       def each_var(type, &block)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -216,6 +216,21 @@ module Steep
 
       lvar_env = lvar_env.annotate(annots)
 
+      call_context = case self_type
+                     when nil
+                       TypeInference::MethodCall::UnknownContext.new()
+                     when AST::Types::Name::Singleton
+                       TypeInference::MethodCall::MethodContext.new(
+                         method_name: SingletonMethodName.new(type_name: module_context.class_name, method_name: method_name)
+                       )
+                     when AST::Types::Name::Instance, AST::Types::Intersection
+                       TypeInference::MethodCall::MethodContext.new(
+                         method_name: InstanceMethodName.new(type_name: module_context.class_name, method_name: method_name)
+                       )
+                     else
+                       raise "Unexpected self_type: #{self_type}"
+                     end
+
       self.class.new(
         checker: checker,
         source: source,
@@ -227,7 +242,8 @@ module Steep
           break_context: nil,
           self_type: annots.self_type || self_type,
           type_env: type_env,
-          lvar_env: lvar_env
+          lvar_env: lvar_env,
+          call_context: call_context
         ),
         typing: typing,
       )
@@ -355,7 +371,8 @@ module Steep
           module_context: module_context_,
           self_type: module_context_.module_type,
           type_env: module_type_env,
-          lvar_env: lvar_env
+          lvar_env: lvar_env,
+          call_context: TypeInference::MethodCall::ModuleContext.new(type_name: module_context_.class_name)
         )
       )
     end
@@ -424,7 +441,8 @@ module Steep
         break_context: nil,
         self_type: module_context.module_type,
         type_env: class_type_env,
-        lvar_env: lvar_env
+        lvar_env: lvar_env,
+        call_context: TypeInference::MethodCall::ModuleContext.new(type_name: module_context.class_name)
       )
 
       self.class.new(
@@ -509,7 +527,8 @@ module Steep
         break_context: nil,
         self_type: module_context.module_type,
         type_env: type_env,
-        lvar_env: lvar_env
+        lvar_env: lvar_env,
+        call_context: TypeInference::MethodCall::ModuleContext.new(type_name: module_context.class_name)
       )
 
       self.class.new(
@@ -606,6 +625,22 @@ module Steep
 
       typing.add_typing(node, type, nil)
       Pair.new(type: type, constr: constr)
+    end
+
+    def add_call(call)
+      case call
+      when TypeInference::MethodCall::NoMethodError
+        typing.add_error(call.error)
+      when TypeInference::MethodCall::Error
+        call.errors.each do |error|
+          typing.add_error(error)
+        end
+      end
+
+      typing.add_typing(call.node, call.return_type, nil)
+      typing.add_call(call.node, call)
+
+      Pair.new(type: call.return_type, constr: self)
     end
 
     def synthesize(node, hint: nil)
@@ -803,16 +838,16 @@ module Steep
                 )
                 args = TypeInference::SendArgs.from_nodes(node.children.dup)
 
-                return_type, _ = type_method_call(node,
-                                                  receiver_type: self_type,
-                                                  method_name: method_context.name,
-                                                  method: super_method,
-                                                  args: args,
-                                                  block_params: nil,
-                                                  block_body: nil,
-                                                  topdown_hint: true)
+                call, constr = type_method_call(node,
+                                                receiver_type: self_type,
+                                                method_name: method_context.name,
+                                                method: super_method,
+                                                args: args,
+                                                block_params: nil,
+                                                block_body: nil,
+                                                topdown_hint: true)
 
-                add_typing node, type: return_type
+                constr.add_call(call)
               else
                 fallback_to_any node do
                   Errors::UnexpectedSuper.new(node: node, method: method_context.name)
@@ -2034,7 +2069,7 @@ module Steep
           unless pair.is_a?(Pair) && !pair.type.is_a?(Pair)
             # Steep.logger.error { "result = #{pair.inspect}" }
             # Steep.logger.error { "node = #{node.type}" }
-            raise "#synthesize should return an instance of Pair: #{pair.class}"
+            raise "#synthesize should return an instance of Pair: #{pair.class}, node=#{node.inspect}"
           end
         end
       end
@@ -2278,185 +2313,231 @@ module Steep
         return_hint = type_hint.return_type
       end
 
-      block_pair = type_block(node: node,
-                              block_param_hint: params_hint,
-                              block_type_hint: return_hint,
-                              node_type_hint: nil,
-                              block_params: params,
-                              block_body: block_body,
-                              block_annotations: block_annotations,
-                              topdown_hint: true)
+      block_constr = for_block(
+        block_params: params,
+        block_param_hint: params_hint,
+        block_annotations: block_annotations,
+        node_type_hint: nil
+      )
 
-      add_typing node, type: block_pair.type
-    end
+      block_constr.typing.add_context_for_body(node, context: block_constr.context)
 
-    def type_send(node, send_node:, block_params:, block_body:, unwrap: false)
-      receiver, method_name, *arguments = send_node.children
-      receiver_type, constr = receiver ? synthesize(receiver) : [AST::Types::Self.new, self]
-
-      if unwrap
-        receiver_type = unwrap(receiver_type)
+      params.params.each do |param|
+        _, block_constr = block_constr.synthesize(param.node, hint: param.type)
       end
 
-      receiver_type = expand_alias(receiver_type)
+      if block_body
+        return_type = block_constr.synthesize_block(
+          node: node,
+          block_body: block_body,
+          topdown_hint: true,
+          block_type_hint: return_hint
+        ) do |error|
+          typing.add_error(error)
+        end
+      else
+        return_type = AST::Builtin.any_type
+      end
 
-      type, constr = case receiver_type
-                     when AST::Types::Any
-                       each_child_node(send_node) do |child|
-                         unless child.equal?(receiver)
-                           _, constr = constr.synthesize(child)
-                         end
-                       end
+      block_type = AST::Types::Proc.new(
+        params: params_hint || params.params_type,
+        return_type: return_type
+      )
 
-                       add_typing node, type: AST::Builtin.any_type
+      add_typing node, type: block_type
+    end
 
-                     when nil
-                       fallback_to_any node
+    def synthesize_children(node, skips: [])
+      skips = Set.new.compare_by_identity.merge(skips)
 
-                     when AST::Types::Void, AST::Types::Bot, AST::Types::Top
-                       fallback_to_any node do
-                         Errors::NoMethod.new(node: node, method: method_name, type: receiver_type)
-                       end
+      constr = self
 
-                     else
-                       case expanded_receiver_type = expand_self(receiver_type)
-                       when AST::Types::Self
-                         Steep.logger.debug { "`self` type cannot be resolved to concrete type" }
-                         fallback_to_any node do
-                           Errors::NoMethod.new(node: node, method: method_name, type: receiver_type)
-                         end
-                       else
-                         begin
-                           interface = checker.factory.interface(receiver_type,
-                                                                 private: !receiver,
-                                                                 self_type: expanded_receiver_type)
+      each_child_node(node) do |child|
+        unless skips.include?(child)
+          _, constr = constr.synthesize(child)
+        end
+      end
 
-                           method = interface.methods[method_name]
+      constr
+    end
 
-                           if method
-                             args = TypeInference::SendArgs.from_nodes(arguments)
-                             return_type, constr, _ = constr.type_method_call(node,
-                                                                              method: method,
-                                                                              method_name: method_name,
-                                                                              args: args,
-                                                                              block_params: block_params,
-                                                                              block_body: block_body,
-                                                                              receiver_type: receiver_type,
-                                                                              topdown_hint: true)
+    def type_send_interface(node, interface:, receiver:, receiver_type:, method_name:, arguments:, block_params:, block_body:)
+      method = interface.methods[method_name]
 
+      if method
+        args = TypeInference::SendArgs.from_nodes(arguments)
+        call, constr = type_method_call(node,
+                                        method: method,
+                                        method_name: method_name,
+                                        args: args,
+                                        block_params: block_params,
+                                        block_body: block_body,
+                                        receiver_type: receiver_type,
+                                        topdown_hint: true)
 
-                             case method_name.to_s
-                             when "[]=", /\w=\Z/
-                               if typing.has_type?(arguments.last)
-                                 return_type = typing.type_of(node: arguments.last)
-                               end
-                             end
+        if call && constr
+          case method_name.to_s
+          when "[]=", /\w=\Z/
+            if typing.has_type?(arguments.last)
+              call = call.with_return_type(typing.type_of(node: arguments.last))
+            end
+          end
+        else
+          error = Errors::UnresolvedOverloading.new(
+            node: node,
+            receiver_type: receiver_type,
+            method_name: method_name,
+            method_types: method.method_types
+          )
+          call = TypeInference::MethodCall::Error.new(
+            node: node,
+            context: context.method_context,
+            method_name: method_name,
+            receiver_type: receiver_type,
+            errors: [error]
+          )
 
-                             add_typing node, type: return_type, constr: constr
-                           else
-                             fallback_to_any node do
-                               Errors::NoMethod.new(node: node, method: method_name, type: expanded_receiver_type)
-                             end
-                           end
-                         rescue => exn
-                           case exn
-                           when RBS::NoTypeFoundError, RBS::NoMixinFoundError, RBS::NoSuperclassFoundError, RBS::InvalidTypeApplicationError
-                             # ignore known RBS errors.
-                           else
-                             Steep.log_error(exn, message: "Unexpected error in #type_send: #{exn.message} (#{exn.class})")
-                           end
+          constr = synthesize_children(node, skips: [receiver])
+          if block_params
+            block_annotations = source.annotations(block: node, factory: checker.factory, current_module: current_namespace)
+            block_params_ = TypeInference::BlockParams.from_node(block_params, annotations: block_annotations)
 
-                           fallback_to_any node do
-                             Errors::NoMethod.new(node: node, method: method_name, type: expanded_receiver_type)
-                           end
-                         end
-                       end
-                     end
+            block_constr = constr.for_block(
+              block_params: block_params_,
+              block_param_hint: nil,
+              block_annotations: block_annotations,
+              node_type_hint: nil
+            )
 
-      case type
-      when nil, Errors::Base
-        arguments.each do |arg|
-          unless typing.has_type?(arg)
-            if arg.type == :splat
-              type, constr = constr.synthesize(arg.children[0])
-              add_typing(arg, type: AST::Builtin::Array.instance_type(type))
-            else
-              _, constr = constr.synthesize(arg)
+            block_constr.typing.add_context_for_body(node, context: block_constr.context)
+
+            block_params_.params.each do |param|
+              _, block_constr = block_constr.synthesize(param.node, hint: param.type)
+            end
+
+            block_constr.synthesize_block(node: node, block_type_hint: nil, block_body: block_body, topdown_hint: false) do |error|
+              errors << error
             end
           end
         end
 
-        if block_body && block_params
-          unless typing.has_type?(block_body)
-            block_annotations = source.annotations(block: node, builder: checker.builder, current_module: current_namespace)
-            params = TypeInference::BlockParams.from_node(block_params, annotations: block_annotations)
-            pairs = params.each.map {|param| [param, AST::Builtin.any_type]}
-
-            for_block, _ = constr.for_block(block_annotations: block_annotations,
-                                            param_pairs: pairs,
-                                            method_return_type: AST::Builtin.any_type,
-                                            typing: typing)
-
-            for_block.typing.add_context_for_body(node, context: for_block.context)
-
-            for_block.synthesize(block_body)
-          end
-        end
+        constr.add_call(call)
       else
-        Pair.new(type: type, constr: constr)
+        add_call(
+          TypeInference::MethodCall::NoMethodError.new(
+            node: node,
+            context: context.method_context,
+            method_name: method_name,
+            receiver_type: receiver_type,
+            error: Errors::NoMethod.new(node: node, method: method_name, type: receiver_type)
+          )
+        )
       end
     end
 
-    def for_block(block_annotations:, param_pairs:, method_return_type:, typing:)
-      block_type_env = type_env.dup.yield_self do |env|
-        param_pairs.each do |param, type|
-          if param.type
-            env.set(lvar: param.var.name, type: param.type)
-          else
-            env.set(lvar: param.var.name, type: type)
-          end
-        end
+    def type_send(node, send_node:, block_params:, block_body:, unwrap: false)
+      receiver, method_name, *arguments = send_node.children
+      recv_type, constr = receiver ? synthesize(receiver) : [AST::Types::Self.new, self]
 
-        env.with_annotations(
-          lvar_types: block_annotations.lvar_types,
-          ivar_types: block_annotations.ivar_types,
-          const_types: block_annotations.const_types,
-        )
+      if unwrap
+        recv_type = unwrap(recv_type)
       end
 
-      lvar_env = context.lvar_env.pin_assignments.annotate(block_annotations)
+      receiver_type = checker.factory.deep_expand_alias(recv_type)
 
-      return_type = if block_annotations.break_type
-                      union_type(method_return_type, block_annotations.break_type)
-                    else
-                      method_return_type
-                    end
-      Steep.logger.debug("return_type = #{return_type}")
+      type, constr = case receiver_type
+                     when nil
+                       raise
 
-      block_context = TypeInference::Context::BlockContext.new(body_type: block_annotations.block_type)
-      Steep.logger.debug("block_context { body_type: #{block_context.body_type} }")
+                     when AST::Types::Any
+                       constr = constr.synthesize_children(node, skips: [receiver])
+                       constr.add_call(
+                         TypeInference::MethodCall::Untyped.new(
+                           node: node,
+                           context: context.method_context,
+                           method_name: method_name
+                         )
+                       )
 
-      break_context = TypeInference::Context::BreakContext.new(
-        break_type: block_annotations.break_type || method_return_type,
-        next_type: block_annotations.block_type
-      )
-      Steep.logger.debug("break_context { type: #{break_context.break_type} }")
+                     when AST::Types::Void, AST::Types::Bot, AST::Types::Top, AST::Types::Var
+                       constr = constr.synthesize_children(node, skips: [receiver])
+                       constr.add_call(
+                         TypeInference::MethodCall::NoMethodError.new(
+                           node: node,
+                           context: context.method_context,
+                           method_name: method_name,
+                           receiver_type: receiver_type,
+                           error: Errors::NoMethod.new(node: node, method: method_name, type: receiver_type)
+                         )
+                       )
 
-      [self.class.new(
-        checker: checker,
-        source: source,
-        annotations: annotations.merge_block_annotations(block_annotations),
-        typing: typing,
-        context: TypeInference::Context.new(
-          block_context: block_context,
-          method_context: method_context,
-          module_context: module_context,
-          break_context: break_context,
-          self_type: block_annotations.self_type || self_type,
-          type_env: block_type_env,
-          lvar_env: lvar_env
+                     when AST::Types::Self
+                       expanded_self = expand_self(receiver_type)
+
+                       if expanded_self.is_a?(AST::Types::Self)
+                         Steep.logger.debug { "`self` type cannot be resolved to concrete type" }
+
+                         constr = constr.synthesize_children(node, skips: [receiver])
+                         constr.add_call(
+                           TypeInference::MethodCall::NoMethodError.new(
+                             node: node,
+                             context: context.method_context,
+                             method_name: method_name,
+                             receiver_type: receiver_type,
+                             error: Errors::NoMethod.new(node: node, method: method_name, type: receiver_type)
+                           )
+                         )
+                       else
+                         interface = checker.factory.interface(expanded_self,
+                                                               private: !receiver,
+                                                               self_type: AST::Types::Self.new)
+
+                         constr.type_send_interface(node,
+                                                    interface: interface,
+                                                    receiver: receiver,
+                                                    receiver_type: expanded_self,
+                                                    method_name: method_name,
+                                                    arguments: arguments,
+                                                    block_params: block_params,
+                                                    block_body: block_body)
+                       end
+                     else
+                       interface = checker.factory.interface(receiver_type,
+                                                             private: !receiver,
+                                                             self_type: receiver_type)
+
+                       constr.type_send_interface(node,
+                                                  interface: interface,
+                                                  receiver: receiver,
+                                                  receiver_type: receiver_type,
+                                                  method_name: method_name,
+                                                  arguments: arguments,
+                                                  block_params: block_params,
+                                                  block_body: block_body)
+                     end
+
+      Pair.new(type: type, constr: constr)
+    rescue => exn
+      case exn
+      when RBS::NoTypeFoundError, RBS::NoMixinFoundError, RBS::NoSuperclassFoundError, RBS::InvalidTypeApplicationError
+        # ignore known RBS errors.
+      else
+        Steep.log_error(exn, message: "Unexpected error in #type_send: #{exn.message} (#{exn.class})")
+      end
+
+      error = Errors::UnexpectedError.new(node: node, error: exn)
+
+      type_any_rec(node)
+
+      add_call(
+        TypeInference::MethodCall::Error.new(
+          node: node,
+          context: context.method_context,
+          method_name: method_name,
+          receiver_type: receiver_type,
+          errors: [error]
         )
-      ), return_type]
+      )
     end
 
     def expand_self(type)
@@ -2476,63 +2557,54 @@ module Steep
 
           zips.map do |arg_pairs|
             typing.new_child(node_range) do |child_typing|
-              ret = self.with_new_typing(child_typing).try_method_type(
+              self.with_new_typing(child_typing).try_method_type(
                 node,
                 receiver_type: receiver_type,
+                method_name: method_name,
                 method_type: method_type,
                 args: args,
                 arg_pairs: arg_pairs,
                 block_params: block_params,
                 block_body: block_body,
-                child_typing: child_typing,
                 topdown_hint: topdown_hint
               )
-
-              raise unless ret.is_a?(Array) && ret[1].is_a?(TypeConstruction)
-
-              result, constr = ret
-
-              [result, constr, method_type]
             end
           end
         end
       end
 
-      unless results.empty?
-        result, constr, method_type = results.find {|result, _, _| !result.is_a?(Errors::Base) } || results.last
-      else
+      case
+      when results.empty?
         method_type = method.method_types.last
+        all_decls = method.method_types.each.with_object(Set[]) do |method_type, set|
+          set.merge(method_type.method_decls)
+        end
+        error = Errors::IncompatibleArguments.new(node: node, receiver_type: receiver_type, method_type: method_type)
+        call = TypeInference::MethodCall::Error.new(
+          node: node,
+          context: context.method_context,
+          method_name: method_name,
+          receiver_type: receiver_type,
+          return_type: method_type.return_type,
+          errors: [error],
+          method_decls: all_decls
+        )
         constr = self.with_new_typing(typing.new_child(node_range))
-        result = Errors::IncompatibleArguments.new(node: node, receiver_type: receiver_type, method_type: method_type)
+      when (call, constr = results.find {|call, _| call.is_a?(TypeInference::MethodCall::Typed) })
+        # Nop
+      else
+        if results.one?
+          call, constr = results[0]
+        else
+          return
+        end
       end
       constr.typing.save!
 
-      case result
-      when Errors::Base
-        if method.method_types.size == 1
-          typing.add_error result
-          type = case method_type.return_type
-                 when AST::Types::Var
-                   AST::Builtin.any_type
-                 else
-                   method_type.return_type
-                 end
-        else
-          typing.add_error Errors::UnresolvedOverloading.new(node: node,
-                                                             receiver_type: expand_self(receiver_type),
-                                                             method_name: method_name,
-                                                             method_types: method.method_types)
-          type = AST::Builtin.any_type
-        end
-
-        [type,
-         update_lvar_env { constr.context.lvar_env },
-         result]
-      else # Type
-        [result,
-         update_lvar_env { constr.context.lvar_env },
-         nil]
-      end
+      [
+        call,
+        update_lvar_env { constr.context.lvar_env }
+      ]
     end
 
     def check_keyword_arg(receiver_type:, node:, method_type:, constraints:)
@@ -2661,151 +2733,222 @@ module Steep
       nil
     end
 
-    def try_method_type(node, receiver_type:, method_type:, args:, arg_pairs:, block_params:, block_body:, child_typing:, topdown_hint:)
+    def try_method_type(node, receiver_type:, method_name:, method_type:, args:, arg_pairs:, block_params:, block_body:, topdown_hint:)
       fresh_types = method_type.type_params.map {|x| AST::Types::Var.fresh(x)}
       fresh_vars = Set.new(fresh_types.map(&:name))
       instantiation = Interface::Substitution.build(method_type.type_params, fresh_types)
 
-      construction = self.class.new(
-        checker: checker,
-        source: source,
-        annotations: annotations,
-        typing: child_typing,
-        context: context
-      )
+      constr = self
 
-      constr = construction
+      method_type = method_type.instantiate(instantiation)
 
-      method_type.instantiate(instantiation).yield_self do |method_type|
-        constraints = Subtyping::Constraints.new(unknowns: fresh_types.map(&:name))
-        variance = Subtyping::VariableVariance.from_method_type(method_type)
-        occurence = Subtyping::VariableOccurence.from_method_type(method_type)
+      constraints = Subtyping::Constraints.new(unknowns: fresh_types.map(&:name))
+      variance = Subtyping::VariableVariance.from_method_type(method_type)
+      occurence = Subtyping::VariableOccurence.from_method_type(method_type)
 
-        arg_pairs.each do |pair|
-          case pair
-          when Array
-            (arg_node, param_type) = pair
-            param_type = param_type.subst(instantiation)
+      errors = []
 
-            arg_type, constr = if arg_node.type == :splat
-                                 constr.synthesize(arg_node.children[0])
-                               else
-                                 constr.synthesize(arg_node, hint: topdown_hint ? param_type : nil)
-                               end
+      arg_pairs.each do |pair|
+        case pair
+        when Array
+          arg_node, param_type = pair
+          param_type = param_type.subst(instantiation)
 
-            check_relation(sub_type: arg_type, super_type: param_type, constraints: constraints).else do |result|
-              return [Errors::ArgumentTypeMismatch.new(node: arg_node,
+          arg_type, constr = if arg_node.type == :splat
+                               constr.synthesize(arg_node.children[0])
+                             else
+                               constr.synthesize(arg_node, hint: topdown_hint ? param_type : nil)
+                             end
+
+          check_relation(sub_type: arg_type, super_type: param_type, constraints: constraints).else do
+            errors << Errors::ArgumentTypeMismatch.new(node: arg_node,
                                                        receiver_type: receiver_type,
                                                        expected: param_type,
-                                                       actual: arg_type),
-                      constr]
-            end
-          else
-            # keyword
-            result = check_keyword_arg(receiver_type: receiver_type,
-                                       node: pair,
-                                       method_type: method_type,
-                                       constraints: constraints)
+                                                       actual: arg_type)
+          end
+        else
+          # keyword
+          result = constr.check_keyword_arg(receiver_type: receiver_type,
+                                            node: pair,
+                                            method_type: method_type,
+                                            constraints: constraints)
 
-            if result.is_a?(Errors::Base)
-              return [result, constr]
-            end
+          if result.is_a?(Errors::Base)
+            errors << result
           end
         end
+      end
 
-        if block_params && method_type.block
-          block_annotations = source.annotations(block: node, factory: checker.factory, current_module: current_namespace)
-          block_params_ = TypeInference::BlockParams.from_node(block_params, annotations: block_annotations)
+      if block_params
+        # block is given
+        block_annotations = source.annotations(block: node, factory: checker.factory, current_module: current_namespace)
+        block_params_ = TypeInference::BlockParams.from_node(block_params, annotations: block_annotations)
 
-          unless block_params_
-            return [
-              Errors::UnsupportedSyntax.new(
-                node: block_params,
-                message: "Unsupported block params pattern, probably masgn?"
-              ),
-              constr
-            ]
-          end
+        if method_type.block
+          pairs = method_type.block && block_params_&.zip(method_type.block.type.params)
 
-          pairs = block_params_.zip(method_type.block.type.params)
+          if pairs
+            begin
+              block_constr = constr.for_block(
+                block_params: block_params_,
+                block_param_hint: method_type.block.type.params,
+                block_annotations: block_annotations,
+                node_type_hint: method_type.return_type
+              )
+              block_constr = block_constr.with_new_typing(
+                block_constr.typing.new_child(
+                  range: block_constr.typing.block_range(node)
+                )
+              )
 
-          unless pairs
-            return [
-              Errors::IncompatibleBlockParameters.new(node: node, method_type: method_type),
-              constr
-            ]
-          end
+              block_constr.typing.add_context_for_body(node, context: block_constr.context)
 
-          pairs.each do |param, type|
-            if param.type
-              check_relation(sub_type: type, super_type: param.type, constraints: constraints).else do |result|
-                return [
-                  Errors::IncompatibleAssignment.new(
-                    node: param.node,
-                    lhs_type: param.type,
-                    rhs_type: type,
-                    result: result
-                  ),
-                  constr
-                ]
+              pairs.each do |param, type|
+                _, block_constr = block_constr.synthesize(param.node, hint: param.type || type)
+
+                if param.type
+                  check_relation(sub_type: type, super_type: param.type, constraints: constraints).else do |result|
+                    error = Errors::IncompatibleAssignment.new(
+                      node: param.node,
+                      lhs_type: param.type,
+                      rhs_type: type,
+                      result: result
+                    )
+                    errors << error
+                  end
+                end
               end
-            end
-          end
-        end
 
-        case
-        when method_type.block && block_params
-          Steep.logger.debug "block is okay: method_type=#{method_type}"
-          Steep.logger.debug "Constraints = #{constraints}"
+              s = constraints.solution(
+                checker,
+                self_type: self_type,
+                variance: variance,
+                variables: method_type.params.free_variables + method_type.block.type.params.free_variables
+              )
+              method_type = method_type.subst(s)
+              block_constr = block_constr.update_lvar_env {|env| env.subst(s) }
+              if block_body
+                block_body_type = block_constr.synthesize_block(
+                  node: node,
+                  block_type_hint: method_type.block.type.return_type,
+                  block_body: block_body,
+                  topdown_hint: topdown_hint
+                ) do |error|
+                  errors << error
+                end
+              else
+                block_body_type = AST::Builtin.nil_type
+              end
 
-          begin
-            method_type.subst(constraints.solution(checker, self_type: self_type, variance: variance, variables: occurence.params)).yield_self do |method_type|
-              type, _ = constr.type_block(node: node,
-                                          block_param_hint: method_type.block.type.params,
-                                          block_type_hint: method_type.block.type.return_type,
-                                          node_type_hint: method_type.return_type,
-                                          block_params: block_params_,
-                                          block_body: block_body,
-                                          block_annotations: block_annotations,
-                                          topdown_hint: topdown_hint)
-
-              result = check_relation(sub_type: type.return_type,
+              result = check_relation(sub_type: block_body_type,
                                       super_type: method_type.block.type.return_type,
                                       constraints: constraints)
 
               case result
               when Subtyping::Result::Success
-                method_type.return_type.subst(constraints.solution(checker, self_type: self_type, variance: variance, variables: fresh_vars)).yield_self do |ret_type|
-                  ty = if block_annotations.break_type
-                         AST::Types::Union.new(types: [block_annotations.break_type, ret_type])
-                       else
-                         ret_type
-                       end
-                  [ty, constr]
+                s = constraints.solution(checker, self_type: self_type, variance: variance, variables: fresh_vars)
+                method_type = method_type.subst(s)
+
+                return_type = method_type.return_type
+                if break_type = block_annotations.break_type
+                  return_type = union_type(break_type, return_type)
                 end
 
               when Subtyping::Result::Failure
-                [Errors::BlockTypeMismatch.new(node: node,
-                                               expected: method_type.block.type,
-                                               actual: type,
-                                               result: result),
-                 constr]
+                block_type = AST::Types::Proc.new(
+                  params: method_type.block.type.params || block_params.params_type,
+                  return_type: block_body_type
+                )
+                errors << Errors::BlockTypeMismatch.new(node: node,
+                                                        expected: method_type.block.type,
+                                                        actual: block_type,
+                                                        result: result)
+
+                return_type = method_type.return_type
               end
+
+              block_constr.typing.save!
+            rescue Subtyping::Constraints::UnsatisfiableConstraint => exn
+              errors << Errors::UnsatisfiableConstraint.new(
+                node: node,
+                method_type: method_type,
+                var: exn.var,
+                sub_type: exn.sub_type,
+                super_type: exn.super_type,
+                result: exn.result
+              )
+
+              block_constr = constr.for_block(
+                block_params: block_params_,
+                block_param_hint: nil,
+                block_annotations: block_annotations,
+                node_type_hint: nil
+              )
+
+              block_constr.typing.add_context_for_body(node, context: block_constr.context)
+
+              block_params_.params.each do |param|
+                _, block_constr = block_constr.synthesize(param.node, hint: param.type)
+              end
+
+              block_constr.synthesize_block(node: node, block_type_hint: nil, block_body: block_body, topdown_hint: false) do |error|
+                errors << error
+              end
+
+              s = Interface::Substitution.build(method_type.free_variables,
+                                                Array.new(method_type.free_variables.size, AST::Builtin.any_type))
+              method_type = method_type.subst(s)
             end
+          else
+            errors << Errors::UnsupportedSyntax.new(
+              node: block_params,
+              message: "Unsupported block params pattern, probably masgn?"
+            )
 
-          rescue Subtyping::Constraints::UnsatisfiableConstraint => exn
-            [Errors::UnsatisfiableConstraint.new(node: node,
-                                                 method_type: method_type,
-                                                 var: exn.var,
-                                                 sub_type: exn.sub_type,
-                                                 super_type: exn.super_type,
-                                                 result: exn.result),
-             constr]
+            s = constraints.solution(checker, variance: variance, variables: fresh_vars, self_type: self_type)
+            method_type = method_type.subst(s)
           end
+        else
+          # Block is given but method doesn't accept
+          constr = constr.synthesize_children(block_params)
+          constr = constr.synthesize_children(block_body) if block_body
 
-        when method_type.block && args.block_pass_arg
-          begin
-            method_type.subst(constraints.solution(checker, self_type: self_type, variance: variance, variables: occurence.params)).yield_self do |method_type|
+          errors << Errors::UnexpectedBlockGiven.new(
+            node: node,
+            method_type: method_type
+          )
+        end
+      else
+        # block is not given
+        if (!method_type.block || method_type.block.optional?)
+          # Method call without block is allowed
+          unless args.block_pass_arg
+            # OK, without block
+            s = constraints.solution(checker, variance: variance, variables: fresh_vars, self_type: self_type)
+            method_type = method_type.subst(s)
+          else
+            # &block arg is given
+            s = constraints.solution(checker, variance: variance, variables: fresh_vars, self_type: self_type)
+            method_type = method_type.subst(s)
+
+            errors << Errors::UnexpectedBlockGiven.new(
+              node: node,
+              method_type: method_type
+            )
+          end
+        else
+          unless args.block_pass_arg
+            # Required block is missing
+            errors << Errors::RequiredBlockMissing.new(
+              node: node,
+              method_type: method_type
+            )
+
+            s = constraints.solution(checker, variance: variance, variables: fresh_vars, self_type: self_type)
+            method_type = method_type.subst(s)
+          else
+            begin
+              method_type = method_type.subst(constraints.solution(checker, self_type: self_type, variance: variance, variables: occurence.params))
               block_type, constr = constr.synthesize(args.block_pass_arg, hint: topdown_hint ? method_type.block.type : nil)
               result = check_relation(
                 sub_type: block_type,
@@ -2819,68 +2962,48 @@ module Steep
                 constraints: constraints
               )
 
-              case result
-              when Subtyping::Result::Success
-                [
-                  method_type.return_type.subst(constraints.solution(checker, self_type: self_type, variance: variance, variables: fresh_vars)),
-                  constr
-                ]
-
-              when Subtyping::Result::Failure
-                [
-                  Errors::BlockTypeMismatch.new(node: node,
-                                                expected: method_type.block.type,
-                                                actual: block_type,
-                                                result: result),
-                  constr
-                ]
+              result.else do |result|
+                errors << Errors::BlockTypeMismatch.new(node: node,
+                                                        expected: method_type.block.type,
+                                                        actual: block_type,
+                                                        result: result)
               end
+
+              method_type = method_type.subst(constraints.solution(checker, self_type: self_type, variance: variance, variables: method_type.free_variables))
             end
-
-          rescue Subtyping::Constraints::UnsatisfiableConstraint => exn
-            [
-              Errors::UnsatisfiableConstraint.new(node: node,
-                                                  method_type: method_type,
-                                                  var: exn.var,
-                                                  sub_type: exn.sub_type,
-                                                  super_type: exn.super_type,
-                                                  result: exn.result),
-              constr
-            ]
           end
-
-        when (!method_type.block || method_type.block.optional?) && !block_params && !block_body && !args.block_pass_arg
-          # OK, without block
-          [
-            method_type.subst(constraints.solution(checker, variance: variance, variables: fresh_vars, self_type: self_type)).return_type,
-            constr
-          ]
-
-        when !method_type.block && (block_params || args.block_pass_arg)
-          [
-            Errors::UnexpectedBlockGiven.new(
-              node: node,
-              method_type: method_type
-            ),
-            constr
-          ]
-
-        when method_type.block && !method_type.block.optional? && !block_params && !block_body && !args.block_pass_arg
-          [
-            Errors::RequiredBlockMissing.new(
-              node: node,
-              method_type: method_type
-            ),
-            constr
-          ]
-
-        else
-          raise "Unexpected case condition"
         end
       end
+
+      call = if errors.empty?
+               TypeInference::MethodCall::Typed.new(
+                 node: node,
+                 context: context.method_context,
+                 receiver_type: receiver_type,
+                 method_name: method_name,
+                 actual_method_type: method_type,
+                 return_type: return_type || method_type.return_type,
+                 method_decls: method_type.method_decls
+               )
+             else
+               TypeInference::MethodCall::Error.new(
+                 node: node,
+                 context: context.method_context,
+                 receiver_type: receiver_type,
+                 method_name: method_name,
+                 return_type: return_type || method_type.return_type,
+                 method_decls: method_type.method_decls,
+                 errors: errors
+               )
+             end
+
+      [
+        call,
+        constr
+      ]
     end
 
-    def type_block(node:, block_param_hint:, block_type_hint:, node_type_hint:, block_params:, block_body:, block_annotations:, topdown_hint:)
+    def for_block(block_params:, block_param_hint:, block_annotations:, node_type_hint:)
       block_param_pairs = block_param_hint && block_params.zip(block_param_hint)
 
       param_types_hash = {}
@@ -2896,30 +3019,30 @@ module Steep
         end
       end
 
-      lvar_env = context.lvar_env.pin_assignments.yield_self do |env|
-        decls = param_types_hash.each.with_object({}) do |(name, type), hash|
-          hash[name] = TypeInference::LocalVariableTypeEnv::Entry.new(type: type)
-        end
-        env.except(decls.keys).update(assigned_types: decls)
-      end.annotate(block_annotations)
+      decls = param_types_hash.each.with_object({}) do |(name, type), hash|
+        hash[name] = TypeInference::LocalVariableTypeEnv::Entry.new(type: type)
+      end
+      lvar_env = context.lvar_env
+                   .pin_assignments
+                   .except(decls.keys)
+                   .update(assigned_types: decls)
+                   .annotate(block_annotations)
 
       break_type = if block_annotations.break_type
                      union_type(node_type_hint, block_annotations.break_type)
                    else
                      node_type_hint
                    end
-      Steep.logger.debug("return_type = #{break_type}")
 
-      block_context = TypeInference::Context::BlockContext.new(body_type: block_annotations.block_type)
-      Steep.logger.debug("block_context { body_type: #{block_context.body_type} }")
-
+      block_context = TypeInference::Context::BlockContext.new(
+        body_type: block_annotations.block_type
+      )
       break_context = TypeInference::Context::BreakContext.new(
         break_type: break_type,
         next_type: block_context.body_type
       )
-      Steep.logger.debug("break_context { type: #{break_context.break_type} }")
 
-      for_block_body = self.class.new(
+      self.class.new(
         checker: checker,
         source: source,
         annotations: annotations.merge_block_annotations(block_annotations),
@@ -2931,37 +3054,34 @@ module Steep
           break_context: break_context,
           self_type: block_annotations.self_type || self_type,
           type_env: type_env.dup,
-          lvar_env: lvar_env
+          lvar_env: lvar_env,
+          call_context: self.context.call_context
         )
       )
+    end
 
-      for_block_body.typing.add_context_for_body(node, context: for_block_body.context)
-
+    def synthesize_block(node:, block_type_hint:, block_body:, topdown_hint:)
       if block_body
-        body_pair = if (body_type = block_context.body_type)
-                      for_block_body.check(block_body, body_type) do |expected, actual, result|
-                        typing.add_error Errors::BlockTypeMismatch.new(node: block_body,
-                                                                       expected: expected,
-                                                                       actual: actual,
-                                                                       result: result)
-
-                      end
-                    else
-                      for_block_body.synthesize(block_body, hint: topdown_hint ? block_type_hint : nil)
-                    end
+        body_type, _, context =
+          if (body_type = block_context.body_type)
+            check(block_body, body_type) do |expected, actual, result|
+              error = Errors::BlockTypeMismatch.new(node: block_body,
+                                                    expected: expected,
+                                                    actual: actual,
+                                                    result: result)
+              yield(error) if block_given?
+            end
+          else
+            synthesize(block_body, hint: topdown_hint ? block_type_hint : nil)
+          end
 
         range = block_body.loc.expression.end_pos..node.loc.end.begin_pos
-        typing.add_context(range, context: body_pair.context)
-      else
-        body_pair = Pair.new(type: AST::Builtin.nil_type, constr: for_block_body)
-      end
+        typing.add_context(range, context: context)
 
-      body_pair.with(
-        type: AST::Types::Proc.new(
-          params: block_param_hint || block_params.params_type,
-          return_type: body_pair.type
-        )
-      )
+        body_type
+      else
+        AST::Builtin.nil_type
+      end
     end
 
     def each_child_node(node)
@@ -3181,6 +3301,14 @@ module Steep
               end
 
       !nodes.empty? && nodes.all? {|child| child.type == :class || child.type == :module}
+    end
+
+    def type_any_rec(node)
+      add_typing node, type: AST::Builtin.any_type
+
+      each_child_node(node) do |child|
+        type_any_rec(child)
+      end
     end
 
     def fallback_any_rec(node)

--- a/lib/steep/type_inference/context.rb
+++ b/lib/steep/type_inference/context.rb
@@ -80,6 +80,7 @@ module Steep
         end
       end
 
+      attr_reader :call_context
       attr_reader :method_context
       attr_reader :block_context
       attr_reader :break_context
@@ -88,7 +89,7 @@ module Steep
       attr_reader :type_env
       attr_reader :lvar_env
 
-      def initialize(method_context:, block_context:, break_context:, module_context:, self_type:, type_env:, lvar_env:)
+      def initialize(method_context:, block_context:, break_context:, module_context:, self_type:, type_env:, lvar_env:, call_context:)
         @method_context = method_context
         @block_context = block_context
         @break_context = break_context
@@ -96,6 +97,7 @@ module Steep
         @self_type = self_type
         @type_env = type_env
         @lvar_env = lvar_env
+        @call_context = call_context
       end
 
       def with(method_context: self.method_context,
@@ -104,7 +106,8 @@ module Steep
                module_context: self.module_context,
                self_type: self.self_type,
                type_env: self.type_env,
-               lvar_env: self.lvar_env)
+               lvar_env: self.lvar_env,
+               call_context: self.call_context)
         self.class.new(
           method_context: method_context,
           block_context: block_context,
@@ -112,7 +115,8 @@ module Steep
           module_context: module_context,
           self_type: self_type,
           type_env: type_env,
-          lvar_env: lvar_env
+          lvar_env: lvar_env,
+          call_context: call_context
         )
       end
     end

--- a/lib/steep/type_inference/local_variable_type_env.rb
+++ b/lib/steep/type_inference/local_variable_type_env.rb
@@ -114,7 +114,9 @@ module Steep
             relation = Subtyping::Relation.new(sub_type: inner_type, super_type: outer_type)
             constraints = Subtyping::Constraints.new(unknowns: Set.new)
             subtyping.check(relation, constraints: constraints, self_type: self_type).else do |result|
-              yield var, outer_type, inner_type, result
+              if block_given?
+                yield var, outer_type, inner_type, result
+              end
             end
           end
         end
@@ -144,6 +146,13 @@ module Steep
         update(
           declared_types: declared_types.reject {|var, _| variables.include?(var) },
           assigned_types: assigned_types.reject {|var, _| variables.include?(var) }
+        )
+      end
+
+      def subst(s)
+        update(
+          declared_types: declared_types.transform_values {|e| e.update(type: e.type.subst(s)) },
+          assigned_types: assigned_types.transform_values {|e| e.update(type: e.type.subst(s)) }
         )
       end
 

--- a/lib/steep/type_inference/method_call.rb
+++ b/lib/steep/type_inference/method_call.rb
@@ -1,0 +1,116 @@
+module Steep
+  module TypeInference
+    class MethodCall
+      class MethodDecl
+        attr_reader :method_name
+        attr_reader :method_def
+
+        def initialize(method_name:, method_def:)
+          @method_name = method_name
+          @method_def = method_def
+        end
+
+        def hash
+          method_name.hash
+          # RBS::MethodType doesn't have #hash
+        end
+
+        def ==(other)
+          other.is_a?(MethodDecl) && other.method_name == method_name && other.method_def == method_def
+        end
+
+        alias eql? ==
+
+        def method_type
+          method_def.type
+        end
+      end
+
+      MethodContext = Struct.new(:method_name, keyword_init: true) do
+        def to_s
+          "@#{method_name}"
+        end
+      end
+
+      ModuleContext = Struct.new(:type_name, keyword_init: true) do
+        def to_s
+          "@#{type_name}@"
+        end
+      end
+
+      TopLevelContext = Class.new() do
+        def to_s
+          "@<main>"
+        end
+      end
+
+      UnknownContext = Class.new() do
+        def to_s
+          "@<unknown>"
+        end
+      end
+
+
+      class Base
+        attr_reader :node
+        attr_reader :context
+        attr_reader :method_name
+        attr_reader :return_type
+        attr_reader :receiver_type
+
+        def initialize(node:, context:, method_name:, receiver_type:, return_type:)
+          @node = node
+          @context = context
+          @method_name = method_name
+          @receiver_type = receiver_type
+          @return_type = return_type
+        end
+
+        def with_return_type(new_type)
+          dup.tap do |copy|
+            copy.instance_eval do
+              @return_type = new_type
+            end
+          end
+        end
+      end
+
+      class Typed < Base
+        attr_reader :actual_method_type
+        attr_reader :method_decls
+
+        def initialize(node:, context:, method_name:, receiver_type:, actual_method_type:, method_decls:, return_type: actual_method_type.return_type)
+          super(node: node, context: context, method_name: method_name, receiver_type: receiver_type, return_type: return_type)
+          @actual_method_type = actual_method_type
+          @method_decls = method_decls
+        end
+      end
+
+      class Untyped < Base
+        def initialize(node:, context:, method_name:)
+          super(node: node, context: context, method_name: method_name, receiver_type: AST::Types::Any.new, return_type: AST::Types::Any.new)
+        end
+      end
+
+      class NoMethodError < Base
+        attr_reader :error
+
+        def initialize(node:, context:, method_name:, receiver_type:, error:)
+          super(node: node, context: context, method_name: method_name, receiver_type: receiver_type, return_type: AST::Types::Any.new)
+          @error = error
+        end
+      end
+
+      class Error < Base
+        attr_reader :errors
+        attr_reader :method_decls
+
+        def initialize(node:, context:, method_name:, receiver_type:, errors:, method_decls: Set[], return_type: AST::Types::Any.new)
+          super(node: node, context: context, method_name: method_name, receiver_type: receiver_type, return_type: return_type)
+          @method_decls = method_decls
+          @errors = errors
+        end
+      end
+    end
+  end
+end

--- a/test/annotation_parsing_test.rb
+++ b/test/annotation_parsing_test.rb
@@ -39,7 +39,7 @@ class AnnotationParsingTest < Minitest::Test
 
       assert_instance_of Annotation::MethodType, annot
       assert_equal :foo, annot.name
-      assert_equal factory.method_type(RBS::Parser.parse_method_type("(Bar) -> Baz"), self_type: Steep::AST::Types::Self.new),
+      assert_equal factory.method_type(RBS::Parser.parse_method_type("(Bar) -> Baz"), self_type: Steep::AST::Types::Self.new, method_decls: Set[]),
                    annot.type
     end
   end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -102,6 +102,8 @@ end
       EOR
 
         provider.run(line: 1, column: 4).tap do |items|
+          items.find {|item| item.identifier == :class }.inherited?
+
           assert_equal [
             { :identifier=>:class, :inherited_method=>true },
             { :identifier=>:is_a?, :inherited_method=>true },
@@ -112,7 +114,7 @@ end
             { :identifier=>:to_s, :inherited_method=>true },
             { :identifier=>:to_str, :inherited_method=>false }
           ],
-          items.map { |item| { identifier: item.identifier, inherited_method: item.inherited_method } }.sort { |h1, h2| h1[:identifier] <=> h2[:identifier] }
+          items.map { |item| { identifier: item.identifier, inherited_method: item.inherited? } }.sort { |h1, h2| h1[:identifier] <=> h2[:identifier] }
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -470,5 +470,66 @@ module LSPTestHelper
   end
 end
 
+module TypeConstructionHelper
+  Namespace = RBS::Namespace
+
+  Typing = Steep::Typing
+  ConstantEnv = Steep::TypeInference::ConstantEnv
+  TypeEnv = Steep::TypeInference::TypeEnv
+  TypeConstruction = Steep::TypeConstruction
+  Annotation = Steep::AST::Annotation
+  Context = Steep::TypeInference::Context
+  LocalVariableTypeEnv = Steep::TypeInference::LocalVariableTypeEnv
+  AST = Steep::AST
+
+  def with_standard_construction(checker, source)
+    self_type = parse_type("::Object")
+
+    annotations = source.annotations(block: source.node, factory: checker.factory, current_module: Namespace.root)
+    const_env = ConstantEnv.new(factory: factory,
+                                context: [Namespace.root])
+    type_env = TypeEnv.build(annotations: annotations,
+                             subtyping: checker,
+                             const_env: const_env,
+                             signatures: checker.factory.env)
+    lvar_env = LocalVariableTypeEnv.empty(
+      subtyping: checker,
+      self_type: self_type
+    ).annotate(annotations)
+
+    context = Context.new(
+      block_context: nil,
+      method_context: nil,
+      module_context: Context::ModuleContext.new(
+        instance_type: AST::Builtin::Object.instance_type,
+        module_type: AST::Builtin::Object.module_type,
+        implement_name: nil,
+        current_namespace: Namespace.root,
+        const_env: const_env,
+        class_name: AST::Builtin::Object.module_name,
+        instance_definition: checker.factory.definition_builder.build_instance(AST::Builtin::Object.module_name),
+        module_definition: checker.factory.definition_builder.build_singleton(AST::Builtin::Object.module_name)
+      ),
+      break_context: nil,
+      self_type: self_type,
+      type_env: type_env,
+      lvar_env: lvar_env
+    )
+    typing = Typing.new(source: source, root_context: context)
+
+    construction = TypeConstruction.new(checker: checker,
+                                        source: source,
+                                        annotations: annotations,
+                                        context: context,
+                                        typing: typing)
+
+    yield construction, typing
+  end
+
+  def assert_no_error(typing)
+    assert_instance_of Typing, typing
+    assert_predicate typing.errors.map {|e| StringIO.new().tap {|io| e.print_to(io) }.string }, :empty?
+  end
+end
 
 TestHelper.timeout = ENV["CI"] ? 50 : 10

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -438,7 +438,7 @@ module FactoryHelper
 
   def parse_method_type(string, factory: self.factory, variables: [], self_type: Steep::AST::Types::Self.new)
     type = RBS::Parser.parse_method_type(string, variables: variables)
-    factory.method_type type, self_type: self_type
+    factory.method_type type, self_type: self_type, method_decls: Set[]
   end
 end
 

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5,6 +5,7 @@ class TypeConstructionTest < Minitest::Test
   include TypeErrorAssertions
   include FactoryHelper
   include SubtypingHelper
+  include TypeConstructionHelper
 
   Namespace = RBS::Namespace
 
@@ -59,50 +60,6 @@ end
     end
 
     super(*files, &block)
-  end
-
-  def with_standard_construction(checker, source)
-    self_type = parse_type("::Object")
-
-    annotations = source.annotations(block: source.node, factory: checker.factory, current_module: Namespace.root)
-    const_env = ConstantEnv.new(factory: factory,
-                                context: [Namespace.root])
-    type_env = TypeEnv.build(annotations: annotations,
-                             subtyping: checker,
-                             const_env: const_env,
-                             signatures: checker.factory.env)
-    lvar_env = LocalVariableTypeEnv.empty(
-      subtyping: checker,
-      self_type: self_type
-    ).annotate(annotations)
-
-    context = Context.new(
-      block_context: nil,
-      method_context: nil,
-      module_context: Context::ModuleContext.new(
-        instance_type: AST::Builtin::Object.instance_type,
-        module_type: AST::Builtin::Object.module_type,
-        implement_name: nil,
-        current_namespace: Namespace.root,
-        const_env: const_env,
-        class_name: AST::Builtin::Object.module_name,
-        instance_definition: checker.factory.definition_builder.build_instance(AST::Builtin::Object.module_name),
-        module_definition: checker.factory.definition_builder.build_singleton(AST::Builtin::Object.module_name)
-      ),
-      break_context: nil,
-      self_type: self_type,
-      type_env: type_env,
-      lvar_env: lvar_env
-    )
-    typing = Typing.new(source: source, root_context: context)
-
-    construction = TypeConstruction.new(checker: checker,
-                                        source: source,
-                                        annotations: annotations,
-                                        context: context,
-                                        typing: typing)
-
-    yield construction, typing
   end
 
   def test_lvar_with_annotation
@@ -2562,11 +2519,6 @@ end
         end
       end
     end
-  end
-
-  def assert_no_error(typing)
-    assert_instance_of Typing, typing
-    assert_operator typing.errors.map {|e| StringIO.new().tap {|io| e.print_to(io) }.string }, :empty?
   end
 
   def test_void2

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -11,7 +11,7 @@ class TypeFactoryTest < Minitest::Test
 
   def assert_overload_with(c, *types)
     types = types.map do |s|
-      factory.method_type(parse_method_type(s), self_type: Steep::AST::Types::Self.new, subst2: nil)
+      factory.method_type(parse_method_type(s), self_type: Steep::AST::Types::Self.new, subst2: nil, method_decls: Set[])
     end
 
     assert_equal Set.new(types), Set.new(c.method_types), "Expected: { #{types.join(" | ")} }, Actual: #{c.to_s}"
@@ -19,7 +19,7 @@ class TypeFactoryTest < Minitest::Test
 
   def assert_overload_including(c, *types)
     types = types.map do |s|
-      factory.method_type(parse_method_type(s), self_type: Steep::AST::Types::Self.new, subst2: nil)
+      factory.method_type(parse_method_type(s), self_type: Steep::AST::Types::Self.new, subst2: nil, method_decls: Set[])
     end
 
     assert_operator Set.new(types),
@@ -215,19 +215,19 @@ class TypeFactoryTest < Minitest::Test
     with_factory() do |factory|
       self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
 
-      factory.method_type(parse_method_type("[A] (A) { (A, B) -> nil } -> void"), self_type: self_type).yield_self do |type|
+      factory.method_type(parse_method_type("[A] (A) { (A, B) -> nil } -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
         assert_equal "[A] (A) { (A, B) -> nil } -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[A] (A) -> void"), self_type: self_type).yield_self do |type|
+      factory.method_type(parse_method_type("[A] (A) -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
         assert_equal "[A] (A) -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[A] () ?{ () -> A } -> void"), self_type: self_type).yield_self do |type|
+      factory.method_type(parse_method_type("[A] () ?{ () -> A } -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
         assert_equal "[A] () ?{ () -> A } -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[X] (X) -> void"), self_type: self_type).yield_self do |type|
+      factory.method_type(parse_method_type("[X] (X) -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
         assert_match(/\[X\((\d+)\)\] \(X\(\1\)\) -> void/, type.to_s)
       end
     end
@@ -238,19 +238,19 @@ class TypeFactoryTest < Minitest::Test
       self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
 
       parse_method_type("[A] (A) { (A, B) -> nil } -> void").tap do |original|
-        type = factory.method_type_1(factory.method_type(original, self_type: self_type),
+        type = factory.method_type_1(factory.method_type(original, self_type: self_type, method_decls: Set[]),
                                      self_type: self_type)
         assert_equal original, type
       end
 
       parse_method_type("[A] (A) -> void").tap do |original|
-        type = factory.method_type_1(factory.method_type(original, self_type: self_type),
+        type = factory.method_type_1(factory.method_type(original, self_type: self_type, method_decls: Set[]),
                                      self_type: self_type)
         assert_equal original, type
       end
 
       parse_method_type("[A] () ?{ () -> A } -> void").tap do |original|
-        type = factory.method_type_1(factory.method_type(original, self_type: self_type),
+        type = factory.method_type_1(factory.method_type(original, self_type: self_type, method_decls: Set[]),
                                      self_type: self_type)
         assert_equal original, type
       end

--- a/test/typing_test.rb
+++ b/test/typing_test.rb
@@ -23,7 +23,8 @@ class TypingTest < Minitest::Test
                              module_context: nil,
                              self_type: parse_type("::Object"),
                              type_env: nil,
-                             lvar_env: nil)
+                             lvar_env: nil,
+                             call_context: Steep::TypeInference::MethodCall::TopLevelContext.new)
   end
 
   def test_1


### PR DESCRIPTION
Introduces an intermediate data structure `MethodCall` that records which methods are called. This is to calculate statistics data and implementing LSP features (jump to definition, ...).