### PR TITLE
Type constant parts

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1311,16 +1311,26 @@ module Steep
         when :self
           add_typing node, type: AST::Types::Self.new
 
+        when :cbase
+          add_typing node, type: AST::Types::Void.new
+
         when :const
-          const_name = module_name_from_node(node)
+          parent = node.children[0]
+          if parent
+            _, constr = synthesize(parent)
+          else
+            constr = self
+          end
+
+          const_name = constr.module_name_from_node(node)
 
           if const_name
             type = type_env.get(const: const_name) do
-              fallback_to_any node
+              constr.fallback_to_any(node)
             end
-            add_typing node, type: type
+            constr.add_typing(node, type: type)
           else
-            fallback_to_any node
+            constr.fallback_to_any(node)
           end
 
         when :casgn

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6239,4 +6239,33 @@ test.foo
       end
     end
   end
+
+  def test_const
+    with_checker(<<RBS) do |checker|
+class Nested
+  module Consta
+    class Nt
+    end
+  end
+end
+RBS
+      source = parse_ruby(<<-RUBY)
+::Nested::Consta::Nt
+Nested::Consta::Nt
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        typing.type_of(node: dig(source.node, 0, 0, 0, 0))
+        typing.type_of(node: dig(source.node, 0, 0, 0))
+        typing.type_of(node: dig(source.node, 0, 0))
+        typing.type_of(node: dig(source.node, 0))
+
+        typing.type_of(node: dig(source.node, 1, 0, 0))
+        typing.type_of(node: dig(source.node, 1, 0))
+        typing.type_of(node: dig(source.node, 1))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add types for constant parts.

```ruby
::A::B::C
^^^^^^^^^   -> Has type
^^^^^^      -> No type has been assigned! 🤯 
```