### PR TITLE
Print environment paths in `project` command

### DIFF
--- a/lib/steep/drivers/print_project.rb
+++ b/lib/steep/drivers/print_project.rb
@@ -47,6 +47,17 @@ module Steep
           target.options.libraries.each do |lib|
             stdout.puts "      - #{lib}"
           end
+          stdout.puts "    library dirs:"
+          Project::Target.construct_env_loader(options: target.options).tap do |loader|
+            loader.each_dir do |lib, path|
+              case lib
+              when :core
+                stdout.puts "      - core: #{path}"
+              else
+                stdout.puts "      - #{lib.name}: #{path}"
+              end
+            end
+          end
         end
 
         0


### PR DESCRIPTION
`steep project` prints the directories to load library RBSs from for troubleshooting.

Example:

```
$ bundle exec steep project
Target:
  app:
    sources:
      patterns:
        - lib
      ignores:
      files:
        - lib/conference.rb
    signatures:
      patterns:
        - sig
      files:
        - sig/conference.rbs
    libraries:
      - set
      - pathname
    library dirs:
      - core: /Users/soutaro/src/steep/vendor/bundle/ruby/2.7.0/gems/rbs-0.16.0/core
      - set: /Users/soutaro/src/steep/vendor/bundle/ruby/2.7.0/gems/rbs-0.16.0/stdlib/set/0
      - pathname: /Users/soutaro/src/steep/vendor/bundle/ruby/2.7.0/gems/rbs-0.16.0/stdlib/pathname/0
```