### PR TITLE
More flexible record typing

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -342,23 +342,21 @@ module Steep
                   constraints: constraints)
 
           when relation.sub_type.is_a?(AST::Types::Record) && relation.super_type.is_a?(AST::Types::Record)
-            if Set.new(relation.sub_type.elements.keys).superset?(Set.new(relation.super_type.elements.keys))
-              keys = relation.super_type.elements.keys
-              type_pairs = keys.map {|key| [relation.sub_type.elements[key], relation.super_type.elements[key]] }
-              results = type_pairs.flat_map do |t1, t2|
-                relation = Relation.new(sub_type: t1, super_type: t2)
-                [check(relation, self_type: self_type, assumption: assumption, trace: trace, constraints: constraints),
-                 check(relation.flip, self_type: self_type, assumption: assumption, trace: trace, constraints: constraints)]
-              end
+            keys = relation.super_type.elements.keys
+            relations = keys.map {|key|
+              Relation.new(
+                sub_type: relation.sub_type.elements[key] || AST::Builtin.nil_type,
+                super_type: relation.super_type.elements[key]
+              )
+            }
+            results = relations.map do |relation|
+              check(relation, self_type: self_type, assumption: assumption, trace: trace, constraints: constraints)
+            end
 
-              if results.all?(&:success?)
-                success(constraints: constraints)
-              else
-                results.find(&:failure?)
-              end
+            if results.all?(&:success?)
+              success(constraints: constraints)
             else
-              failure(error: Result::Failure::UnknownPairError.new(relation: relation),
-                      trace: trace)
+              results.find(&:failure?)
             end
 
           when relation.sub_type.is_a?(AST::Types::Record) && relation.super_type.is_a?(AST::Types::Name::Base)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3491,6 +3491,8 @@ module Steep
     end
 
     def try_hash_type(node, hint)
+      hint = expand_alias(hint)
+
       case hint
       when AST::Types::Record
         typing.new_child(node.loc.expression.yield_self {|l| l.begin_pos..l.end_pos }) do |child_typing|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -277,7 +277,7 @@ end
 class Regexp
 end
 
-class Array[A]
+class Array[unchecked out A]
   def initialize: () -> untyped
                 | (Integer, A) -> untyped
                 | (Integer) -> untyped

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6467,4 +6467,19 @@ end
       end
     end
   end
+
+  def test_typing_record_nilable_attribute
+    with_checker() do |checker|
+      source = parse_ruby(<<-RUBY)
+# @type var x: { foo: Integer? }
+x = { }
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6431,6 +6431,24 @@ x = "foo"
     end
   end
 
+  def test_typing_record_union_alias
+    with_checker(<<RBS) do |checker|
+type foo_bar = { foo: String, bar: Integer } | String
+RBS
+      source = parse_ruby(<<-RUBY)
+# @type var x: foo_bar
+x = { foo: "hello", bar: 42 }
+x = "foo"
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_typing_record_map1
     with_checker() do |checker|
       source = parse_ruby(<<-RUBY)


### PR DESCRIPTION
* Support alias to record types (bug fix!)
* Record types are now co-variant
* Allows skipping `nil`-able attributes

```
# @type var x: { name: String, email: String? }
x = { name: "foo", email: "foo@example.com" }          # OK
x = { name: "foo", email: nil }                        # OK
x = { name: "foo" }                                    # OK 🐕 
```