### PR TITLE
Improve `&&` and `||` typing

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -368,6 +368,8 @@ module Steep
             ]
           when AST::Types::Name::Alias
             unwrap_optional(expand_alias(type))
+          when AST::Types::Boolean
+            [AST::Builtin.true_type, AST::Builtin.false_type]
           else
             [type, nil]
           end

--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -59,15 +59,16 @@ module Steep
         end
 
         class Env < Base
-          attr_reader :truthy, :falsy
+          attr_reader :truthy, :falsy, :type
 
-          def initialize(truthy:, falsy:, location: nil)
+          def initialize(truthy:, falsy:, type:, location: nil)
             @truthy = truthy
             @falsy = falsy
+            @type = type
           end
 
           def ==(other)
-            other.is_a?(Env) && other.truthy == truthy && other.falsy == falsy
+            other.is_a?(Env) && other.truthy == truthy && other.falsy == falsy && other.type == type
           end
 
           alias eql? ==
@@ -75,6 +76,12 @@ module Steep
           def hash
             self.class.hash ^ truthy.hash ^ falsy.hash
           end
+
+          def inspect
+            "#<Steep::AST::Types::Env @type=#{type}, @truthy=..., @falsy=...>"
+          end
+
+          alias to_s inspect
         end
       end
     end

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -41,8 +41,11 @@ module Steep
 
         if type.is_a?(AST::Types::Logic::Base)
           vars.each do |var_name|
-            truthy_env = truthy_env.assign!(var_name, node: node, type: AST::Builtin.true_type)
-            falsy_env = truthy_env.assign!(var_name, node: node, type: AST::Builtin.false_type)
+            var_type = truthy_env[var_name]
+            truthy_type, falsy_type = factory.unwrap_optional(var_type)
+            falsy_type ||= AST::Builtin.nil_type
+            truthy_env = truthy_env.assign!(var_name, node: node, type: truthy_type) {|_, type, _| type }
+            falsy_env = truthy_env.assign!(var_name, node: node, type: falsy_type) {|_, type, _| type }
           end
 
           case type


### PR DESCRIPTION
`condition:` keyword argument is true if the node is in the _conditional_ context.