### PR TITLE
Type-case based on literal value

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -423,6 +423,14 @@ module Steep
                     return_type: AST::Types::Logic::ArgIsReceiver.new(location: method_type.type.return_type.location)
                   )
                 )
+              when RBS::BuiltinNames::Object.name, RBS::BuiltinNames::String.name, RBS::BuiltinNames::Integer.name, RBS::BuiltinNames::Symbol.name,
+                RBS::BuiltinNames::TrueClass.name, RBS::BuiltinNames::FalseClass.name, TypeName("::NilClass")
+                # Value based type-case works on literal types which is available for String, Integer, Symbol, TrueClass, FalseClass, and NilClass
+                return method_type.with(
+                  type: method_type.type.with(
+                    return_type: AST::Types::Logic::ArgEqualsReceiver.new(location: method_type.type.return_type.location)
+                  )
+                )
               end
             end
           end

--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -58,6 +58,12 @@ module Steep
           end
         end
 
+        class ArgEqualsReceiver < Base
+          def initialize(location: nil)
+            @location = location
+          end
+        end
+
         class Env < Base
           attr_reader :truthy, :falsy, :type
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1685,6 +1685,7 @@ module Steep
                   falsy_env = cond_vars.inject(falsy_env) do |env, var|
                     env.assign!(var, node: test_node, type: env[first_var])
                   end
+
                   test_envs << truthy_env
                   test_constr = test_constr.update_lvar_env { falsy_env }
                 end

--- a/smoke/type_case/a.rb
+++ b/smoke/type_case/a.rb
@@ -16,7 +16,7 @@ end
 
 case x
 when 1
-  # !expects NoMethodError: type=(::Integer | ::String | ::Symbol), method=foobar
+  # !expects NoMethodError: type=1, method=foobar
   x.foobar
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -219,6 +219,7 @@ class Object < BasicObject
   def nil?: -> bool
   def itself: -> self
   def is_a?: (Module) -> bool
+  def ===: (untyped) -> bool
 
 private
   def require: (String) -> void
@@ -246,6 +247,8 @@ end
 class Numeric
   def `+`: (Numeric) -> Numeric
   def to_int: -> Integer
+
+  def zero?: () -> bool
 end
 
 class Integer < Numeric


### PR DESCRIPTION
Steep now analyzes case-when exhaustiveness based on value equality with literal types.

```ruby
# @type var x: :foo | :bar | nil | Integer
x = nil 

# @type var a: bool
a = case x
    when nil
      true    # x: nil
    when :foo
      false   # x: :foo
    when Symbol
      true    # x: :bar
    when Integer
      false   # x: Integer
    end       # And this case is exhaustive! ❗ 
```