### PR TITLE
Do not cast `untyped || something` to bool type

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1580,7 +1580,7 @@ module Steep
                   end
 
             type = case
-                   when check_relation(sub_type: left_type, super_type: AST::Builtin.bool_type).success?
+                   when check_relation(sub_type: left_type, super_type: AST::Builtin.bool_type).success? && !left_type.is_a?(AST::Types::Any)
                      AST::Builtin.bool_type
                    else
                      union_type(left_type, right_type)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3913,9 +3913,12 @@ EOF
       source = parse_ruby(<<EOF)
 # @type var x: String?
 x = nil
+# @type var y: untyped
+y = _ = nil
 
 a = x || "foo"
 b = "foo" || x
+c = y || "foo"
 EOF
 
       with_standard_construction(checker, source) do |construction, typing|
@@ -3924,6 +3927,7 @@ EOF
         assert_no_error typing
         assert_equal parse_type("::String"), pair.context.lvar_env[:a]
         assert_equal parse_type("::String?"), pair.context.lvar_env[:b]
+        assert_equal parse_type("untyped"), pair.context.lvar_env[:c]
       end
     end
   end


### PR DESCRIPTION
# Problem


Steep casts `untyped || something` to bool type, but I think it is not the expected behavior.
For example:

```ruby
# test.rb

# @type var x: untyped
a = _ = nil
b = a || 42
b[0]
```

```ruby
# Steepfile
target :lib do
  check 'test.rb'
end
```

```console
$ steep check
test.rb:6:0: NoMethodError: type=bool, method=[] (b[0])
```

In this case, I expect `b` is also `untyped` because it is introduced by `a` (== `untyped`). But actually it is `bool`. So I got the `NoMethodError` unexpectedly.


# Solution


Stop casting `x || y` to `bool` type if the LHS (`x`) is `untyped`.