### PR TITLE
Fix RBS error handling

### DIFF
--- a/lib/steep/project/source_file.rb
+++ b/lib/steep/project/source_file.rb
@@ -94,13 +94,6 @@ module Steep
         parse(subtyping.factory) do |source|
           typing = self.class.type_check(source, subtyping: subtyping)
           @status = TypeCheckStatus.new(typing: typing, source: source, timestamp: now)
-        rescue RBS::NoTypeFoundError,
-          RBS::NoMixinFoundError,
-          RBS::NoSuperclassFoundError,
-          RBS::DuplicatedMethodDefinitionError,
-          RBS::InvalidTypeApplicationError => exn
-          # Skip logging known signature errors (they are handled with load_signatures(validate: true))
-          @status = TypeCheckErrorStatus.new(error: exn, timestamp: now)
         rescue => exn
           Steep.log_error(exn)
           @status = TypeCheckErrorStatus.new(error: exn, timestamp: now)

--- a/test/project_file_test.rb
+++ b/test/project_file_test.rb
@@ -62,7 +62,7 @@ class ProjectFileTest < Minitest::Test
 
   def test_source_file_signature_invalid
     with_checker <<RBS do |checker|
-class Foo < Bar
+class Foo < Bar   # Bar is undefined
 end
 RBS
       file = Project::SourceFile.new(path: Pathname("lib/foo.rb"))
@@ -70,7 +70,8 @@ RBS
 
       assert file.type_check(checker, Time.now), "returns true if contains some update"
 
-      assert_instance_of Project::SourceFile::TypeCheckErrorStatus, file.status
+      assert_instance_of Project::SourceFile::TypeCheckStatus, file.status
+      refute_empty file.errors
     end
   end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -7139,4 +7139,27 @@ RUBY
       end
     end
   end
+
+  def test_rescue_rbs_errors
+    with_checker(<<RBS) do |checker|
+interface _Hello
+  def to_s: () -> String
+  def to_s: () -> String
+end
+RBS
+      source = parse_ruby(<<'RUBY')
+# @type var x: _Hello
+x = ""
+
+x.to_s()
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_typing_error(typing) do |error|
+          assert_instance_of Diagnostic::Ruby::UnexpectedError, error
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Report with `UnexpectedError` diagnostics, instead of ignoring them.