### PR TITLE
Add validations for module-self-types and instance variables

### DIFF
--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -237,6 +237,25 @@ module Steep
           "Module self type constraint in type `#{name}` doesn't satisfy: `#{relation}`"
         end
       end
+
+      class InstanceVariableTypeError < Base
+        attr_reader :name
+        attr_reader :variable
+        attr_reader :var_type
+        attr_reader :parent_type
+
+        def initialize(name:, location:, var_type:, parent_type:)
+          super(location: location)
+
+          @name = name
+          @var_type = var_type
+          @parent_type = parent_type
+        end
+
+        def header_line
+          "Instance variable cannot have different type with parents: #{var_type} <=> #{parent_type}"
+        end
+      end
     end
   end
 end

--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -219,6 +219,24 @@ module Steep
           "The variance of type parameter `#{param.name}` is #{param.variance}, but used in incompatible position here"
         end
       end
+
+      class ModuleSelfTypeError < Base
+        attr_reader :name
+        attr_reader :ancestor
+        attr_reader :relation
+
+        def initialize(name:, ancestor:, relation:, location:)
+          super(location: location)
+
+          @name = name
+          @ancestor = ancestor
+          @relation = relation
+        end
+
+        def header_line
+          "Module self type constraint in type `#{name}` doesn't satisfy: `#{relation}`"
+        end
+      end
     end
   end
 end

--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -61,15 +61,92 @@ module Steep
         validator.validate_type type, context: [RBS::Namespace.root]
       end
 
+      def ancestor_to_type(ancestor)
+        case ancestor
+        when RBS::Definition::Ancestor::Instance
+          args = ancestor.args.map {|type| checker.factory.type(type) }
+
+          case
+          when ancestor.name.interface?
+            AST::Types::Name::Interface.new(name: ancestor.name, args: args, location: nil)
+          when ancestor.name.class?
+            AST::Types::Name::Instance.new(name: ancestor.name, args: args, location: nil)
+          else
+            raise "#{ancestor.name}"
+          end
+        else
+          raise "Unexpected ancestor: #{ancestor.inspect}"
+        end
+      end
+
+      def mixin_constraints(definition, mixin_ancestors, immediate_self_types:)
+        relations = []
+
+        self_type = checker.factory.type(definition.self_type)
+        if immediate_self_types && !immediate_self_types.empty?
+          self_type = AST::Types::Intersection.build(
+            types: immediate_self_types.map {|st| ancestor_to_type(st) }.push(self_type),
+            location: nil
+          )
+        end
+
+        mixin_ancestors.each do |ancestor|
+          args = ancestor.args.map {|type| checker.factory.type(type) }
+          ancestor_ancestors = builder.ancestor_builder.one_instance_ancestors(ancestor.name)
+          self_constraints = ancestor_ancestors.self_types.map do |self_ancestor|
+            s = Interface::Substitution.build(ancestor_ancestors.params, args)
+            ancestor_to_type(self_ancestor).subst(s)
+          end
+
+          self_constraints.each do |constraint|
+            relations << [
+              Subtyping::Relation.new(sub_type: self_type, super_type: constraint),
+              ancestor
+            ]
+          end
+        end
+
+        relations
+      end
+
       def validate_one_class(name)
         rescue_validation_errors(name) do
           Steep.logger.debug "Validating class definition `#{name}`..."
           Steep.logger.tagged "#{name}" do
-            builder.build_instance(name).each_type do |type|
-              validate_type type
+            builder.build_instance(name).tap do |definition|
+              ancestors = builder.ancestor_builder.one_instance_ancestors(name)
+              mixin_constraints(definition, ancestors.included_modules, immediate_self_types: ancestors.self_types).each do |relation, ancestor|
+                checker.check(relation, self_type: nil, constraints: Subtyping::Constraints.empty).else do
+                  @errors << Diagnostic::Signature::ModuleSelfTypeError.new(
+                    name: name,
+                    location: ancestor.source&.location || raise,
+                    ancestor: ancestor,
+                    relation: relation
+                  )
+                end
+              end
+
+              definition.each_type do |type|
+                validate_type type
+              end
             end
-            builder.build_singleton(name).each_type do |type|
-              validate_type type
+
+            builder.build_singleton(name).tap do |definition|
+              ancestors = builder.ancestor_builder.one_singleton_ancestors(name)
+              mixin_constraints(definition, ancestors.extended_modules, immediate_self_types: ancestors.self_types).each do |relation, ancestor|
+                checker.check(relation, self_type: nil, constraints: Subtyping::Constraints.empty).else do
+                  @errors << Diagnostic::Signature::ModuleSelfTypeError.new(
+                    name: name,
+                    location: ancestor.source&.location || raise,
+                    ancestor: ancestor,
+                    relation: relation
+                  )
+                end
+              end
+
+              definition.each_type do |type|
+                validate_type type
+              end
             end
           end
         end

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -9,6 +9,21 @@ module Steep
         @cache = {}
       end
 
+      def each_ancestor(ancestors, &block)
+        if block_given?
+          if ancestors.super_class
+            yield ancestors.super_class
+          end
+          ancestors.each_included_module(&block)
+          ancestors.each_included_interface(&block)
+          ancestors.each_prepended_module(&block)
+          ancestors.each_extended_module(&block)
+          ancestors.each_extended_interface(&block)
+        else
+          enum_for :each_ancestor, ancestors
+        end
+      end
+
       def instance_super_types(type_name, args:)
         ancestors = factory.definition_builder.ancestor_builder.one_instance_ancestors(type_name)
 
@@ -17,7 +32,7 @@ module Steep
                   RBS::Substitution.build(ancestors.params, args_)
                 end
 
-        ancestors.each_ancestor.map do |ancestor|
+        each_ancestor(ancestors).map do |ancestor|
           name = ancestor.name
 
           case ancestor

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -357,8 +357,133 @@ end
     end
   end
 
-  def test_validate_module
-    skip "Not implemented yet"
+  def test_validate_mixin_class
+    with_checker <<-EOF do |checker|
+interface _FooEach[A]
+  def each: () { (A) -> void } -> void
+end
+
+module Enum[A] : _FooEach[A]
+  def count: () -> Integer
+end
+
+class A
+  include Enum[Integer]
+
+  def each: () { (Integer) -> void } -> void
+end
+
+class B
+  include Enum[Integer]
+end
+
+class C
+  include Enum[Integer]
+
+  def each: () { (String, Integer) -> void } -> void
+end
+
+class D
+  extend Enum[D]
+
+  def self.each: () { (D) -> void } -> Array[D]
+end
+
+class E
+  extend Enum[String]
+end
+    EOF
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::A"))
+
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::B"))
+
+        assert_predicate validator, :has_error?
+        assert_any!(validator.each_error, size: 1) do |error|
+          assert_instance_of Diagnostic::Signature::ModuleSelfTypeError, error
+        end
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::C"))
+
+        assert_predicate validator, :has_error?
+        assert_any!(validator.each_error, size: 1) do |error|
+          assert_instance_of Diagnostic::Signature::ModuleSelfTypeError, error
+        end
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::D"))
+
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::E"))
+
+        assert_predicate validator, :has_error?
+        assert_any!(validator.each_error, size: 1) do |error|
+          assert_instance_of Diagnostic::Signature::ModuleSelfTypeError, error
+        end
+      end
+    end
+  end
+
+  def test_validate_mixin_module
+    with_checker <<-EOF do |checker|
+interface _FooEach[A]
+  def each: () { (A) -> void } -> void
+end
+
+module Enum[A] : _FooEach[A]
+  def count: () -> Integer
+end
+
+module ArrayExt[A] : Array[A]
+end
+
+module A
+  include Enum[String]
+
+  def each: () { (String) -> void } -> void
+end
+
+module B : Array[String]
+  include ArrayExt[String]
+end
+
+module C
+  include ArrayExt[Integer]
+end
+    EOF
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::A"))
+
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::B"))
+
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::C"))
+
+        assert_predicate validator, :has_error?
+        assert_any!(validator.each_error, size: 1) do |error|
+          assert_instance_of Diagnostic::Signature::ModuleSelfTypeError, error
+        end
+      end
+    end
   end
 
   def test_validate_instance_variables


### PR DESCRIPTION
RBS allows declaring _module-self-types_ which is a requirement for classes or modules to mix-in the module. This PR implements a validation if the requirement is satisfied.

This PR also adds type checking for types of instance variables.