### PR TITLE
Let TypeCheckWorker handle workspace/symbol request

### DIFF
--- a/lib/steep/index/signature_symbol_provider.rb
+++ b/lib/steep/index/signature_symbol_provider.rb
@@ -33,7 +33,7 @@ module Steep
         end
       end
 
-      def query_symbol(query)
+      def query_symbol(query, assignment:)
         symbols = []
 
         indexes.each do |index|
@@ -46,6 +46,8 @@ module Steep
               name = entry.type_name.name.to_s
 
               entry.declarations.each do |decl|
+                next unless assignment =~ decl.location.buffer.name
+
                 case decl
                 when RBS::AST::Declarations::Class
                   symbols << SymbolInformation.new(
@@ -89,6 +91,8 @@ module Steep
               container_name = entry.method_name.type_name.relative!.to_s
 
               entry.declarations.each do |decl|
+                next unless assignment =~ decl.location.buffer.name
+
                 case decl
                 when RBS::AST::Members::MethodDefinition
                   symbols << SymbolInformation.new(
@@ -126,6 +130,8 @@ module Steep
               next unless SignatureSymbolProvider.test_const_name(query, entry.const_name)
 
               entry.declarations.each do |decl|
+                next unless assignment =~ decl.location.buffer.name
+
                 symbols << SymbolInformation.new(
                   name: entry.const_name.name.to_s,
                   location: decl.location,
@@ -137,6 +143,8 @@ module Steep
               next unless SignatureSymbolProvider.test_global_name(query, entry.global_name)
 
               entry.declarations.each do |decl|
+                next unless assignment =~ decl.location.buffer.name
+
                 symbols << SymbolInformation.new(
                   name: decl.name.to_s,
                   location: decl.location,

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -220,11 +220,16 @@ module Steep
           # Ignores open notification
 
         when "workspace/symbol"
-          # send_request(message, worker: signature_worker) do |handler|
-          #   handler.on_completion do |response|
-          #     write_queue << response
-          #   end
-          # end
+          send_request(message, workers: typecheck_workers) do |handler|
+            handler.on_completion do |*responses|
+              result = responses.flat_map {|resp| resp[:result] || [] }
+
+              write_queue << {
+                id: handler.request_id,
+                result: result
+              }
+            end
+          end
 
         when "workspace/executeCommand"
           case message[:params][:command]

--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -12,6 +12,13 @@ module Steep
           @diagnostics = diagnostics
           @last_builder = last_builder
         end
+
+        def rbs_index
+          @rbs_index ||= Index::RBSIndex.new().tap do |index|
+            builder = Index::RBSIndex::Builder.new(index: index)
+            builder.env(last_builder.env)
+          end
+        end
       end
 
       class AncestorErrorStatus
@@ -22,6 +29,13 @@ module Steep
           @changed_paths = changed_paths
           @diagnostics = diagnostics
           @last_builder = last_builder
+        end
+
+        def rbs_index
+          @rbs_index ||= Index::RBSIndex.new().tap do |index|
+            builder = Index::RBSIndex::Builder.new(index: index)
+            builder.env(last_builder.env)
+          end
         end
       end
 
@@ -35,6 +49,13 @@ module Steep
 
         def subtyping
           @subtyping ||= Subtyping::Check.new(factory: AST::Types::Factory.new(builder: builder))
+        end
+
+        def rbs_index
+          @rbs_index ||= Index::RBSIndex.new().tap do |index|
+            builder = Index::RBSIndex::Builder.new(index: index)
+            builder.env(self.builder.env)
+          end
         end
       end
 
@@ -88,6 +109,10 @@ module Steep
         when SyntaxErrorStatus, AncestorErrorStatus
           status.last_builder
         end
+      end
+
+      def latest_rbs_index
+        status.rbs_index
       end
 
       def current_subtyping

--- a/test/lsp_double.rb
+++ b/test/lsp_double.rb
@@ -177,6 +177,16 @@ class LSPDouble
     end
   end
 
+  def workspace_symbol(query = "")
+    send_request(
+      id: next_request_id,
+      method: "workspace/symbol",
+      params: { query: query }
+    ) do |response|
+      response[:result]
+    end
+  end
+
   def diagnostics_for(path)
     diagnostics["file://#{path}"]
   end

--- a/test/signature_symbol_provider_test.rb
+++ b/test/signature_symbol_provider_test.rb
@@ -4,9 +4,15 @@ class SignatureSymbolProviderTest < Minitest::Test
   include TestHelper
   include FactoryHelper
 
+  include Steep
+
   LSP = LanguageServer::Protocol
-  SignatureSymbolProvider = Steep::Index::SignatureSymbolProvider
-  RBSIndex = Steep::Index::RBSIndex
+  SignatureSymbolProvider = Index::SignatureSymbolProvider
+  RBSIndex = Index::RBSIndex
+
+  def assignment
+    Services::PathAssignment.all
+  end
 
   def test_find_class_symbol
     with_factory({ "a.rbs" => <<RBS }) do |factory|
@@ -28,39 +34,39 @@ RBS
       provider = SignatureSymbolProvider.new()
       provider.indexes << index
 
-      assert_any! provider.query_symbol("") do |symbol|
+      assert_any! provider.query_symbol("", assignment: assignment) do |symbol|
         assert_equal 'Class1', symbol.name
         assert_equal "", symbol.container_name
         assert_equal LSP::Constant::SymbolKind::CLASS, symbol.kind
         assert_operator symbol.location.buffer.name, :end_with?, "a.rbs"
       end
 
-      assert_any! provider.query_symbol("") do |symbol|
+      assert_any! provider.query_symbol("", assignment: assignment) do |symbol|
         assert_equal 'Module1', symbol.name
         assert_equal "Class1", symbol.container_name
         assert_equal LSP::Constant::SymbolKind::MODULE, symbol.kind
         assert_operator symbol.location.buffer.name, :end_with?, "a.rbs"
       end
 
-      assert_any! provider.query_symbol("") do |symbol|
+      assert_any! provider.query_symbol("", assignment: assignment) do |symbol|
         assert_equal '_Interface1', symbol.name
         assert_equal "Class1::Module1", symbol.container_name
         assert_equal LSP::Constant::SymbolKind::INTERFACE, symbol.kind
         assert_operator symbol.location.buffer.name, :end_with?, "a.rbs"
       end
 
-      assert_any! provider.query_symbol("") do |symbol|
+      assert_any! provider.query_symbol("", assignment: assignment) do |symbol|
         assert_equal 'alias1', symbol.name
         assert_equal "Class1::Module1", symbol.container_name
         assert_equal LSP::Constant::SymbolKind::ENUM, symbol.kind
         assert_operator symbol.location.buffer.name, :end_with?, "a.rbs"
       end
 
-      assert_any! provider.query_symbol("class1") do |symbol|
+      assert_any! provider.query_symbol("class1", assignment: assignment) do |symbol|
         assert_equal 'Class1', symbol.name
       end
 
-      assert_any! provider.query_symbol("class") do |symbol|
+      assert_any! provider.query_symbol("class", assignment: assignment) do |symbol|
         assert_equal 'Class1', symbol.name
       end
     end
@@ -89,7 +95,7 @@ RBS
       provider = SignatureSymbolProvider.new()
       provider.indexes << index
 
-      provider.query_symbol("").tap do |symbols|
+      provider.query_symbol("", assignment: assignment).tap do |symbols|
         assert_any! symbols do |symbol|
           assert_equal "#foo", symbol.name
           assert_equal "Class1", symbol.container_name
@@ -174,7 +180,7 @@ RBS
       provider = SignatureSymbolProvider.new()
       provider.indexes << index
 
-      provider.query_symbol("").tap do |symbols|
+      provider.query_symbol("", assignment: assignment).tap do |symbols|
         assert_any! symbols do |symbol|
           assert_equal "VERSION", symbol.name
           assert_equal "Steep", symbol.container_name


### PR DESCRIPTION
Implement `workspace/symbol` request handling based on the abstractions introduced in #312.