### PR TITLE
Pass commandline args to workers

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -192,6 +192,8 @@ module Steep
           opts.on("--max-index=COUNT") {|count| command.max_index = Integer(count) }
           opts.on("--index=INDEX") {|index| command.index = Integer(index) }
         end.parse!(argv)
+
+        command.commandline_args.push(*argv)
       end.run
     end
   end

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -37,7 +37,11 @@ module Steep
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
         interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path, delay_shutdown: true)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, delay_shutdown: true)
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(
+          steepfile: project.steepfile_path,
+          args: command_line_patterns,
+          delay_shutdown: true
+        )
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -41,7 +41,7 @@ module Steep
         loader.load_signatures()
 
         interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path)
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: [])
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -39,7 +39,7 @@ module Steep
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
         interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path)
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: dirs)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -9,6 +9,7 @@ module Steep
       attr_accessor :delay_shutdown
       attr_accessor :max_index
       attr_accessor :index
+      attr_accessor :commandline_args
 
       include Utils::DriverHelper
 
@@ -16,6 +17,7 @@ module Steep
         @stdout = stdout
         @stderr = stderr
         @stdin = stdin
+        @commandline_args = []
       end
 
       def run()
@@ -28,7 +30,11 @@ module Steep
           worker = case worker_type
                    when :typecheck
                      assignment = Services::PathAssignment.new(max_index: max_index, index: index)
-                     Server::TypeCheckWorker.new(project: project, reader: reader, writer: writer, assignment: assignment)
+                     Server::TypeCheckWorker.new(project: project,
+                                                 reader: reader,
+                                                 writer: writer,
+                                                 assignment: assignment,
+                                                 commandline_args: commandline_args)
                    when :interaction
                      loader = Project::FileLoader.new(project: project)
                      loader.load_sources([])

--- a/lib/steep/server/change_buffer.rb
+++ b/lib/steep/server/change_buffer.rb
@@ -23,12 +23,12 @@ module Steep
         end
       end
 
-      def load_files(project:)
+      def load_files(project:, commandline_args:)
         push_buffer do |changes|
           loader = Project::FileLoader.new(project: project)
 
           project.targets.each do |target|
-            loader.each_path_in_patterns(target.source_pattern) do |path|
+            loader.each_path_in_patterns(target.source_pattern, commandline_args) do |path|
               content = project.absolute_path(path).read()
               changes[path] = [Services::ContentChange.string(content)]
             end

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -41,7 +41,7 @@ module Steep
       def handle_request(request)
         case request[:method]
         when "initialize"
-          load_files(project: project)
+          load_files(project: project, commandline_args: [])
           queue << ApplyChangeJob.new
           writer.write({ id: request[:id], result: nil })
 

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -40,9 +40,13 @@ module Steep
         new(reader: reader, writer: writer, stderr: stderr, wait_thread: thread, name: name)
       end
 
-      def self.spawn_typecheck_workers(steepfile:, count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
+      def self.spawn_typecheck_workers(steepfile:, args:, count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
         count.times.map do |i|
-          spawn_worker(:typecheck, name: "typecheck@#{i}", steepfile: steepfile, options: ["--max-index=#{count}", "--index=#{i}"], delay_shutdown: delay_shutdown)
+          spawn_worker(:typecheck,
+                       name: "typecheck@#{i}",
+                       steepfile: steepfile,
+                       options: ["--max-index=#{count}", "--index=#{i}", *args],
+                       delay_shutdown: delay_shutdown)
         end
       end
 

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -25,7 +25,7 @@ EOF
       Project::DSL.parse(project, steepfile.read)
 
       interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 1)
+      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 1, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,
@@ -77,7 +77,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 1)
+      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 1, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,
@@ -139,7 +139,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 2)
+      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 2, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,
@@ -190,7 +190,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 2)
+      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 2, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,


### PR DESCRIPTION
This allows specifying part of a project through command line arguments to type check.

```
$ steep check lib/steep/ast lib/steep/cli.rb
```