### PR TITLE
Emit diagnostics with respect to target config

### DIFF
--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -50,6 +50,10 @@ module Steep
             formatter = Diagnostic::LSPFormatter.new()
 
             service.update(changes: changes) do |path, diagnostics|
+              if target = project.target_for_source_path(path)
+                diagnostics = diagnostics.select {|diagnostic| target.options.error_to_report?(diagnostic) }
+              end
+
               writer.write(
                 method: :"textDocument/publishDiagnostics",
                 params: LSP::Interface::PublishDiagnosticsParams.new(


### PR DESCRIPTION
Errors reported to Ruby code can be ignored.