### PR TITLE
Add -j option to control number of workers

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -16,6 +16,8 @@ require "stringio"
 require 'uri'
 require "yaml"
 
+require "parallel/processor_count"
+
 require "rbs"
 
 require "steep/method_name"
@@ -113,6 +115,7 @@ require "steep/project/file_loader"
 
 require "steep/expectations"
 require "steep/drivers/utils/driver_helper"
+require "steep/drivers/utils/jobs_count"
 require "steep/drivers/check"
 require "steep/drivers/stats"
 require "steep/drivers/validate"

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -10,6 +10,7 @@ module Steep
       attr_accessor :save_expectations_path
 
       include Utils::DriverHelper
+      include Utils::JobsCount
 
       def initialize(stdout:, stderr:)
         @stdout = stdout
@@ -40,7 +41,8 @@ module Steep
         typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(
           steepfile: project.steepfile_path,
           args: command_line_patterns,
-          delay_shutdown: true
+          delay_shutdown: true,
+          count: jobs_count
         )
 
         master = Server::Master.new(

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -10,6 +10,7 @@ module Steep
       attr_reader :type_check_thread
 
       include Utils::DriverHelper
+      include Utils::JobsCount
 
       TypeCheckRequest = Struct.new(:version, keyword_init: true)
 
@@ -41,7 +42,7 @@ module Steep
         loader.load_signatures()
 
         interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: [])
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: [], count: jobs_count)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/utils/jobs_count.rb
+++ b/lib/steep/drivers/utils/jobs_count.rb
@@ -1,0 +1,9 @@
+module Steep
+  module Drivers
+    module Utils
+      module JobsCount
+        attr_accessor :jobs_count
+      end
+    end
+  end
+end

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -7,6 +7,7 @@ module Steep
       attr_reader :queue
 
       include Utils::DriverHelper
+      include Utils::JobsCount
 
       LSP = LanguageServer::Protocol
 
@@ -39,7 +40,7 @@ module Steep
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
         interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: dirs)
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: dirs, count: jobs_count)
 
         master = Server::Master.new(
           project: project,

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", "~> 3.15.0.1"
   spec.add_runtime_dependency "rbs", "~> 1.0.5"
+  spec.add_runtime_dependency "parallel", ">= 1.0.0"
 end


### PR DESCRIPTION
The default is calculated from _# of cores_.

* Added `parallel` gem as dependency for `#physical_processor_count`.