### PR TITLE
Fix unexpected error handling

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -613,10 +613,6 @@ module Steep
         def header_line
           "UnexpectedError: #{error.message}"
         end
-
-        def detail_lines
-          error.backtrace.join("\n")
-        end
       end
     end
   end

--- a/smoke/unexpected/Steepfile
+++ b/smoke/unexpected/Steepfile
@@ -1,0 +1,5 @@
+target :test do
+  typing_options :strict
+  check "*.rb"
+  signature "*.rbs"
+end

--- a/smoke/unexpected/test_expectations.yml
+++ b/smoke/unexpected/test_expectations.yml
@@ -1,0 +1,25 @@
+---
+- file: unexpected.rb
+  diagnostics:
+  - range:
+      start:
+        line: 1
+        character: 0
+      end:
+        line: 1
+        character: 14
+    severity: ERROR
+    message: 'UnexpectedError: unexpected.rbs:2:17...2:24: Could not find String1'
+    code: Ruby::UnexpectedError
+- file: unexpected.rbs
+  diagnostics:
+  - range:
+      start:
+        line: 2
+        character: 17
+      end:
+        line: 2
+        character: 24
+    severity: ERROR
+    message: Cannot find type `String1`
+    code: RBS::UnknownTypeName

--- a/smoke/unexpected/unexpected.rb
+++ b/smoke/unexpected/unexpected.rb
@@ -1,0 +1,1 @@
+Unexpected.new.foo().bar

--- a/smoke/unexpected/unexpected.rbs
+++ b/smoke/unexpected/unexpected.rbs
@@ -1,0 +1,3 @@
+class Unexpected
+  def foo: () -> String1
+end


### PR DESCRIPTION
Stop printing all of the stack trace in the diagnostic.