### PR TITLE
Small LSP improvements

### DIFF
--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -460,9 +460,6 @@ module Steep
           @client_write_thread = Thread.new do
             Steep.logger.formatter.push_tags(*tags, "write")
 
-            # Start writing to client after `initialize` request
-            Thread.stop
-
             while message = write_queue.pop
               writer.write(message)
             end
@@ -544,14 +541,13 @@ module Steep
                   )
                 )
               }
-
-              if typecheck_automatically
-                request = controller.make_request(include_unchanged: true)
-                start_type_check(request, last_request: nil, start_progress: request.total > 10)
-              end
-
-              client_write_thread.wakeup()
             end
+          end
+
+        when "initialized"
+          if typecheck_automatically
+            request = controller.make_request(include_unchanged: true)
+            start_type_check(request, last_request: nil, start_progress: request.total > 10)
           end
 
         when "textDocument/didChange"

--- a/test/lsp_double.rb
+++ b/test/lsp_double.rb
@@ -46,6 +46,7 @@ class LSPDouble
     end
 
     send_request(id: next_request_id, method: "initialize") { }
+    send_notification(method: "initialized", params: {})
 
     if block_given?
       begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,6 +71,25 @@ module TestHelper
     refute collection.any?(&block)
   end
 
+  def assert_none!(collection, size: nil)
+    assert_equal size, collection.count if size
+
+    result = collection.all? do |c|
+      begin
+        yield(c)
+        false
+      rescue Minitest::Assertion
+        true
+      end
+    end
+
+    unless result
+      raise Minitest::Assertion.new(
+        "Assertion shouldn't hold any of the collection members: [#{collection.map(&:inspect).join(', ')}]"
+      )
+    end
+  end
+
   def assert_size(size, collection)
     assert_equal size, collection.size
   end


### PR DESCRIPTION
1. Use `initialized` notification to start type checking
2. Confirm if `window/workDoneProgress/create` is supported