### PR TITLE
Fix type checking passing `nil` as a block

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -220,10 +220,6 @@ module Steep
         def header_line
           "The method cannot be called with a block"
         end
-
-        def to_s
-          format_message "method_type=#{method_type}"
-        end
       end
 
       class RequiredBlockMissing < Base

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3269,10 +3269,14 @@ module Steep
             )
             method_type = method_type.subst(s)
 
-            errors << Diagnostic::Ruby::UnexpectedBlockGiven.new(
-              node: node,
-              method_type: method_type
-            )
+            type, constr = constr.synthesize(args.block_pass_arg, hint: AST::Builtin.nil_type)
+            type = expand_alias(type)
+            unless type.is_a?(AST::Types::Nil)
+              errors << Diagnostic::Ruby::UnexpectedBlockGiven.new(
+                node: node,
+                method_type: method_type
+              )
+            end
           end
         else
           unless args.block_pass_arg


### PR DESCRIPTION
Passing `nil` as a block doesn't give a block.

```ruby
[1,2,3].each(&nil)        # Returns an Enumerator because block is not given!
```

Fixes https://github.com/soutaro/steep/issues/268.