### PR TITLE
Fix unexpected `add_call` call

### DIFF
--- a/smoke/regression/issue_332.rb
+++ b/smoke/regression/issue_332.rb
@@ -1,0 +1,11 @@
+module Issue332
+  module TimeDurationExtensions
+    def -(other)
+      if other.is_a?(Duration)
+        Time.now
+      else
+        super(other)
+      end
+    end
+  end
+end

--- a/smoke/regression/issue_332.rbs
+++ b/smoke/regression/issue_332.rbs
@@ -1,0 +1,19 @@
+module Issue332
+  class Duration
+  end
+
+  interface _TimeDurationExtensions
+    def -: (Numeric other) -> Time
+         | (Time other) -> Float
+  end
+
+  module TimeDurationExtensions : _TimeDurationExtensions
+    def -: (Duration other) -> Time
+         | ...
+  end
+end
+
+class Time
+  prepend Issue332::TimeDurationExtensions
+end
+

--- a/smoke/regression/test_expectations.yml
+++ b/smoke/regression/test_expectations.yml
@@ -1,4 +1,21 @@
 ---
+- file: issue_332.rb
+  diagnostics:
+  - range:
+      start:
+        line: 7
+        character: 8
+      end:
+        line: 7
+        character: 20
+    severity: ERROR
+    message: |-
+      Cannot find compatible overloading of method `-` of type `(::Object & ::Issue332::_TimeDurationExtensions & ::Issue332::TimeDurationExtensions)`
+      Method types:
+        def -: (::Issue332::Duration) -> ::Time
+             | (::Numeric) -> ::Time
+             | (::Time) -> ::Float
+    code: Ruby::UnresolvedOverloading
 - file: set_divide.rb
   diagnostics:
   - range:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -566,7 +566,7 @@ module TypeConstructionHelper
 
   def assert_no_error(typing)
     assert_instance_of Typing, typing
-    assert_predicate typing.errors.map {|e| e.to_s }, :empty?
+    assert_predicate typing.errors.map {|e| e.header_line }, :empty?
   end
 
   def assert_typing_error(typing, size: nil)


### PR DESCRIPTION
`super` calls with unresolved overloading result in `undefined method "add_call"`. This is to fix the `add_call` error.

The type checking still fails, because of `UnresolvedOverloading`.

Related to https://github.com/soutaro/steep/issues/332.
Fixes https://github.com/soutaro/steep/issues/345.