### PR TITLE
Pretty table printing

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -17,6 +17,7 @@ require "yaml"
 require "securerandom"
 
 require "parallel/processor_count"
+require "terminal-table"
 
 require "rbs"
 

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -113,14 +113,7 @@ module Steep
           opts.banner = "Usage: steep stats [options] [sources]"
 
           opts.on("--steepfile=PATH") {|path| check.steepfile = Pathname(path) }
-          opts.on("--format=FORMAT", "Specify output format: csv, table") do |format|
-            case format
-            when "csv", "table"
-              check.format = format
-            else
-              stderr.puts "--format option is ignored because it has unknown value: `#{format}`"
-            end
-          end
+          opts.on("--format=FORMAT", "Specify output format: csv, table") {|format| check.format = format }
           handle_jobs_option check, opts
           handle_logging_options opts
         end.parse!(argv)

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -113,6 +113,14 @@ module Steep
           opts.banner = "Usage: steep stats [options] [sources]"
 
           opts.on("--steepfile=PATH") {|path| check.steepfile = Pathname(path) }
+          opts.on("--format=FORMAT", "Specify output format: csv, table") do |format|
+            case format
+            when "csv", "table"
+              check.format = format
+            else
+              stderr.puts "--format option is ignored because it has unknown value: `#{format}`"
+            end
+          end
           handle_jobs_option check, opts
           handle_logging_options opts
         end.parse!(argv)

--- a/lib/steep/drivers/stats.rb
+++ b/lib/steep/drivers/stats.rb
@@ -178,12 +178,14 @@ module Steep
                     CSVPrinter.new(io: stdout)
                   when "table"
                     TablePrinter.new(io: stdout)
-                  else
+                  when nil
                     if stdout.tty?
                       TablePrinter.new(io: stdout)
                     else
                       CSVPrinter.new(io: stdout)
                     end
+                  else
+                    raise ArgumentError.new("Invalid format: #{format}")
                   end
 
         printer.print(stats_result)

--- a/lib/steep/drivers/stats.rb
+++ b/lib/steep/drivers/stats.rb
@@ -3,9 +3,103 @@ require "csv"
 module Steep
   module Drivers
     class Stats
+      class CSVPrinter
+        attr_reader :io
+
+        def initialize(io:)
+          @io = io
+        end
+
+        def print(stats_result)
+          io.puts(
+            CSV.generate do |csv|
+              csv << ["Target", "File", "Status", "Typed calls", "Untyped calls", "All calls", "Typed %"]
+              stats_result.each do |row|
+                if row[:type] == "success"
+                  csv << [
+                    row[:target],
+                    row[:path],
+                    row[:type],
+                    row[:typed_calls],
+                    row[:untyped_calls],
+                    row[:total_calls],
+                    if row[:total_calls].nonzero?
+                      (row[:typed_calls].to_f / row[:total_calls] * 100).to_i
+                    else
+                      100
+                    end
+                  ]
+                else
+                  csv << [
+                    row[:target],
+                    row[:path],
+                    row[:type],
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                end
+              end
+            end
+          )
+        end
+      end
+
+      class TablePrinter
+        attr_reader :io
+
+        def initialize(io:)
+          @io = io
+        end
+
+        def print(stats_result)
+          rows = []
+          stats_result.sort_by {|row| row[:path] }.each do |row|
+            if row[:type] == "success"
+              rows << [
+                row[:target],
+                row[:path] + "  ",
+                row[:type],
+                row[:typed_calls],
+                row[:untyped_calls],
+                row[:total_calls],
+                if row[:total_calls].nonzero?
+                  "#{(row[:typed_calls].to_f / row[:total_calls] * 100).to_i}%"
+                else
+                  "100%"
+                end
+              ]
+            else
+              rows << [
+                row[:target],
+                row[:path],
+                row[:type],
+                0,
+                0,
+                0,
+                "N/A"
+              ]
+            end
+          end
+
+          table = Terminal::Table.new(
+            headings: ["Target", "File", "Status", "Typed calls", "Untyped calls", "All calls", "Typed %"],
+            rows: rows
+          )
+          table.align_column(3, :right)
+          table.align_column(4, :right)
+          table.align_column(5, :right)
+          table.align_column(6, :right)
+          table.style = { border_top: false, border_bottom: false, border_y: "", border_i: "" }
+          io.puts(table)
+        end
+      end
+
       attr_reader :stdout
       attr_reader :stderr
       attr_reader :command_line_patterns
+      attr_accessor :format
 
       include Utils::DriverHelper
       include Utils::JobsCount
@@ -79,96 +173,22 @@ module Steep
         shutdown_exit(reader: client_reader, writer: client_writer)
         main_thread.join()
 
-        stdout.puts(
-          CSV.generate do |csv|
-            csv << ["Target", "File", "Status", "Typed calls", "Untyped calls", "All calls", "Typed %"]
-            stats_result.each do |row|
-              if row[:type] == "success"
-                csv << [
-                  row[:target],
-                  row[:path],
-                  row[:type],
-                  row[:typed_calls],
-                  row[:untyped_calls],
-                  row[:total_calls],
-                  if row[:total_calls].nonzero?
-                    (row[:typed_calls].to_f / row[:total_calls] * 100).to_i
+        printer = case format
+                  when "csv"
+                    CSVPrinter.new(io: stdout)
+                  when "table"
+                    TablePrinter.new(io: stdout)
                   else
-                    100
+                    if stdout.tty?
+                      TablePrinter.new(io: stdout)
+                    else
+                      CSVPrinter.new(io: stdout)
+                    end
                   end
-                ]
-              else
-                csv << [
-                  row[:target],
-                  row[:path],
-                  row[:type],
-                  0,
-                  0,
-                  0,
-                  0
-                ]
-              end
-            end
-          end
-        )
-        #
-        # type_check(project)
-        #
-        # stdout.puts(
-        #   CSV.generate do |csv|
-        #     csv << ["Target", "File", "Status", "Typed calls", "Untyped calls", "All calls", "Typed %"]
-        #
-        #     project.targets.each do |target|
-        #       case (status = target.status)
-        #       when Project::Target::TypeCheckStatus
-        #         status.type_check_sources.each do |source_file|
-        #           case source_file.status
-        #           when Project::SourceFile::TypeCheckStatus
-        #             typing = source_file.status.typing
-        #
-        #             typed = 0
-        #             untyped = 0
-        #             total = 0
-        #             typing.method_calls.each_value do |call|
-        #               case call
-        #               when TypeInference::MethodCall::Typed
-        #                 typed += 1
-        #               when TypeInference::MethodCall::Untyped
-        #                 untyped += 1
-        #               end
-        #
-        #               total += 1
-        #             end
-        #
-        #             csv << format_stats(target, source_file.path, "success", typed, untyped, total)
-        #           when Project::SourceFile::TypeCheckErrorStatus
-        #             csv << format_stats(target, source_file.path, "error", 0, 0, 0)
-        #           else
-        #             csv << format_stats(target, source_file.path, "unknown (#{source_file.status.class.to_s.split(/::/).last})", 0, 0, 0)
-        #           end
-        #         end
-        #       end
-        #     end
-        #   end
-        # )
+
+        printer.print(stats_result)
 
         0
-      end
-
-      def format_stats(target, path, status, typed, untyped, total)
-        [
-          target.name,
-          path.to_s,
-          status,
-          typed,
-          untyped,
-          total,
-          if total.nonzero?
-            format("%.2f", (typed.to_f/total)*100)
-          else
-            0
-          end
-        ]
       end
     end
   end

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
   spec.add_runtime_dependency "rbs", "~> 1.1.0"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
+  spec.add_runtime_dependency "terminal-table", "~> 2.0"
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -364,6 +364,28 @@ RUBY
     end
   end
 
+  def test_stats_default_no_tty
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+      EOF
+
+      (current_dir + "foo.rb").write(<<-EOF)
+1 + 2
+      EOF
+
+      stdout, _, status = sh3(*steep, "stats")
+
+      assert_predicate status, :success?, stdout
+      assert_equal <<CSV, stdout
+Target,File,Status,Typed calls,Untyped calls,All calls,Typed %
+app,foo.rb,success,1,0,1,100
+CSV
+    end
+  end
+
   def test_stats_csv
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)
@@ -376,7 +398,7 @@ end
 1 + 2
       EOF
 
-      stdout, status = sh(*steep, "stats", "--format=csv")
+      stdout, _, status = sh3(*steep, "stats", "--format=csv")
 
       assert_predicate status, :success?, stdout
       assert_equal <<CSV, stdout
@@ -398,7 +420,7 @@ end
 1 + 2
       EOF
 
-      stdout, status = sh(*steep, "stats", "--format=table")
+      stdout, _, status = sh3(*steep, "stats", "--format=table")
 
       assert_predicate status, :success?, stdout
       assert_equal <<CSV, stdout
@@ -406,6 +428,24 @@ end
 ---------------------------------------------------------------------------
  app     foo.rb    success            1              0          1     100%
 CSV
+    end
+  end
+
+  def test_stats_error
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+      EOF
+
+      (current_dir + "foo.rb").write(<<-EOF)
+1 + 2
+      EOF
+
+      stdout, status = sh2e(*steep, "stats", "--format=unknown")
+
+      refute_predicate status, :success?, stdout
     end
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -364,7 +364,7 @@ RUBY
     end
   end
 
-  def test_stats
+  def test_stats_csv
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)
 target :app do
@@ -376,12 +376,35 @@ end
 1 + 2
       EOF
 
-      stdout, status = sh(*steep, "stats")
+      stdout, status = sh(*steep, "stats", "--format=csv")
 
       assert_predicate status, :success?, stdout
       assert_equal <<CSV, stdout
 Target,File,Status,Typed calls,Untyped calls,All calls,Typed %
 app,foo.rb,success,1,0,1,100
+CSV
+    end
+  end
+
+  def test_stats_table
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+      EOF
+
+      (current_dir + "foo.rb").write(<<-EOF)
+1 + 2
+      EOF
+
+      stdout, status = sh(*steep, "stats", "--format=table")
+
+      assert_predicate status, :success?, stdout
+      assert_equal <<CSV, stdout
+ Target  File      Status   Typed calls  Untyped calls  All calls  Typed %
+---------------------------------------------------------------------------
+ app     foo.rb    success            1              0          1     100%
 CSV
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -413,6 +413,14 @@ module ShellHelper
     Open3.capture2(env_vars, *command, chdir: current_dir.to_s)
   end
 
+  def sh3(*command)
+    Open3.capture3(env_vars, *command, chdir: current_dir.to_s)
+  end
+
+  def sh2e(*command)
+    Open3.capture2e(env_vars, *command, chdir: current_dir.to_s)
+  end
+
   def sh!(*command)
     stdout, status = sh(*command)
     unless status.success?


### PR DESCRIPTION
`steep stats` now support _table_ and _csv_ printing modes. Users can specify the mode through `--format` options.

```shell
$ steep stats --format=table
 Target  File                                         Status   Typed calls  Untyped calls  All calls  Typed %
--------------------------------------------------------------------------------------------------------------
 test    argument_type_mismatch.rb                    success            0              0          1       0%
 test    block_body_type_mismatch.rb                  success            1              0          2      50%
 test    block_type_mismatch.rb                       success            0              2          3       0%
 test    break_type_mismatch.rb                       success            1              0          1     100%
```

The default mode depends on `STDOUT.tty?`. _table_ mode is used if it's `true` and _csv_ mode is used if it's `false`. This assumes a workflow to run `steep stats` command behind a pipe and save the result as a CSV file for further visualization/review/processing. This PR won't break the workflow.