### PR TITLE
Do not crash when completion request context is missing

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -65,7 +65,7 @@ module Steep
           uri = URI.parse(params[:textDocument][:uri])
           path = project.relative_path(Pathname(uri.path))
           line, column = params[:position].yield_self {|hash| [hash[:line]+1, hash[:character]] }
-          trigger = params[:context][:triggerCharacter]
+          trigger = params.dig(:context, :triggerCharacter)
 
           queue << CompletionJob.new(id: id, path: path, line: line, column: column, trigger: trigger)
         end


### PR DESCRIPTION
Sublime LSP plugin doesn't send the `context` when doing a `textDocument/completion` request:

```
:: --> ruby textDocument/completion(7): {'position': {'line': 10, 'character': 21}, 'textDocument': {'uri': 'file://[redacted]/app.rb'}}
```

This causes Steep to crash with `NoMethodError (undefined method '[]' for nil:NilClass)`.

I'm not sure if this is a violation of the protocol, but it looks like `trigger` isn't used for anything important in Steep, so let's handle it gracefully.