### PR TITLE
Fix goto definition/implementation from block

### DIFF
--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -125,6 +125,7 @@ module Steep
                 end
               when :send
                 if test_ast_location(node.location.selector, line: line, column: column)
+                  node = parents[0] if parents[0]&.type == :block
                   case call = typing.call_of(node: node)
                   when TypeInference::MethodCall::Typed, TypeInference::MethodCall::Error
                     call.method_decls.each do |decl|

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -630,4 +630,21 @@ RBS
       end
     end
   end
+
+  def test_method_block
+    type_check = type_check_service do |changes|
+      changes[Pathname("lib/test.rb")] = [ContentChange.string(<<RBS)]
+[].each do |x|
+end
+RBS
+    end
+
+    service = Services::GotoService.new(type_check: type_check)
+
+    service.definition(path: dir + "lib/test.rb", line: 1, column: 4).tap do |locs|
+      assert_any!(locs, size: 1) do |loc|
+        assert_equal Pathname("array.rbs"), Pathname(loc.buffer.name).basename
+      end
+    end
+  end
 end


### PR DESCRIPTION
_Calls_ for `send` nodes with blocks are recorded with the `block` nodes.