### PR TITLE
Fix FileLoader to skip files not matching to the given pattern

### DIFF
--- a/lib/steep/services/file_loader.rb
+++ b/lib/steep/services/file_loader.rb
@@ -8,29 +8,36 @@ module Steep
       end
 
       def each_path_in_patterns(pattern, commandline_patterns = [])
-        pats = commandline_patterns.empty? ? pattern.patterns : commandline_patterns
+        if block_given?
+          pats = commandline_patterns.empty? ? pattern.patterns : commandline_patterns
 
-        pats.each do |path|
-          absolute_path = base_dir + path
+          pats.each do |path|
+            absolute_path = base_dir + path
 
-          if absolute_path.file?
-            yield absolute_path.relative_path_from(base_dir)
-          else
-            files = if absolute_path.directory?
-                      Pathname.glob("#{absolute_path}/**/*#{pattern.ext}")
-                    else
-                      Pathname.glob(absolute_path)
-                    end
+            if absolute_path.file?
+              if pattern =~ path
+                yield absolute_path.relative_path_from(base_dir)
+              end
+            else
+              files = if absolute_path.directory?
+                        Pathname.glob("#{absolute_path}/**/*#{pattern.ext}")
+                      else
+                        Pathname.glob(absolute_path)
+                      end
 
-            files.sort.each do |source_path|
-              if source_path.file?
-                relative_path = source_path.relative_path_from(base_dir)
-                unless pattern.ignore?(relative_path)
-                  yield relative_path
+              files.sort.each do |source_path|
+                if source_path.file?
+                  relative_path = source_path.relative_path_from(base_dir)
+                  unless pattern.ignore?(relative_path)
+                    yield relative_path
+                  end
                 end
               end
             end
+
           end
+        else
+          enum_for :each_path_in_patterns, pattern, commandline_patterns
         end
       end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -205,6 +205,21 @@ end
     end
   end
 
+  def test_check_unknown
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+      EOF
+
+      (current_dir + "bar.rb").write("")
+
+      stdout, status = sh(*steep, "check", "bar.rb")
+      assert_predicate status, :success?, stdout
+    end
+  end
+
   def test_annotations
     in_tmpdir do
       (current_dir + "foo.rb").write(<<-RUBY)

--- a/test/file_loader_test.rb
+++ b/test/file_loader_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class FileLoaderTest < Minitest::Test
+  include Steep
+  include TestHelper
+  include ShellHelper
+
+  Pattern = Project::Pattern
+  FileLoader = Services::FileLoader
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def test_each_path_in_patterns
+    in_tmpdir do
+      loader = FileLoader.new(base_dir: current_dir)
+
+      (current_dir + "lib").mkdir()
+      (current_dir + "test").mkdir()
+      (current_dir + "lib/foo.rb").write("")
+      (current_dir + "lib/parser.y").write("")
+      (current_dir + "test/foo_test.rb").write("")
+      (current_dir + "Rakefile").write("")
+
+      pat = Pattern.new(patterns: ["lib", "test"], ext: ".rb")
+
+      assert_equal [Pathname("lib/foo.rb"), Pathname("test/foo_test.rb")], loader.each_path_in_patterns(pat).to_a
+      assert_equal [Pathname("lib/foo.rb")], loader.each_path_in_patterns(pat, ["lib"]).to_a
+      assert_empty loader.each_path_in_patterns(pat, ["lib/parser.y"]).to_a
+      assert_empty loader.each_path_in_patterns(pat, ["Rakefile"]).to_a
+    end
+  end
+end


### PR DESCRIPTION
The previous behavior resulted in a crash when a non-project file is given to `steep check`.

```
$ steep check README.md # => Unexpected error: #<NoMethodError: undefined method `name' for nil:NilClass>
```