### PR TITLE
Display type information when type alias is hovered in rbs

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -77,19 +77,13 @@ module Steep
             Steep.logger.info { "path=#{job.path}, line=#{job.line}, column=#{job.column}" }
 
             hover = Services::HoverContent.new(service: service)
-            content = hover.content_for(path: job.path, line: job.line, column: job.column+1)
+            content = hover.content_for(path: job.path, line: job.line, column: job.column)
             if content
               range = content.location.yield_self do |location|
-                case content.location
-                when RBS::Location::WithChildren
-                  start_position = { line: location.start_line - 1, character: location.start_column }
-                  end_position = { line: location.start_line - 1, character: location.start_column }
-                  { start: start_position, end: end_position }
-                else
-                  start_position = { line: location.line - 1, character: location.column }
-                  end_position = { line: location.last_line - 1, character: location.last_column }
-                  { start: start_position, end: end_position }
-                end
+                lsp_range = location.as_lsp_range
+                start_position = { line: lsp_range[:start][:line], character: lsp_range[:start][:character] }
+                end_position = { line: lsp_range[:end][:line], character: lsp_range[:end][:character] }
+                { start: start_position, end: end_position }
               end
 
               LSP::Interface::Hover.new(

--- a/lib/steep/services/hover_content.rb
+++ b/lib/steep/services/hover_content.rb
@@ -11,6 +11,7 @@ module Steep
           end
         end
       end
+      TypeAliasContent = Struct.new(:location, :decl, keyword_init: true)
 
       InstanceMethodName = Struct.new(:class_name, :method_name)
       SingletonMethodName = Struct.new(:class_name, :method_name)
@@ -50,99 +51,124 @@ module Steep
       end
 
       def content_for(path:, line:, column:)
-        target = project.target_for_source_path(path)
+        case
+        when target = project.target_for_source_path(path)
+          Steep.logger.info "target #{target}"
 
-        if target
-          file = service.source_files[path]
-          typing = typecheck(target, path: path, content: file.content, line: line, column: column) or return
+          hover_for_source(column, line, path, target)
+        when (_, targets = project.targets_for_path(path))
+          target = targets[0]
+          service = self.service.signature_services[target.name]
+          _buffer, decls = service.latest_env.buffers_decls.find do |buffer, _|
+            Pathname(buffer.name) == path
+          end
 
-          node, *parents = typing.source.find_nodes(line: line, column: column)
+          locator = RBS::Locator.new(decls: decls)
+          hd, tail = locator.find2(line: line, column: column)
 
-          if node
-            case node.type
-            when :lvar
-              var_name = node.children[0]
-              context = typing.context_at(line: line, column: column)
-              var_type = context.lvar_env[var_name] || AST::Types::Any.new(location: nil)
+          case type = tail[0]
+          when RBS::Types::Alias
+            env = service.latest_env
+            alias_decl = env.alias_decls[type.name]&.decl or raise
 
-              VariableContent.new(node: node, name: var_name, type: var_type, location: node.location.name)
-            when :lvasgn
-              var_name, rhs = node.children
-              context = typing.context_at(line: line, column: column)
-              type = context.lvar_env[var_name] || typing.type_of(node: rhs)
+            location = tail[0].location
+            TypeAliasContent.new(
+              location: location,
+              decl: alias_decl
+            )
+          end
+        end
+      end
 
-              VariableContent.new(node: node, name: var_name, type: type, location: node.location.name)
-            when :send
-              receiver, method_name, *_ = node.children
+      def hover_for_source(column, line, path, target)
+        file = service.source_files[path]
+        typing = typecheck(target, path: path, content: file.content, line: line, column: column) or return
+        node, *parents = typing.source.find_nodes(line: line, column: column)
+
+        if node
+          case node.type
+          when :lvar
+            var_name = node.children[0]
+            context = typing.context_at(line: line, column: column)
+            var_type = context.lvar_env[var_name] || AST::Types::Any.new(location: nil)
+
+            VariableContent.new(node: node, name: var_name, type: var_type, location: node.location.name)
+          when :lvasgn
+            var_name, rhs = node.children
+            context = typing.context_at(line: line, column: column)
+            type = context.lvar_env[var_name] || typing.type_of(node: rhs)
+
+            VariableContent.new(node: node, name: var_name, type: type, location: node.location.name)
+          when :send
+            receiver, method_name, *_ = node.children
 
 
-              result_node = if parents[0]&.type == :block
-                              parents[0]
+            result_node = if parents[0]&.type == :block
+                            parents[0]
+                          else
+                            node
+                          end
+
+            context = typing.context_at(line: line, column: column)
+
+            receiver_type = if receiver
+                              typing.type_of(node: receiver)
                             else
-                              node
+                              context.self_type
                             end
 
-              context = typing.context_at(line: line, column: column)
-
-              receiver_type = if receiver
-                                typing.type_of(node: receiver)
-                              else
-                                context.self_type
-                              end
-
-              factory = context.type_env.subtyping.factory
-              method_name, definition = case receiver_type
-                                        when AST::Types::Name::Instance
-                                          method_definition = method_definition_for(factory, receiver_type.name, instance_method: method_name)
-                                          if method_definition&.defined_in
-                                            owner_name = method_definition.defined_in
-                                            [
-                                              InstanceMethodName.new(owner_name, method_name),
-                                              method_definition
-                                            ]
-                                          end
-                                        when AST::Types::Name::Singleton
-                                          method_definition = method_definition_for(factory, receiver_type.name, singleton_method: method_name)
-                                          if method_definition&.defined_in
-                                            owner_name = method_definition.defined_in
-                                            [
-                                              SingletonMethodName.new(owner_name, method_name),
-                                              method_definition
-                                            ]
-                                          end
-                                        else
-                                          nil
+            factory = context.type_env.subtyping.factory
+            method_name, definition = case receiver_type
+                                      when AST::Types::Name::Instance
+                                        method_definition = method_definition_for(factory, receiver_type.name, instance_method: method_name)
+                                        if method_definition&.defined_in
+                                          owner_name = method_definition.defined_in
+                                          [
+                                            InstanceMethodName.new(owner_name, method_name),
+                                            method_definition
+                                          ]
                                         end
+                                      when AST::Types::Name::Singleton
+                                        method_definition = method_definition_for(factory, receiver_type.name, singleton_method: method_name)
+                                        if method_definition&.defined_in
+                                          owner_name = method_definition.defined_in
+                                          [
+                                            SingletonMethodName.new(owner_name, method_name),
+                                            method_definition
+                                          ]
+                                        end
+                                      else
+                                        nil
+                                      end
 
-              MethodCallContent.new(
+            MethodCallContent.new(
+              node: node,
+              method_name: method_name,
+              type: typing.type_of(node: result_node),
+              definition: definition,
+              location: result_node.location.expression
+            )
+          when :def, :defs
+            context = typing.context_at(line: line, column: column)
+            method_context = context.method_context
+
+            if method_context && method_context.method
+              DefinitionContent.new(
                 node: node,
-                method_name: method_name,
-                type: typing.type_of(node: result_node),
-                definition: definition,
-                location: result_node.location.expression
-              )
-            when :def, :defs
-              context = typing.context_at(line: line, column: column)
-              method_context = context.method_context
-
-              if method_context && method_context.method
-                DefinitionContent.new(
-                  node: node,
-                  method_name: method_context.name,
-                  method_type: method_context.method_type,
-                  definition: method_context.method,
-                  location: node.loc.expression
-                )
-              end
-            else
-              type = typing.type_of(node: node)
-
-              TypeContent.new(
-                node: node,
-                type: type,
-                location: node.location.expression
+                method_name: method_context.name,
+                method_type: method_context.method_type,
+                definition: method_context.method,
+                location: node.loc.expression
               )
             end
+          else
+            type = typing.type_of(node: node)
+
+            TypeContent.new(
+              node: node,
+              type: type,
+              location: node.location.expression
+            )
           end
         end
       end

--- a/lib/steep/services/hover_content.rb
+++ b/lib/steep/services/hover_content.rb
@@ -5,13 +5,13 @@ module Steep
       VariableContent = Struct.new(:node, :name, :type, :location, keyword_init: true)
       MethodCallContent = Struct.new(:node, :method_name, :type, :definition, :location, keyword_init: true)
       DefinitionContent = Struct.new(:node, :method_name, :method_type, :definition, :location, keyword_init: true) do
+      TypeAliasContent = Struct.new(:location, :decl, keyword_init: true)
         def comment_string
           if comments = definition&.comments
             comments.map {|c| c.string.chomp }.uniq.join("\n----\n")
           end
         end
       end
-      TypeAliasContent = Struct.new(:location, :decl, keyword_init: true)
 
       InstanceMethodName = Struct.new(:class_name, :method_name)
       SingletonMethodName = Struct.new(:class_name, :method_name)

--- a/test/hover_test.rb
+++ b/test/hover_test.rb
@@ -246,7 +246,6 @@ RBS
     end
   end
 
-
   def test_hover_on_syntax_error
     in_tmpdir do
       service = typecheck_service()

--- a/test/hover_test.rb
+++ b/test/hover_test.rb
@@ -218,6 +218,35 @@ RBS
     end
   end
 
+  def test_hover_on_rbs
+    in_tmpdir do
+      service = typecheck_service()
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+type foo = Integer | String
+
+class FooBar
+  def f: (foo) -> void
+end
+RBS
+        }
+      ) {}
+
+      hover = HoverContent.new(service: service)
+
+      hover.content_for(path: Pathname("hello.rbs"), line: 4, column: 11).tap do |content|
+        assert_instance_of HoverContent::TypeAliasContent, content
+        assert_instance_of RBS::Location::WithChildren, content.location
+
+        assert_equal content.location.start_line, 4
+        assert_equal content.location.start_column, 10
+      end
+    end
+  end
+
+
   def test_hover_on_syntax_error
     in_tmpdir do
       service = typecheck_service()

--- a/test/interaction_worker_test.rb
+++ b/test/interaction_worker_test.rb
@@ -209,7 +209,7 @@ RBS
 ```
 "
       assert_equal({ kind: "markdown", value: expected_value }, response[:contents])
-      assert_equal({ start: { line: 4, character: 10 }, end: { line: 4, character: 10 }}, response[:range])
+      assert_equal({ start: { line: 4, character: 10 }, end: { line: 4, character: 13 }}, response[:range])
     end
   end
 


### PR DESCRIPTION
we now display type information when alias is hovered in rbs 
![image](https://user-images.githubusercontent.com/18569016/122393021-65424380-cfaf-11eb-94af-ca433ee24494.png)

## Known issue
The judgment when hovering is off by one character.
I think this is a location issue, so I'll fix it in a later PR.
