### PR TITLE
Assign different error code to break without value

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -332,6 +332,23 @@ module Steep
         end
       end
 
+      class ImplicitBreakValueMismatch < Base
+        attr_reader :jump_type
+        attr_reader :result
+
+        include ResultPrinter
+
+        def initialize(node:, jump_type:, result:)
+          super(node: node)
+          @jump_type = jump_type
+          @result = result
+        end
+
+        def header_line
+          "Breaking without a value may result an error because a value of type `#{jump_type}` is expected"
+        end
+      end
+
       class UnexpectedJump < Base
         def header_line
           "Cannot jump from here"

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1154,10 +1154,9 @@ module Steep
               else
                 check_relation(sub_type: AST::Builtin.nil_type, super_type: break_type).else do |result|
                   typing.add_error(
-                    Diagnostic::Ruby::BreakTypeMismatch.new(
+                    Diagnostic::Ruby::ImplicitBreakValueMismatch.new(
                       node: node,
-                      expected: break_type,
-                      actual: AST::Builtin.nil_type,
+                      jump_type: break_type,
                       result: result
                     )
                   )


### PR DESCRIPTION
Breaking without value often happens and causes type errors.

```rb
[1,2,3].each do |i|
  break      # Type error because the #each method expects Array[Integer]
end
```

This cannot be handled well under the current type checker architecture, so assigning another error code would help to ignore this type errors if the user wants it.