### PR TITLE
WIP: Object in main interface send

### DIFF
--- a/lib/steep/ast/types/intersection.rb
+++ b/lib/steep/ast/types/intersection.rb
@@ -43,7 +43,8 @@ module Steep
         end
 
         def ==(other)
-          other.is_a?(Intersection) && other.types == types
+          (other.is_a?(Intersection) && other.types == types) ||
+          types.any? { |typ| typ == other }
         end
 
         def hash

--- a/lib/steep/ast/types/union.rb
+++ b/lib/steep/ast/types/union.rb
@@ -45,7 +45,9 @@ module Steep
 
         def ==(other)
           other.is_a?(Union) &&
-            Set.new(other.types) == Set.new(types)
+           other.types.all? do |typ1|
+            types.any? { |typ2| typ1 == typ2 }
+           end
         end
 
         def hash

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3514,7 +3514,7 @@ module Steep
     end
 
     def current_namespace
-      module_context&.current_namespace || AST::Namespace.root
+      module_context&.current_namespace || RBS::Namespace.root
     end
 
     def nested_namespace_for_module(module_name)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -756,7 +756,11 @@ module Steep
           yield_self do
             var = node.children[0]
             if (type = context.lvar_env[var])
-              add_typing node, type: type
+              if type.is_a?(AST::Types::Name::Interface) && type.name.kind == :interface
+                add_typing node, type: AST::Types::Intersection.build(types: [type, AST::Builtin::Object.instance_type])
+              else
+                add_typing node, type: type
+              end
             else
               fallback_to_any(node)
             end

--- a/lib/steep/type_inference/local_variable_type_env.rb
+++ b/lib/steep/type_inference/local_variable_type_env.rb
@@ -86,7 +86,7 @@ module Steep
           relation = Subtyping::Relation.new(sub_type: type, super_type: declared_type)
           constraints = Subtyping::Constraints.new(unknowns: Set.new)
           subtyping.check(relation, constraints: constraints, self_type: self_type, instance_type: instance_type, class_type: class_type).else do |result|
-            yield declared_type, type, result
+            yield declared_type, type, result if block_given?
           end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -473,7 +473,11 @@ module FactoryHelper
 
   def parse_type(string, factory: self.factory, variables: [])
     type = RBS::Parser.parse_type(string, variables: variables)
-    factory.type(type)
+    type = factory.type(type)
+    if type.is_a?(Steep::AST::Types::Name::Interface) && type.name.kind == :interface
+      type = Steep::AST::Types::Intersection.build(types: [type, Steep::AST::Builtin::Object.instance_type])
+    end
+    type
   end
 
   def parse_ruby(string, factory: self.factory)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -751,7 +751,7 @@ end
         construction.synthesize(source.node)
 
         assert_any typing.errors do |error|
-          error.is_a?(Diagnostic::Ruby::ReturnTypeMismatch) && error.expected == parse_type("::_X") && error.actual == parse_type("::_A")
+          error.is_a?(Diagnostic::Ruby::ReturnTypeMismatch) && parse_type("::_X") == error.expected && parse_type("::_A") == error.actual
         end
       end
     end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5958,6 +5958,29 @@ end
     end
   end
 
+
+  def test_return_union_with_interface
+    with_checker(<<-RBS) do |checker|
+interface _Foo1
+  def to_s: () -> String
+end
+interface _Foo2
+  def to_s: () -> (_Foo1 | Integer)
+end
+    RBS
+      source = parse_ruby(<<-RUBY)
+# @type var x: _Foo2
+x = nil
+x.to_s == 1
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_flow_sensitive_and
     with_checker(<<-RBS) do |checker|
 class Fun

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -186,6 +186,23 @@ x.f
     end
   end
 
+  def test_method_call_from_object
+    with_checker do |checker|
+      source = parse_ruby(<<-EOF)
+# @type var x: _C
+x = (_ = nil)
+x.to_s
+      EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+        assert_equal parse_type("::String"), typing.type_of(node: source.node)
+      end
+    end
+  end
+
   def test_method_call_with_argument
     with_checker do |checker|
       source = parse_ruby(<<-EOF)


### PR DESCRIPTION
This PR integrates `Object` methods on method call checks.

The purpose is for calls to "implicit methods" such as `.nil?`, `==` or `.to_s` to not be tagged by `steep` as not implemented.

Fixes #392 