### PR TITLE
Extend the functionality of hover in rbs files.

### DIFF
--- a/lib/steep/services/hover_content.rb
+++ b/lib/steep/services/hover_content.rb
@@ -6,6 +6,9 @@ module Steep
       MethodCallContent = Struct.new(:node, :method_name, :type, :definition, :location, keyword_init: true)
       DefinitionContent = Struct.new(:node, :method_name, :method_type, :definition, :location, keyword_init: true) do
       TypeAliasContent = Struct.new(:location, :decl, keyword_init: true)
+      ClassContent = Struct.new(:location, :decl, keyword_init: true)
+      InterfaceContent = Struct.new(:location, :decl, keyword_init: true)
+
         def comment_string
           if comments = definition&.comments
             comments.map {|c| c.string.chomp }.uniq.join("\n----\n")
@@ -75,6 +78,25 @@ module Steep
             TypeAliasContent.new(
               location: location,
               decl: alias_decl
+            )
+          when RBS::Types::ClassInstance, RBS::Types::ClassSingleton
+            if hd == :name
+              env = service.latest_env
+              class_decl = env.class_decls[type.name]&.decls[0]&.decl or raise
+              location = tail[0].location[:name]
+              ClassContent.new(
+                location: location,
+                decl: class_decl
+              )
+            end
+          when RBS::Types::Interface
+            env = service.latest_env
+            interface_decl = env.interface_decls[type.name]&.decl or raise
+            location = type.location
+
+            InterfaceContent.new(
+              location: location,
+              decl: interface_decl
             )
           end
         end

--- a/lib/steep/services/hover_content.rb
+++ b/lib/steep/services/hover_content.rb
@@ -92,7 +92,7 @@ module Steep
           when RBS::Types::Interface
             env = service.latest_env
             interface_decl = env.interface_decls[type.name]&.decl or raise
-            location = type.location
+            location = type.location[:name]
 
             InterfaceContent.new(
               location: location,

--- a/test/hover_test.rb
+++ b/test/hover_test.rb
@@ -318,7 +318,7 @@ RBS
       hover = HoverContent.new(service: service)
       hover.content_for(path: Pathname("hello.rbs"), line: 6, column: 13).tap do |content|
         assert_instance_of HoverContent::InterfaceContent, content
-        assert_instance_of RBS::Location::WithChildren, content.location
+        assert_instance_of RBS::Location, content.location
         assert_equal content.location.start_line, 6
         assert_equal content.location.start_column, 12
         assert_instance_of RBS::AST::Declarations::Interface, content.decl

--- a/test/hover_test.rb
+++ b/test/hover_test.rb
@@ -218,9 +218,9 @@ RBS
     end
   end
 
-  def test_hover_on_rbs
+  def test_hover_alias_on_rbs
     in_tmpdir do
-      service = typecheck_service()
+      service = typecheck_service
 
       service.update(
         changes: {
@@ -242,6 +242,86 @@ RBS
 
         assert_equal content.location.start_line, 4
         assert_equal content.location.start_column, 10
+      end
+    end
+  end
+
+  def test_hover_class_singleton_on_rbs
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+class C
+  def foo: () -> singleton(String)
+end
+RBS
+        }
+      ) {}
+
+      hover = HoverContent.new(service: service)
+      hover.content_for(path: Pathname("hello.rbs"), line: 2, column: 28).tap do |content|
+        assert_instance_of HoverContent::ClassContent, content
+        assert_instance_of RBS::Location, content.location
+        assert_equal content.location.start_line, 2
+        assert_equal content.location.start_column, 27
+        assert_instance_of RBS::AST::Declarations::Class, content.decl
+      end
+    end
+  end
+
+  def test_hover_class_instance_on_rbs
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+class Hoge end
+class Qux
+  @foo: Hoge
+end
+RBS
+        }
+      ) {}
+
+      hover = HoverContent.new(service: service)
+      hover.content_for(path: Pathname("hello.rbs"), line: 3, column: 9).tap do |content|
+        assert_instance_of HoverContent::ClassContent, content
+        assert_instance_of RBS::Location, content.location
+        assert_equal content.location.start_line, 3
+        assert_equal content.location.start_column, 8
+        assert_instance_of RBS::AST::Declarations::Class, content.decl
+      end
+    end
+  end
+
+  def test_hover_interface_on_rbs
+    in_tmpdir do
+      service = typecheck_service()
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+interface _Fooable
+  def foo: () -> nil
+end
+
+class Foo
+  def foo: (_Fooable) -> singleton(String)
+end
+RBS
+        }
+      ) {}
+
+      hover = HoverContent.new(service: service)
+      hover.content_for(path: Pathname("hello.rbs"), line: 6, column: 13).tap do |content|
+        assert_instance_of HoverContent::InterfaceContent, content
+        assert_instance_of RBS::Location::WithChildren, content.location
+        assert_equal content.location.start_line, 6
+        assert_equal content.location.start_column, 12
+        assert_instance_of RBS::AST::Declarations::Interface, content.decl
       end
     end
   end


### PR DESCRIPTION
add hover supports for `RBS::Types::ClassInstance`, `RBS::Types::ClassSingleton` and `RBS::Types::Interface`.

When these are hovered, the information and comments will now be displayed!

![image](https://user-images.githubusercontent.com/18569016/125070604-28232a00-e0f3-11eb-85eb-88bb01082d4d.png)

### How to test
crate a rbs file with this content and you can confirm that you can see the information when you hover them
```rbs
# my comment
class Foo [T] < Parent[T]
end

class Parent [in T]
end

module Hoge
end

class Qux
  @foo: Foo[Hoge]
end

interface _Fooable
  def foo: () -> nil
end

class C
  def foo: (_Fooable) -> singleton(String)
end
```