### PR TITLE
Allow break without value from bot methods

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1161,14 +1161,16 @@ module Steep
                   )
                 end
               else
-                check_relation(sub_type: AST::Builtin.nil_type, super_type: break_type).else do |result|
-                  typing.add_error(
-                    Diagnostic::Ruby::ImplicitBreakValueMismatch.new(
-                      node: node,
-                      jump_type: break_type,
-                      result: result
+                unless break_type.is_a?(AST::Types::Bot)
+                  check_relation(sub_type: AST::Builtin.nil_type, super_type: break_type).else do |result|
+                    typing.add_error(
+                      Diagnostic::Ruby::ImplicitBreakValueMismatch.new(
+                        node: node,
+                        jump_type: break_type,
+                        result: result
+                      )
                     )
-                  )
+                  end
                 end
               end
             else

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -7741,4 +7741,24 @@ RUBY
       end
     end
   end
+
+  def test_break_from_loop
+    with_checker(<<RBS) do |checker|
+class Object
+  def loop: () { () -> void } -> bot
+end
+RBS
+      source = parse_ruby(<<RUBY)
+loop do
+  break
+end
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a special case for `break` from `#loop`.

```
loop do
  break if foo
end
```

1. The return type of `#loop` is `bot`, which implies the return value is not used
2. It `break`s without value == returning no value
3. Hiding type error for that `break` would make sense 💡 