### PR TITLE
Should be ignored hover for none target files

### DIFF
--- a/lib/steep/services/hover_content.rb
+++ b/lib/steep/services/hover_content.rb
@@ -61,6 +61,7 @@ module Steep
           hover_for_source(column, line, path, target)
         when (_, targets = project.targets_for_path(path))
           target = targets[0]
+          return unless target
           service = self.service.signature_services[target.name]
           _buffer, decls = service.latest_env.buffers_decls.find do |buffer, _|
             Pathname(buffer.name) == path

--- a/test/hover_test.rb
+++ b/test/hover_test.rb
@@ -68,6 +68,8 @@ RUBY
         assert_equal [3,8]...[3, 24], [content.location.line,content.location.column]...[content.location.last_line, content.location.last_column]
         assert_equal "::Array[(::Integer | ::String)]", content.type.to_s
       end
+
+      assert_nil hover.content_for(path: Pathname("nothing.rb"), line: 0, column: 0)
     end
   end
 


### PR DESCRIPTION
I use steep on vscode with master version ( 43f896d ).

But it rails an error when hover with none target files.

![image](https://user-images.githubusercontent.com/935310/128879814-511d2dda-5bfc-4aef-9660-a3ec8f2c5d97.png)

I fixed it.