### PR TITLE
Fix NoMethodError when csend

### DIFF
--- a/lib/steep/type_inference/send_args.rb
+++ b/lib/steep/type_inference/send_args.rb
@@ -578,8 +578,12 @@ module Steep
 
                   break
                 end
-              when PositionalArgs::UnexpectedArg, PositionalArgs::MissingArg
+              when PositionalArgs::UnexpectedArg
                 errors << value
+              when PositionalArgs::MissingArg
+                if node.type != :csend
+                  errors << value
+                end
               end
             end
           end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -7576,6 +7576,27 @@ end
     end
   end
 
+  def test_missing_args_with_csend
+    with_checker(<<-RBS) do |checker|
+module MissingArgs
+  class Foo
+    def csend: (Integer) -> void
+  end
+end
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+MissingArgs::Foo.new&.csend
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_ruby3_endless_def
     with_checker(<<-RBS) do |checker|
 module Ruby3


### PR DESCRIPTION
I encountered the following error.

![image](https://user-images.githubusercontent.com/935310/128886521-e89ece69-b809-4189-bfe2-ce6e86309c7a.png)

And I found out that the backtrace is happening for `csend` at the fix point.
I hope this error will fix.