### PR TITLE
Fix error when MissingArg with numblock

### DIFF
--- a/lib/steep/type_inference/send_args.rb
+++ b/lib/steep/type_inference/send_args.rb
@@ -578,8 +578,12 @@ module Steep
 
                   break
                 end
-              when PositionalArgs::UnexpectedArg, PositionalArgs::MissingArg
+              when PositionalArgs::UnexpectedArg
                 errors << value
+              when PositionalArgs::MissingArg
+                if node.type != :numblock
+                  errors << value
+                end
               end
             end
           end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -7665,6 +7665,30 @@ RUBY
     end
   end
 
+  def test_ruby3_numbered_parameter4
+    with_checker(<<RBS) do |checker|
+module Ruby3
+  class Foo
+    def foo: (Integer) -> void
+           | () { (Integer) -> void } -> void
+  end
+end
+RBS
+
+      source = parse_ruby(<<RUBY)
+Ruby3::Foo.new().foo do
+  _1
+end
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_type_check_def_without_decl
     with_checker(<<RBS) do |checker|
 RBS


### PR DESCRIPTION
If MissingArg with numblock, it should not be InsuficientPositionalArguments.

### Before

![image](https://user-images.githubusercontent.com/935310/129898966-5705e48c-4d6b-4bc9-9660-57ab249b25b7.png)


### After

![image](https://user-images.githubusercontent.com/935310/129898831-481364f4-031f-45f2-a1a4-f1c625159053.png)
