### PR TITLE
Fix Unexpected error

### DIFF
--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -275,6 +275,34 @@ module Steep
         end
       end
 
+      class MixinClassError < Base
+        attr_reader :member
+        attr_reader :type_name
+
+        def initialize(location:, member:, type_name:)
+          super(location: location)
+          @member = member
+          @type_name = type_name
+        end
+
+        def header_line
+          "Cannot #{mixin_name} a class `#{member.name}` in the definition of `#{type_name}`"
+        end
+
+        private
+
+        def mixin_name
+          case member
+          when RBS::AST::Members::Prepend
+            "prepend"
+          when RBS::AST::Members::Include
+            "include"
+          when RBS::AST::Members::Extend
+            "extend"
+          end
+        end
+      end
+
       class UnexpectedError < Base
         attr_reader :message
 
@@ -364,6 +392,12 @@ module Steep
             name: error.type_name,
             param: error.param,
             location: error.location
+          )
+        when RBS::MixinClassError
+          Diagnostic::Signature::MixinClassError.new(
+            location: error.location,
+            type_name: error.type_name,
+            member: error.member,
           )
         else
           raise error

--- a/smoke/diagnostics-rbs/mixin-class-error.rbs
+++ b/smoke/diagnostics-rbs/mixin-class-error.rbs
@@ -1,0 +1,6 @@
+class Foo
+end
+
+class Bar
+  include Foo
+end

--- a/smoke/diagnostics-rbs/test_expectations.yml
+++ b/smoke/diagnostics-rbs/test_expectations.yml
@@ -229,3 +229,15 @@
     severity: ERROR
     message: Cannot find type `ZZZ`
     code: RBS::UnknownTypeName
+- file: mixin-class-error.rbs
+  diagnostics:
+  - range:
+      start:
+        line: 5
+        character: 2
+      end:
+        line: 5
+        character: 13
+    severity: ERROR
+    message: Cannot include a class `::Foo` in the definition of `::Bar`
+    code: RBS::MixinClassError


### PR DESCRIPTION
If `RBS::MixinClassError` is raised during a steep check, the steep worker thread will be in a wait state forever.

With this fix, not only will steep not stop when `RBS::MixinClassError` is raised, but it will also show the problem.


```
mixin-class-error.rbs:5:2: [error] Cannot include a class `::Foo` in the definition of `::Bar`
│ Diagnostic ID: RBS::MixinClassError
│
└   include Foo
    ~~~~~~~~~~~
```