### PR TITLE
Compact error reporting for method body type mismatch

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -471,7 +471,7 @@ module Steep
         include ResultPrinter
 
         def initialize(node:, expected:, actual:, result:)
-          super(node: node)
+          super(node: node, location: node.loc.name)
           @expected = expected
           @actual = actual
           @result = result

--- a/smoke/class/test_expectations.yml
+++ b/smoke/class/test_expectations.yml
@@ -14,10 +14,10 @@
   - range:
       start:
         line: 13
-        character: 2
+        character: 6
       end:
-        line: 15
-        character: 5
+        line: 13
+        character: 10
     severity: ERROR
     message: |-
       Cannot allow method body have type `::Integer` because declared as type `::String`
@@ -29,10 +29,10 @@
   - range:
       start:
         line: 22
-        character: 2
+        character: 11
       end:
-        line: 24
-        character: 5
+        line: 22
+        character: 14
     severity: ERROR
     message: |-
       Cannot allow method body have type `::String` because declared as type `::Integer`

--- a/smoke/diagnostics/test_expectations.yml
+++ b/smoke/diagnostics/test_expectations.yml
@@ -233,10 +233,10 @@
   - range:
       start:
         line: 3
-        character: 2
+        character: 6
       end:
-        line: 5
-        character: 5
+        line: 3
+        character: 9
     severity: ERROR
     message: |-
       Cannot allow method body have type `::String` because declared as type `::Integer`

--- a/smoke/ensure/test_expectations.yml
+++ b/smoke/ensure/test_expectations.yml
@@ -32,10 +32,10 @@
   - range:
       start:
         line: 13
-        character: 0
+        character: 4
       end:
-        line: 18
-        character: 3
+        line: 13
+        character: 7
     severity: ERROR
     message: |-
       Cannot allow method body have type `::Integer` because declared as type `::String`

--- a/smoke/method/test_expectations.yml
+++ b/smoke/method/test_expectations.yml
@@ -4,10 +4,10 @@
   - range:
       start:
         line: 3
-        character: 0
+        character: 4
       end:
-        line: 11
-        character: 3
+        line: 3
+        character: 7
     severity: ERROR
     message: |-
       Cannot allow method body have type `::Integer` because declared as type `::String`
@@ -77,10 +77,10 @@
   - range:
       start:
         line: 4
-        character: 2
+        character: 6
       end:
-        line: 6
-        character: 5
+        line: 4
+        character: 9
     severity: ERROR
     message: |-
       Cannot allow method body have type `::Symbol` because declared as type `(::Integer | ::String)`

--- a/smoke/rescue/test_expectations.yml
+++ b/smoke/rescue/test_expectations.yml
@@ -64,10 +64,10 @@
   - range:
       start:
         line: 37
-        character: 0
+        character: 4
       end:
-        line: 41
-        character: 3
+        line: 37
+        character: 7
     severity: ERROR
     message: |-
       Cannot allow method body have type `(::Integer | ::String)` because declared as type `::String`

--- a/smoke/toplevel/test_expectations.yml
+++ b/smoke/toplevel/test_expectations.yml
@@ -4,10 +4,10 @@
   - range:
       start:
         line: 1
-        character: 0
+        character: 4
       end:
-        line: 3
-        character: 3
+        line: 1
+        character: 13
     severity: ERROR
     message: |-
       Cannot allow method body have type `nil` because declared as type `::String`


### PR DESCRIPTION
This PR is to report method body type error only for method name, because reporting type error for all of `def` syntax looks really verbose and hides other errors inside the method definition.

### Before

<img width="338" alt="スクリーンショット 2021-08-22 18 41 56" src="https://user-images.githubusercontent.com/139089/130350402-64db0b29-2e86-4006-bf12-7047d737d53b.png">

### After

<img width="363" alt="スクリーンショット 2021-08-22 18 42 18" src="https://user-images.githubusercontent.com/139089/130350406-00d396de-1cab-435d-963d-b6ad516f54d2.png">
