### PR TITLE
Avoid to stop process by invalid jobs_count

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -70,7 +70,7 @@ module Steep
       default = physical_processor_count + modifier
       command.jobs_count = default
       opts.on("-j N", "--jobs=N", "Specify the number of type check workers (defaults: #{default})") do |count|
-        command.jobs_count = Integer(count)
+        command.jobs_count = Integer(count) if Integer(count) > 0
       end
     end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -24,6 +24,30 @@ class CLITest < Minitest::Test
     end
   end
 
+  def test_jobs_count
+    sub_test = -> (command, args) do
+      in_tmpdir do
+        (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+        EOF
+
+        (current_dir + "foo.rb").write(<<-EOF)
+1 + 2
+        EOF
+
+        stdout, status = sh(*steep, command, *args)
+
+        assert_predicate status, :success?, stdout
+        assert_match /No type error detected\./, stdout
+      end
+    end
+    sub_test.call("check", %w(-j 1))
+    sub_test.call("check", %w(-j 0))
+    sub_test.call("check", %w(-j -1))
+  end
+
   def test_check_success
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)


### PR DESCRIPTION
If jobs_count is specified 0 or less, the progress of steep is stopped in middle. Hence I modified so that default count is used if invalid jobs count is specified.