### PR TITLE
Enable RBS collection feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       parallel (>= 1.0.0)
       parser (>= 3.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 1.2.0)
+      rbs (>= 1.6.0)
       terminal-table (>= 2, < 4)
 
 PATH
@@ -74,4 +74,4 @@ DEPENDENCIES
   without_steep_types!
 
 BUNDLED WITH
-   2.2.22
+   2.2.27

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -13,6 +13,7 @@ module Steep
 
       attr_reader :libraries
       attr_accessor :paths
+      attr_accessor :collection_lock
 
       def initialize
         @paths = PathOptions.new(repo_paths: [])

--- a/lib/steep/project/target.rb
+++ b/lib/steep/project/target.rb
@@ -57,6 +57,7 @@ module Steep
           name, version = lib.split(/:/, 2)
           loader.add(library: name, version: version)
         end
+        loader.add_collection(options.collection_lock) if options.collection_lock
 
         loader
       end

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", ">= 1.2.0"
+  spec.add_runtime_dependency "rbs", ">= 1.6.0"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
 end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -131,4 +131,80 @@ RUBY
       end
     end
   end
+
+  def test_collection_implicit
+    in_tmpdir do
+      current_dir.join('rbs_collection.yaml').write('')
+      current_dir.join('rbs_collection.lock.yaml').write(<<YAML)
+sources: []
+path: '.gem_rbs_collection'
+gems:
+  - name: pathname
+    source:
+      type: stdlib
+YAML
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<EOF)
+target :app do
+end
+EOF
+
+      project.targets[0].tap do |target|
+        assert target.options.collection_lock
+        assert target.options.collection_lock.gem('pathname')
+      end
+    end
+  end
+
+  def test_collection_explicit
+    in_tmpdir do
+      current_dir.join('my-rbs_collection.yaml').write('')
+      current_dir.join('my-rbs_collection.lock.yaml').write(<<YAML)
+sources: []
+path: '.gem_rbs_collection'
+gems:
+  - name: pathname
+    source:
+      type: stdlib
+YAML
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<EOF)
+target :app do
+  collection_config 'my-rbs_collection.yaml'
+end
+EOF
+
+      project.targets[0].tap do |target|
+        assert target.options.collection_lock
+        assert target.options.collection_lock.gem('pathname')
+      end
+    end
+  end
+
+  def test_disable_collection
+    in_tmpdir do
+      current_dir.join('rbs_collection.yaml').write('')
+      current_dir.join('rbs_collection.lock.yaml').write(<<YAML)
+sources: []
+path: '.gem_rbs_collection'
+gems:
+  - name: pathname
+    source:
+      type: stdlib
+YAML
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<EOF)
+target :app do
+  disable_collection
+end
+EOF
+
+      project.targets[0].tap do |target|
+        assert_nil target.options.collection_lock
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces `rbs collection` feature, https://github.com/ruby/rbs/pull/589,  to Steep.


# Usage


* If `rbs_collection.yaml` exists in the same directory as `Steepfile`, Steep loads libraries' RBSs from the config file.
* If `collection_config path` is specified in Steepfile, Steep loads libraries' RBSs from the specified file.
  * I suppose the configuration will be used like `collection_config '../other/path/rbs_collection.yaml'` in many cases.
* If `disable_collection` is specified in Steepfile, Steep ignores `rbs_collection.yaml`.
* If `rbs_collection.yaml` doesn't exist and no options are specified, Steep does nothing about rbs collection feature.



