### PR TITLE
Revise path DSL

### DIFF
--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -1,20 +1,28 @@
 module Steep
   class Project
     class Options
+      PathOptions = Struct.new(:core_root, :stdlib_root, :repo_paths, keyword_init: true) do
+        def customized_stdlib?
+          stdlib_root != nil
+        end
+
+        def customized_core?
+          core_root != nil
+        end
+      end
+
       attr_accessor :allow_fallback_any
       attr_accessor :allow_missing_definitions
       attr_accessor :allow_unknown_constant_assignment
       attr_accessor :allow_unknown_method_calls
-      attr_accessor :vendor_path
+
       attr_reader :libraries
-      attr_reader :repository_paths
+      attr_accessor :paths
 
       def initialize
         apply_default_typing_options!
-        self.vendor_path = nil
-
+        @paths = PathOptions.new(repo_paths: [])
         @libraries = []
-        @repository_paths = []
       end
 
       def apply_default_typing_options!

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -18,7 +18,8 @@ target :app do
   typing_options :strict
   check "app"
   ignore "app/views"
-  vendor
+
+  stdlib_path(core_root: "vendor/rbs/core", stdlib_root: "vendor/rbs/stdlib")
 
   signature "sig", "sig-private"
 
@@ -27,6 +28,7 @@ target :app do
 end
 
 target :Gemfile, template: :gemfile do
+  stdlib_path(core_root: false, stdlib_root: false)
 end
 EOF
 
@@ -38,7 +40,8 @@ EOF
         assert_equal ["app/views"], target.source_pattern.ignores
         assert_equal ["sig", "sig-private"], target.signature_pattern.patterns
         assert_equal ["set", "strong_json"], target.options.libraries
-        assert_equal Pathname("vendor/sigs"), target.options.vendor_path
+        assert_equal Pathname("vendor/rbs/core"), target.options.paths.core_root
+        assert_equal Pathname("vendor/rbs/stdlib"), target.options.paths.stdlib_root
         assert_equal false, target.options.allow_missing_definitions
       end
 
@@ -48,7 +51,8 @@ EOF
         assert_equal [], target.source_pattern.ignores
         assert_equal [], target.signature_pattern.patterns
         assert_equal ["gemfile"], target.options.libraries
-        assert_nil target.options.vendor_path
+        assert_equal false, target.options.paths.core_root
+        assert_equal false, target.options.paths.stdlib_root
         assert_equal true, target.options.allow_missing_definitions
       end
     end
@@ -62,7 +66,6 @@ EOF
 target :app do
   check "app"
   ignore "app/views"
-  vendor
 
   typing_options :strict,
                  allow_missing_definitions: true,
@@ -102,7 +105,9 @@ target :app do
   repo_path "vendor/rbs/internal"
 end
 EOF
-      assert_equal [Pathname("vendor/rbs/internal")], project.targets[0].options.repository_paths
+      project.targets[0].tap do |target|
+        assert_equal [Pathname("vendor/rbs/internal")], target.options.paths.repo_paths
+      end
     end
   end
 end

--- a/test/target_test.rb
+++ b/test/target_test.rb
@@ -4,39 +4,56 @@ module Steep
   class TargetTest < Minitest::Test
     include TestHelper
 
-    def test_environment_loader
+    def with_dir
       Dir.mktmpdir do |dir|
         path = Pathname(dir)
 
         (path + "vendor/repo").mkpath
         (path + "vendor/core").mkpath
+        (path + "vendor/stdlib").mkpath
 
         project = Project.new(steepfile_path: path + "Steepfile")
+        yield project, path
+      end
+    end
 
-        Project::Target.construct_env_loader(
-          options: Project::Options.new.tap {|opts|
-            opts.repository_paths << path + "vendor/repo"
-          },
-          project: project
-        ).tap do |loader|
-          refute_nil loader.core_root
+    def test_environment_loader_default
+      with_dir do |project, path|
+        options = Project::Options.new()
+        options.paths.core_root = nil
+        options.paths.stdlib_root = nil
 
+        Project::Target.construct_env_loader(options: options, project: project).tap do |loader|
+          assert_equal RBS::EnvironmentLoader::DEFAULT_CORE_ROOT, loader.core_root
           assert_includes loader.repository.dirs, RBS::Repository::DEFAULT_STDLIB_ROOT
+        end
+      end
+    end
+
+    def test_environment_loader_custom
+      with_dir do |project, path|
+        options = Project::Options.new()
+        options.paths.core_root = Pathname("vendor/core")
+        options.paths.stdlib_root = Pathname("vendor/stdlib")
+        options.paths.repo_paths << Pathname("vendor/repo")
+
+        Project::Target.construct_env_loader(options: options, project: project).tap do |loader|
+          assert_equal path + "vendor/core", loader.core_root
+          assert_includes loader.repository.dirs, path + "vendor/stdlib"
           assert_includes loader.repository.dirs, path + "vendor/repo"
         end
+      end
+    end
 
-        Project::Target.construct_env_loader(
-          options: Project::Options.new.tap {|opts|
-            opts.vendor_path = path + "vendor/core"
-            opts.repository_paths << path + "vendor/repo"
-          },
-          project: project
-        ).tap do |loader|
+    def test_environment_loader_none
+      with_dir do |project, path|
+        options = Project::Options.new()
+        options.paths.core_root = false
+        options.paths.stdlib_root = false
+
+        Project::Target.construct_env_loader(options: options, project: project).tap do |loader|
           assert_nil loader.core_root
-
-          assert_includes loader.dirs, path + "vendor/core"
-          refute_includes loader.repository.dirs, RBS::Repository::DEFAULT_STDLIB_ROOT
-          assert_includes loader.repository.dirs, path + "vendor/repo"
+          assert_empty loader.repository.dirs
         end
       end
     end


### PR DESCRIPTION
The `vendor` DSL was broken. This PR introduces new `stdlib_path` DSL to customize _core_root_ and _stdlib_root_ with keyword argument.

```rb
target(:app) do
  stdlib_path(
    core_root: "vendor/rbs/core",              # Load core RBS from vendor/rbs/core/*.rbs
    stdlib_root: nil                           # Load stdlib RBS from default place
  )
end

target(:test) do
  stdlib_path(
    core_root: false,        # Skip loading core RBSs
    stdlib_root: false       # Skip loading stdlib RBSs
  )

  signature "sig"            # You have to write RBS files of core classes in "sig" directory
end
```