### PR TITLE
Flexible diagnostics configuration

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -99,6 +99,9 @@ module Steep
           opts.on("--save-expectations[=PATH]", "Save expectations with current type check result to PATH (or steep_expectations.yml)") do |path|
             check.save_expectations_path = Pathname(path || "steep_expectations.yml")
           end
+          opts.on("--severity-level=LEVEL", /^error|warning|information|hint$/, "Specify the minimum diagnostic severity to be recognized as an error (defaults: warning): error, warning, information, or hint") do |level|
+            check.severity_level = level.to_sym
+          end
           handle_jobs_option check, opts
           handle_logging_options opts
         end.parse!(argv)
@@ -155,6 +158,9 @@ module Steep
       Drivers::Watch.new(stdout: stdout, stderr: stderr).tap do |command|
         OptionParser.new do |opts|
           opts.banner = "Usage: steep watch [options] [dirs]"
+          opts.on("--severity-level=LEVEL", /^error|warning|information|hint$/, "Specify the minimum diagnostic severity to be recognized as an error (defaults: warning): error, warning, information, or hint") do |level|
+            command.severity_level = level.to_sym
+          end
           handle_jobs_option command, opts
           handle_logging_options opts
         end.parse!(argv)

--- a/lib/steep/diagnostic/lsp_formatter.rb
+++ b/lib/steep/diagnostic/lsp_formatter.rb
@@ -3,13 +3,66 @@ module Steep
     class LSPFormatter
       LSP = LanguageServer::Protocol
 
+      attr_reader :config
+      attr_reader :default_severity
+
+      ERROR = :error
+      WARNING = :warning
+      INFORMATION = :information
+      HINT = :hint
+
+      def initialize(config = {}, default_severity: ERROR)
+        @config = config
+        @default_severity = default_severity
+
+        config.each do |klass, severity|
+          validate_severity(klass, severity)
+          validate_class(klass)
+        end
+        validate_severity(:default, default_severity)
+      end
+
+      def validate_class(klass)
+        unless klass < Diagnostic::Ruby::Base
+          raise "Unexpected diagnostics class `#{klass}` given"
+        end
+      end
+
+      def validate_severity(klass, severity)
+        case severity
+        when ERROR, WARNING, INFORMATION, HINT, nil
+          # ok
+        else
+          raise "Unexpected severity `#{severity}` is specified for #{klass}"
+        end
+      end
+
       def format(diagnostic)
-        LSP::Interface::Diagnostic.new(
-          message: diagnostic.full_message,
-          code: diagnostic.diagnostic_code,
-          severity: LSP::Constant::DiagnosticSeverity::ERROR,
-          range: diagnostic.location.as_lsp_range
-        ).to_hash
+        severity = severity_for(diagnostic)
+
+        if severity
+          LSP::Interface::Diagnostic.new(
+            message: diagnostic.full_message,
+            code: diagnostic.diagnostic_code,
+            severity: severity,
+            range: diagnostic.location.as_lsp_range
+          ).to_hash
+        end
+      end
+
+      def severity_for(diagnostic)
+        case config.fetch(diagnostic.class, default_severity)
+        when ERROR
+          LSP::Constant::DiagnosticSeverity::ERROR
+        when WARNING
+          LSP::Constant::DiagnosticSeverity::WARNING
+        when INFORMATION
+          LSP::Constant::DiagnosticSeverity::INFORMATION
+        when HINT
+          LSP::Constant::DiagnosticSeverity::HINT
+        when nil
+          nil
+        end
       end
     end
   end

--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -700,6 +700,57 @@ module Steep
           "SyntaxError: #{message}"
         end
       end
+
+      ALL = ObjectSpace.each_object(Class).with_object([]) do |klass, array|
+        if klass < Base
+          array << klass
+        end
+      end
+
+      def self.all_error
+        @all_error ||= ALL.each.with_object({}) do |klass, hash|
+          hash[klass] = LSPFormatter::ERROR
+        end.freeze
+      end
+
+      def self.default
+        @default ||= all_error.merge(
+          {
+            ImplicitBreakValueMismatch => :warning,
+            FallbackAny => :information,
+            ElseOnExhaustiveCase => :warning,
+            UnknownConstantAssigned => :warning,
+            MethodDefinitionMissing => :information
+          }
+        ).freeze
+      end
+
+      def self.strict
+        @strict ||= all_error.merge(
+          {
+            NoMethod => nil,
+            ImplicitBreakValueMismatch => nil,
+            FallbackAny => nil,
+            ElseOnExhaustiveCase => nil,
+            UnknownConstantAssigned => nil,
+            MethodDefinitionMissing => nil
+          }
+        ).freeze
+      end
+
+      def self.lenient
+        @lenient ||= all_error.merge(
+          {
+            NoMethod => nil,
+            ImplicitBreakValueMismatch => nil,
+            FallbackAny => nil,
+            ElseOnExhaustiveCase => nil,
+            UnknownConstantAssigned => nil,
+            MethodDefinitionMissing => nil,
+            UnexpectedJump => nil
+          }
+        ).freeze
+      end
     end
   end
 end

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -8,6 +8,7 @@ module Steep
       attr_reader :command_line_patterns
       attr_accessor :with_expectations_path
       attr_accessor :save_expectations_path
+      attr_accessor :severity_level
 
       include Utils::DriverHelper
       include Utils::JobsCount
@@ -16,6 +17,7 @@ module Steep
         @stdout = stdout
         @stderr = stderr
         @command_line_patterns = []
+        @severity_level = :warning
       end
 
       def run
@@ -70,6 +72,7 @@ module Steep
           case
           when response[:method] == "textDocument/publishDiagnostics"
             ds = response[:params][:diagnostics]
+            ds.select! {|d| keep_diagnostic?(d) }
             if ds.empty?
               stdout.print "."
             else

--- a/lib/steep/drivers/init.rb
+++ b/lib/steep/drivers/init.rb
@@ -8,6 +8,8 @@ module Steep
       include Utils::DriverHelper
 
       TEMPLATE = <<~EOF
+      # D = Steep::Diagnostic
+      #
       # target :lib do
       #   signature "sig"
       #
@@ -18,15 +20,20 @@ module Steep
       #
       #   # library "pathname", "set"       # Standard libraries
       #   # library "strong_json"           # Gems
+      #   
+      #   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
+      #   # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
+      #   # configure_code_diagnostics do |hash|             # You can setup everything yourself
+      #   #   hash[D::Ruby::NoMethod] = :information
+      #   # end
       # end
 
-      # target :spec do
+      # target :test do
       #   signature "sig", "sig-private"
       #
-      #   check "spec"
+      #   check "test"
       #
       #   # library "pathname", "set"       # Standard libraries
-      #   # library "rspec"
       # end
       EOF
 

--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -55,6 +55,21 @@ module Steep
             end
           end
         end
+
+        def keep_diagnostic?(diagnostic)
+          severity = diagnostic[:severity]
+
+          case self.severity_level
+          when nil, :hint
+            true
+          when :error
+            severity <= LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR
+          when :warning
+            severity <= LanguageServer::Protocol::Constant::DiagnosticSeverity::WARNING
+          when :information
+            severity <= LanguageServer::Protocol::Constant::DiagnosticSeverity::INFORMATION
+          end
+        end
       end
     end
   end

--- a/lib/steep/drivers/validate.rb
+++ b/lib/steep/drivers/validate.rb
@@ -36,7 +36,7 @@ module Steep
 
           any_error ||= !errors.empty?
 
-          formatter = Diagnostic::LSPFormatter.new
+          formatter = Diagnostic::LSPFormatter.new({})
           diagnostics = errors.group_by {|e| e.location.buffer }.transform_values do |errors|
             errors.map {|error| formatter.format(error) }
           end

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -5,6 +5,7 @@ module Steep
       attr_reader :stdout
       attr_reader :stderr
       attr_reader :queue
+      attr_accessor :severity_level
 
       include Utils::DriverHelper
       include Utils::JobsCount
@@ -16,6 +17,7 @@ module Steep
         @stdout = stdout
         @stderr = stderr
         @queue = Thread::Queue.new
+        @severity_level = :warning
       end
 
       def watching?(changed_path, files:, dirs:)
@@ -126,6 +128,7 @@ module Steep
               printer = DiagnosticPrinter.new(stdout: stdout, buffer: buffer)
 
               diagnostics = response[:params][:diagnostics]
+              diagnostics.filter! {|d| keep_diagnostic?(d) }
 
               unless diagnostics.empty?
                 diagnostics.each do |diagnostic|

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -146,7 +146,7 @@ module Steep
                    self.class.templates[template]&.dup&.update(name: name) or
                      raise "Unknown template: #{template}, available templates: #{@@templates.keys.join(", ")}"
                  else
-                   TargetDSL.new(name)
+                   TargetDSL.new(name, code_diagnostics_config: Diagnostic::Ruby.default.dup)
                  end
 
         Steep.logger.tagged "target=#{name}" do

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -11,61 +11,12 @@ module Steep
         end
       end
 
-      attr_accessor :allow_fallback_any
-      attr_accessor :allow_missing_definitions
-      attr_accessor :allow_unknown_constant_assignment
-      attr_accessor :allow_unknown_method_calls
-
       attr_reader :libraries
       attr_accessor :paths
 
       def initialize
-        apply_default_typing_options!
         @paths = PathOptions.new(repo_paths: [])
         @libraries = []
-      end
-
-      def apply_default_typing_options!
-        self.allow_fallback_any = true
-        self.allow_missing_definitions = true
-        self.allow_unknown_constant_assignment = false
-        self.allow_unknown_method_calls = false
-      end
-
-      def apply_strict_typing_options!
-        self.allow_fallback_any = false
-        self.allow_missing_definitions = false
-        self.allow_unknown_constant_assignment = false
-        self.allow_unknown_method_calls = false
-      end
-
-      def apply_lenient_typing_options!
-        self.allow_fallback_any = true
-        self.allow_missing_definitions = true
-        self.allow_unknown_constant_assignment = true
-        self.allow_unknown_method_calls = true
-      end
-
-      def error_to_report?(error)
-        case
-        when error.is_a?(Diagnostic::Ruby::FallbackAny)
-          !allow_fallback_any
-        when error.is_a?(Diagnostic::Ruby::MethodDefinitionMissing)
-          !allow_missing_definitions
-        when error.is_a?(Diagnostic::Ruby::NoMethod)
-          !allow_unknown_method_calls
-        when error.is_a?(Diagnostic::Ruby::UnknownConstantAssigned)
-          !allow_unknown_constant_assignment
-        else
-          true
-        end
-      end
-
-      def merge!(hash)
-        self.allow_fallback_any = hash[:allow_fallback_any] if hash.key?(:allow_fallback_any)
-        self.allow_missing_definitions = hash[:allow_missing_definitions] if hash.key?(:allow_missing_definitions)
-        self.allow_unknown_constant_assignment = hash[:allow_unknown_constant_assignment] if hash.key?(:allow_unknown_constant_assignment)
-        self.allow_unknown_method_calls = hash[:allow_unknown_method_calls] if hash.key?(:allow_unknown_method_calls)
       end
     end
   end

--- a/lib/steep/project/target.rb
+++ b/lib/steep/project/target.rb
@@ -6,12 +6,14 @@ module Steep
 
       attr_reader :source_pattern
       attr_reader :signature_pattern
+      attr_reader :code_diagnostics_config
 
-      def initialize(name:, options:, source_pattern:, signature_pattern:)
+      def initialize(name:, options:, source_pattern:, signature_pattern:, code_diagnostics_config:)
         @name = name
         @options = options
         @source_pattern = source_pattern
         @signature_pattern = signature_pattern
+        @code_diagnostics_config = code_diagnostics_config
 
         @source_files = {}
         @signature_files = {}

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -181,7 +181,7 @@ module Steep
             Steep.logger.info { "Processing TypeCheckCodeJob for guid=#{job.guid}, path=#{job.path}" }
             service.typecheck_source(path: project.relative_path(job.path)) do |path, diagnostics|
               if target = project.target_for_source_path(path)
-                diagnostics = diagnostics.select {|diagnostic| target.options.error_to_report?(diagnostic) }
+                diagnostics = diagnostics.select {|diagnostic| true }
               end
 
               formatter = Diagnostic::LSPFormatter.new()

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -144,7 +144,7 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateAppSignature for guid=#{job.guid}, path=#{job.path}" }
             service.validate_signature(path: project.relative_path(job.path)) do |path, diagnostics|
-              formatter = Diagnostic::LSPFormatter.new()
+              formatter = Diagnostic::LSPFormatter.new({})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",
@@ -162,13 +162,13 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateLibrarySignature for guid=#{job.guid}, path=#{job.path}" }
             service.validate_signature(path: job.path) do |path, diagnostics|
-              formatter = Diagnostic::LSPFormatter.new()
+              formatter = Diagnostic::LSPFormatter.new({})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",
                 params: LSP::Interface::PublishDiagnosticsParams.new(
                   uri: URI.parse(job.path.to_s).tap {|uri| uri.scheme = "file"},
-                  diagnostics: diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq
+                  diagnostics: diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq.compact
                 )
               )
             end
@@ -180,17 +180,14 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing TypeCheckCodeJob for guid=#{job.guid}, path=#{job.path}" }
             service.typecheck_source(path: project.relative_path(job.path)) do |path, diagnostics|
-              if target = project.target_for_source_path(path)
-                diagnostics = diagnostics.select {|diagnostic| true }
-              end
-
-              formatter = Diagnostic::LSPFormatter.new()
+              target = project.target_for_source_path(path)
+              formatter = Diagnostic::LSPFormatter.new({})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",
                 params: LSP::Interface::PublishDiagnosticsParams.new(
                   uri: URI.parse(job.path.to_s).tap {|uri| uri.scheme = "file"},
-                  diagnostics: diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq
+                  diagnostics: diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq.compact
                 )
               )
             end

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -181,7 +181,7 @@ module Steep
             Steep.logger.info { "Processing TypeCheckCodeJob for guid=#{job.guid}, path=#{job.path}" }
             service.typecheck_source(path: project.relative_path(job.path)) do |path, diagnostics|
               target = project.target_for_source_path(path)
-              formatter = Diagnostic::LSPFormatter.new({})
+              formatter = Diagnostic::LSPFormatter.new(target&.code_diagnostics_config || {})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",

--- a/sample/Steepfile
+++ b/sample/Steepfile
@@ -1,6 +1,13 @@
-target :app do
-  check "lib"
+D = Steep::Diagnostic
+
+target :lib do
   signature "sig"
 
-  library "set", "pathname"
+  check "lib"                       # Directory name
+
+  # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
+  # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
+  # configure_code_diagnostics do |hash|             # You can setup everything yourself
+  #   hash[D::Ruby::NoMethod] = :information
+  # end
 end

--- a/smoke/alias/Steepfile
+++ b/smoke/alias/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/alias/Steepfile
+++ b/smoke/alias/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/and/Steepfile
+++ b/smoke/and/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/and/Steepfile
+++ b/smoke/and/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/array/Steepfile
+++ b/smoke/array/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/array/Steepfile
+++ b/smoke/array/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/block/Steepfile
+++ b/smoke/block/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/block/Steepfile
+++ b/smoke/block/Steepfile
@@ -1,5 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
-end
 
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
+end

--- a/smoke/case/Steepfile
+++ b/smoke/case/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/case/Steepfile
+++ b/smoke/case/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/class/Steepfile
+++ b/smoke/class/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/class/Steepfile
+++ b/smoke/class/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/const/Steepfile
+++ b/smoke/const/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/const/Steepfile
+++ b/smoke/const/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/diagnostics-rbs-duplicated/Steepfile
+++ b/smoke/diagnostics-rbs-duplicated/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/diagnostics-rbs-duplicated/Steepfile
+++ b/smoke/diagnostics-rbs-duplicated/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/diagnostics-rbs/Steepfile
+++ b/smoke/diagnostics-rbs/Steepfile
@@ -3,5 +3,6 @@ all_sigs = Pathname.glob("*.rbs")
 all_sigs.each do |path|
   target path.basename(".rbs").to_s.to_sym do
     signature path.to_s
+    configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
   end
 end

--- a/smoke/diagnostics-rbs/Steepfile
+++ b/smoke/diagnostics-rbs/Steepfile
@@ -2,7 +2,6 @@ all_sigs = Pathname.glob("*.rbs")
 
 all_sigs.each do |path|
   target path.basename(".rbs").to_s.to_sym do
-    typing_options :strict
     signature path.to_s
   end
 end

--- a/smoke/diagnostics-ruby-unsat/Steepfile
+++ b/smoke/diagnostics-ruby-unsat/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/diagnostics-ruby-unsat/Steepfile
+++ b/smoke/diagnostics-ruby-unsat/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/diagnostics/Steepfile
+++ b/smoke/diagnostics/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/diagnostics/Steepfile
+++ b/smoke/diagnostics/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/dstr/Steepfile
+++ b/smoke/dstr/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/dstr/Steepfile
+++ b/smoke/dstr/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/ensure/Steepfile
+++ b/smoke/ensure/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/ensure/Steepfile
+++ b/smoke/ensure/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/enumerator/Steepfile
+++ b/smoke/enumerator/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/enumerator/Steepfile
+++ b/smoke/enumerator/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/extension/Steepfile
+++ b/smoke/extension/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/extension/Steepfile
+++ b/smoke/extension/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/hash/Steepfile
+++ b/smoke/hash/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/hash/Steepfile
+++ b/smoke/hash/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/hello/Steepfile
+++ b/smoke/hello/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/hello/Steepfile
+++ b/smoke/hello/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/if/Steepfile
+++ b/smoke/if/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/if/Steepfile
+++ b/smoke/if/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/implements/Steepfile
+++ b/smoke/implements/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/implements/Steepfile
+++ b/smoke/implements/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/initialize/Steepfile
+++ b/smoke/initialize/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/initialize/Steepfile
+++ b/smoke/initialize/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/integer/Steepfile
+++ b/smoke/integer/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/integer/Steepfile
+++ b/smoke/integer/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/interface/Steepfile
+++ b/smoke/interface/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/interface/Steepfile
+++ b/smoke/interface/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/kwbegin/Steepfile
+++ b/smoke/kwbegin/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/kwbegin/Steepfile
+++ b/smoke/kwbegin/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/lambda/Steepfile
+++ b/smoke/lambda/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/lambda/Steepfile
+++ b/smoke/lambda/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/literal/Steepfile
+++ b/smoke/literal/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/literal/Steepfile
+++ b/smoke/literal/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/map/Steepfile
+++ b/smoke/map/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/map/Steepfile
+++ b/smoke/map/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/method/Steepfile
+++ b/smoke/method/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/method/Steepfile
+++ b/smoke/method/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/module/Steepfile
+++ b/smoke/module/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/module/Steepfile
+++ b/smoke/module/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/regexp/Steepfile
+++ b/smoke/regexp/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/regexp/Steepfile
+++ b/smoke/regexp/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/regression/Steepfile
+++ b/smoke/regression/Steepfile
@@ -2,4 +2,6 @@ target :test do
   check "*.rb"
   signature "*.rbs"
   library "set"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/regression/Steepfile
+++ b/smoke/regression/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
   library "set"

--- a/smoke/rescue/Steepfile
+++ b/smoke/rescue/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/rescue/Steepfile
+++ b/smoke/rescue/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/self/Steepfile
+++ b/smoke/self/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/self/Steepfile
+++ b/smoke/self/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/skip/Steepfile
+++ b/smoke/skip/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/skip/Steepfile
+++ b/smoke/skip/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/stdout/Steepfile
+++ b/smoke/stdout/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/stdout/Steepfile
+++ b/smoke/stdout/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/super/Steepfile
+++ b/smoke/super/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/super/Steepfile
+++ b/smoke/super/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/toplevel/Steepfile
+++ b/smoke/toplevel/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/toplevel/Steepfile
+++ b/smoke/toplevel/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/tsort/Steepfile
+++ b/smoke/tsort/Steepfile
@@ -1,5 +1,7 @@
 target :test do
-  signature "."
-  check "."
+  check "*.rb"
+  signature "*.rbs"
   library "tsort"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/tsort/Steepfile
+++ b/smoke/tsort/Steepfile
@@ -1,8 +1,5 @@
 target :test do
   signature "."
   check "."
-
-  typing_options :strict
-
   library "tsort"
 end

--- a/smoke/type_case/Steepfile
+++ b/smoke/type_case/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/type_case/Steepfile
+++ b/smoke/type_case/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/unexpected/Steepfile
+++ b/smoke/unexpected/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/unexpected/Steepfile
+++ b/smoke/unexpected/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/smoke/yield/Steepfile
+++ b/smoke/yield/Steepfile
@@ -1,4 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/yield/Steepfile
+++ b/smoke/yield/Steepfile
@@ -1,5 +1,4 @@
 target :test do
-  typing_options :strict
   check "*.rb"
   signature "*.rbs"
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -399,7 +399,6 @@ RUBY
         Process.waitpid(pid)
         assert_equal 0, $?.exitstatus
       end
-
     end
   end
 

--- a/test/langserver_test.rb
+++ b/test/langserver_test.rb
@@ -24,7 +24,6 @@ class LangserverTest < Minitest::Test
 target :app do
   check "lib"
   signature "sig"
-  typing_options :strict
 end
 EOF
 

--- a/test/lsp_formatter_test.rb
+++ b/test/lsp_formatter_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class LSPFormatterTest < Minitest::Test
+  include TestHelper
+  include Steep
+
+  LSP = LanguageServer::Protocol
+  LSPFormatter = Diagnostic::LSPFormatter
+
+  def node
+    ::Parser::Ruby30.parse("1+2")
+  end
+
+  def test_severity_for
+    formatter = LSPFormatter.new(
+      {
+        Diagnostic::Ruby::FallbackAny => LSPFormatter::INFORMATION
+      },
+      default_severity: LSPFormatter::ERROR
+    )
+
+    assert_equal(
+      LSP::Constant::DiagnosticSeverity::INFORMATION,
+      formatter.severity_for(
+        Diagnostic::Ruby::FallbackAny.new(node: node)
+      )
+    )
+
+    assert_equal(
+      LSP::Constant::DiagnosticSeverity::ERROR,
+      formatter.severity_for(
+        Diagnostic::Ruby::UnexpectedJump.new(node: node)
+      )
+    )
+  end
+end

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -575,7 +575,6 @@ end
 target :lib do
   check "lib"
   signature "sig"
-  typing_options :strict
 end
       EOF
 
@@ -637,7 +636,6 @@ end
 target :lib do
   check "lib"
   signature "sig"
-  typing_options :strict
 end
       EOF
 
@@ -688,7 +686,6 @@ x.ab
 target :lib do
   check "lib"
   signature "sig"
-  typing_options :strict
 end
       EOF
 

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -41,7 +41,6 @@ EOF
         assert_equal ["set", "strong_json"], target.options.libraries
         assert_equal Pathname("vendor/rbs/core"), target.options.paths.core_root
         assert_equal Pathname("vendor/rbs/stdlib"), target.options.paths.stdlib_root
-        assert_equal false, target.options.allow_missing_definitions
       end
 
       project.targets.find {|target| target.name == :Gemfile }.tap do |target|
@@ -52,7 +51,6 @@ EOF
         assert_equal ["gemfile"], target.options.libraries
         assert_equal false, target.options.paths.core_root
         assert_equal false, target.options.paths.stdlib_root
-        assert_equal true, target.options.allow_missing_definitions
       end
     end
   end
@@ -75,7 +73,7 @@ target :app do
 end
 RUBY
 
-        assert_match(/\[Steepfile\] \[target=app\] #typing_options is deprecated and has no effect as of version 0\.45\.0/, Steep.log_output.string)
+        assert_match(/\[Steepfile\] \[target=app\] #typing_options is deprecated and has no effect as of version 0\.46\.0/, Steep.log_output.string)
       ensure
         Steep.log_output = STDERR
       end
@@ -126,10 +124,7 @@ end
 RUBY
 
       project.targets[0].tap do |target|
-        assert_equal(
-          { Diagnostic::Ruby::FallbackAny => :warning },
-          target.code_diagnostics_config
-        )
+        assert_equal :warning, target.code_diagnostics_config[Diagnostic::Ruby::FallbackAny]
       end
     end
   end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -108,4 +108,29 @@ EOF
       end
     end
   end
+
+  def test_diagnostics
+    in_tmpdir do
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<RUBY)
+target :app do
+  repo_path "vendor/rbs/internal"
+
+  configure_code_diagnostics(
+    {
+      Steep::Diagnostic::Ruby::FallbackAny => :warning
+    }
+  )
+end
+RUBY
+
+      project.targets[0].tap do |target|
+        assert_equal(
+          { Diagnostic::Ruby::FallbackAny => :warning },
+          target.code_diagnostics_config
+        )
+      end
+    end
+  end
 end

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -34,7 +34,7 @@ EOF
 
   def reporter
     -> ((path, diagnostics)) {
-      formatter = Diagnostic::LSPFormatter.new()
+      formatter = Diagnostic::LSPFormatter.new({})
       reported_diagnostics[path] = diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq
     }
   end


### PR DESCRIPTION
This PR adds a new diagnostics configuration via `#configure_code_diagnostics` method.

It yields a hash, and the update the hash in the block.

```rb
D = Steep::Diagnostic

target :app do
  configure_code_diagnostics do |hash|
    hash[D::Ruby::UnexpectedPositionalArgument] = :error
  end
end

target :test do
  configure_code_diagnostics D::Ruby.lenient
end
```

* [x] Implement new diagnostics configuration mechanics
* [x] Add default configurations
* [x] Fix output tests
* [x] Add option to CLI to configure the threshold to be reported as an error
* [x] Fix Steepfile template