### PR TITLE
Print instruction to update configuration

### DIFF
--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -49,7 +49,51 @@ module Steep
         end
 
         def typing_options(level = nil, **hash)
-          Steep.logger.error "#typing_options is deprecated and has no effect as of version 0.46.0"
+          Steep.logger.error "#typing_options is deprecated and has no effect as of version 0.46.0. Update your Steepfile as follows for (almost) equivalent setting:"
+
+          messages = []
+
+          messages << "# D = Steep::Diagnostic                          # Define a constant to shorten namespace"
+
+          case level
+          when :strict
+            messages << "configure_code_diagnostics(D::Ruby.strict)       # :strict"
+          when :default
+            messages << "configure_code_diagnostics(D::Ruby.default)      # :default"
+          when :lenient
+            messages << "configure_code_diagnostics(D::Ruby.lenient)      # :lenient"
+          end
+
+          messages.each do |msg|
+            Steep.logger.error "  #{msg}"
+          end
+
+          config = []
+
+          if hash[:allow_missing_definitions]
+            config << "hash[D::Ruby::MethodDefinitionMissing] = nil   # allow_missing_definitions"
+          end
+
+          if hash[:allow_fallback_any]
+            config << "hash[D::Ruby::FallbackAny] = nil               # allow_fallback_any"
+          end
+
+          if hash[:allow_unknown_constant_assignment]
+            config << "hash[D::Ruby::UnknownConstantAssigned] = nil   # allow_unknown_constant_assignment"
+          end
+
+          if hash[:allow_unknown_method_calls]
+            config << "hash[D::Ruby::NoMethod] = nil                  # allow_unknown_method_calls"
+          end
+
+          unless config.empty?
+            Steep.logger.error "  configure_code_diagnostics do |hash|"
+            config.each do |c|
+              Steep.logger.error "    #{c}"
+            end
+            Steep.logger.error "  end"
+          end
+
         end
 
         def signature(*args)

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -73,7 +73,10 @@ target :app do
 end
 RUBY
 
-        assert_match(/\[Steepfile\] \[target=app\] #typing_options is deprecated and has no effect as of version 0\.46\.0/, Steep.log_output.string)
+        assert_match(/\[Steepfile\] \[target=app\] #typing_options is deprecated and has no effect as of version 0\.46\.0\. Update your Steepfile as follows for \(almost\) equivalent setting:/, Steep.log_output.string)
+        assert_match(/configure_code_diagnostics\(D::Ruby\.strict\)/, Steep.log_output.string)
+        assert_match(/hash\[D::Ruby::MethodDefinitionMissing\] = nil/, Steep.log_output.string)
+        assert_match(/hash\[D::Ruby::FallbackAny\] = nil/, Steep.log_output.string)
       ensure
         Steep.log_output = STDERR
       end


### PR DESCRIPTION
This helps users to update their configuration:

```
[Steep 0.45.0] [Steepfile] [target=app] #typing_options is deprecated and has no effect as of version 0.46.0. Update your Steepfile as follows for (almost) equivalent setting:
[Steep 0.45.0] [Steepfile] [target=app]   # D = Steep::Diagnostic                          # Define a constant to shorten namespace
[Steep 0.45.0] [Steepfile] [target=app]   configure_code_diagnostics(D::Ruby.strict)       # :strict
[Steep 0.45.0] [Steepfile] [target=app]   configure_code_diagnostics do |hash|
[Steep 0.45.0] [Steepfile] [target=app]     hash[D::Ruby::MethodDefinitionMissing] = nil   # allow_missing_definitions
[Steep 0.45.0] [Steepfile] [target=app]     hash[D::Ruby::FallbackAny] = nil               # allow_fallback_any
[Steep 0.45.0] [Steepfile] [target=app]   end
```