### PR TITLE
Fix error when hover on comment for rbs

### DIFF
--- a/lib/steep/services/hover_content.rb
+++ b/lib/steep/services/hover_content.rb
@@ -74,6 +74,9 @@ module Steep
           locator = RBS::Locator.new(decls: decls)
           hd, tail = locator.find2(line: line, column: column)
 
+          # Maybe hover on comment
+          return if tail.nil?
+
           case type = tail[0]
           when RBS::Types::Alias
             alias_decl = service.latest_env.alias_decls[type.name]&.decl or raise

--- a/test/hover_test.rb
+++ b/test/hover_test.rb
@@ -350,6 +350,25 @@ RBS
     end
   end
 
+  def test_hover_comment_on_rbs
+    in_tmpdir do
+      service = typecheck_service()
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+# Comment
+class Foo
+end
+RBS
+        }
+      ) {}
+
+      hover = HoverContent.new(service: service)
+      assert_nil hover.content_for(path: Pathname("hello.rbs"), line: 1, column: 4)
+    end
+  end
+
   def test_hover_on_syntax_error
     in_tmpdir do
       service = typecheck_service()


### PR DESCRIPTION
Fixed an error that occurred when hovering the IDE cursor over a comment in rbs file.