### PR TITLE
Support Japanese filename

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -21,6 +21,8 @@ require "terminal-table"
 
 require "rbs"
 
+require "steep/utils/uri_helper.rb"
+
 require "steep/equatable"
 require "steep/method_name"
 require "steep/ast/types/helper"

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -12,6 +12,7 @@ module Steep
 
       include Utils::DriverHelper
       include Utils::JobsCount
+      include Steep::Utils::URIHelper
 
       def initialize(stdout:, stderr:)
         @stdout = stdout
@@ -138,7 +139,7 @@ module Steep
         missing_count = 0
 
         ns = notifications.each.with_object({}) do |notification, hash|
-          path = project.relative_path(Pathname(URI.parse(notification[:uri]).path))
+          path = project.relative_path(Pathname(decode_uri(notification[:uri])))
           hash[path] = notification[:diagnostics]
         end
 
@@ -185,7 +186,7 @@ module Steep
                        end
 
         ns = notifications.each.with_object({}) do |notification, hash|
-          path = project.relative_path(Pathname(URI.parse(notification[:uri]).path))
+          path = project.relative_path(Pathname(decode_uri(notification[:uri])))
           hash[path] = notification[:diagnostics]
         end
 
@@ -214,7 +215,7 @@ module Steep
           total = errors.sum {|notification| notification[:diagnostics].size }
 
           errors.each do |notification|
-            path = project.relative_path(Pathname(URI.parse(notification[:uri]).path))
+            path = project.relative_path(Pathname(decode_uri(notification[:uri])))
             buffer = RBS::Buffer.new(name: path, content: path.read)
             printer = DiagnosticPrinter.new(buffer: buffer, stdout: stdout)
 

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -11,6 +11,8 @@ module Steep
         attr_reader :priority_paths
         attr_reader :checked_paths
 
+        include Steep::Utils::URIHelper
+
         def initialize(guid:)
           @guid = guid
           @library_paths = Set[]
@@ -20,19 +22,13 @@ module Steep
           @checked_paths = Set[]
         end
 
-        def uri(path)
-          URI.parse(path.to_s).tap do |uri|
-            uri.scheme = "file"
-          end
-        end
-
         def as_json(assignment:)
           {
             guid: guid,
-            library_uris: library_paths.grep(assignment).map {|path| uri(path).to_s },
-            signature_uris: signature_paths.grep(assignment).map {|path| uri(path).to_s },
-            code_uris: code_paths.grep(assignment).map {|path| uri(path).to_s },
-            priority_uris: priority_paths.map {|path| uri(path).to_s }
+            library_uris: library_paths.grep(assignment).map {|path| encode_uri(path).to_s },
+            signature_uris: signature_paths.grep(assignment).map {|path| encode_uri(path).to_s },
+            code_uris: code_paths.grep(assignment).map {|path| encode_uri(path).to_s },
+            priority_uris: priority_paths.map {|path| encode_uri(path).to_s }
           }
         end
 

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -265,7 +265,7 @@ module Steep
       end
 
       def goto(job)
-        path = Pathname(encode_uri(job.params[:textDocument][:uri]))
+        path = Pathname(decode_uri(job.params[:textDocument][:uri]))
         line = job.params[:position][:line] + 1
         column = job.params[:position][:character]
 

--- a/lib/steep/utils/uri_helper.rb
+++ b/lib/steep/utils/uri_helper.rb
@@ -1,0 +1,20 @@
+module Steep
+  module Utils
+    module URIHelper
+      def decode_uri(path)
+        path = path.delete_prefix("file://")
+        URI.decode_www_form_component(URI.parse(path).to_s)
+      end
+
+      def encode_uri(path)
+        path = path.to_s.split("/").map { |dir|
+          URI.encode_www_form_component(dir)
+        }.join("/")
+
+        URI.parse(path).tap do |uri|
+          uri.scheme = "file"
+        end
+      end
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -258,6 +258,25 @@ end
     end
   end
 
+  def test_check_with_multibyte_filename
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "テスト.rb"
+end
+      EOF
+
+      (current_dir + "テスト.rb").write(<<-EOF)
+1+2
+      EOF
+
+      stdout, status = sh(*steep, "check")
+
+      assert_predicate status, :success?, stdout
+      assert_match /No type error detected\./, stdout
+    end
+  end
+
   def test_check_unknown
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)


### PR DESCRIPTION
If I use Japanese file name like "テスト.rb", URI.parse raise exception URI::InvalidURIError.
To avoid this issue, file names needed to escaped.