### PR TITLE
Fix percentile

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -213,7 +213,7 @@ module Steep
     end
 
     def percentile(p)
-      slowests(count - count * p / 100r).last&.last || 0
+      slowests([count * p / 100r, 1].max).last&.last || 0
     end
   end
 


### PR DESCRIPTION
Fixed a issue where the percentile display would be `0` if there were few samples.

### Before

```
$ ruby -r steep -e 'Steep.measure2("test", level: :error) { |s| 3.times { |i| s.sample(i) { sleep(i / 10.0) } } }'
[Steep 0.46.0] 0.308099secs for "test"
[Steep 0.46.0]   Average: 0.10269966666666668secs
[Steep 0.46.0]   Median: 0.205162secs
[Steep 0.46.0]   Samples: 3
[Steep 0.46.0]   99 percentile: 0secs
[Steep 0.46.0]   90 percentile: 0secs
[Steep 0.46.0]   10 Slowests:
[Steep 0.46.0]     2 (0.205162secs)
[Steep 0.46.0]     1 (0.10291secs)
[Steep 0.46.0]     0 (2.7e-05secs)
```

### After

```
$ ruby -r steep -e 'Steep.measure2("test", level: :error) { |s| 3.times { |i| s.sample(i) { sleep(i / 10.0) } } }'
[Steep 0.46.0] 0.305917secs for "test"
[Steep 0.46.0]   Average: 0.10197233333333333secs
[Steep 0.46.0]   Median: 0.200867secs
[Steep 0.46.0]   Samples: 3
[Steep 0.46.0]   99 percentile: 0.105019secs
[Steep 0.46.0]   90 percentile: 0.105019secs
[Steep 0.46.0]   10 Slowests:
[Steep 0.46.0]     2 (0.200867secs)
[Steep 0.46.0]     1 (0.105019secs)
[Steep 0.46.0]     0 (3.1e-05secs)
```