### PR TITLE
Adjusting display of CompletionItem

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -383,7 +383,7 @@ HOVER
         when RBS::AST::Declarations::Interface
           "interface #{name_and_params(decl.name, decl.type_params)}"
         end
-    end
+      end
 
       def format_completion_item(item)
         range = LanguageServer::Protocol::Interface::Range.new(
@@ -402,18 +402,18 @@ HOVER
           LanguageServer::Protocol::Interface::CompletionItem.new(
             label: item.identifier,
             kind: LanguageServer::Protocol::Constant::CompletionItemKind::VARIABLE,
-            detail: "#{item.identifier}: #{item.type}",
+            detail: item.type.to_s,
             text_edit: LanguageServer::Protocol::Interface::TextEdit.new(
               range: range,
-              new_text: "#{item.identifier}"
+              new_text: item.identifier
             )
           )
         when Services::CompletionProvider::MethodNameItem
-          label = "def #{item.identifier}: #{item.method_type}"
           method_type_snippet = method_type_to_snippet(item.method_type)
           LanguageServer::Protocol::Interface::CompletionItem.new(
-            label: label,
+            label: item.identifier,
             kind: LanguageServer::Protocol::Constant::CompletionItemKind::METHOD,
+            detail: item.method_type.to_s,
             text_edit: LanguageServer::Protocol::Interface::TextEdit.new(
               new_text: "#{item.identifier}#{method_type_snippet}",
               range: range
@@ -423,14 +423,14 @@ HOVER
             sort_text: item.inherited? ? 'z' : 'a' # Ensure language server puts non-inherited methods before inherited methods
           )
         when Services::CompletionProvider::InstanceVariableItem
-          label = "#{item.identifier}: #{item.type}"
           LanguageServer::Protocol::Interface::CompletionItem.new(
-            label: label,
+            label: item.identifier,
             kind: LanguageServer::Protocol::Constant::CompletionItemKind::FIELD,
+            detail: item.type.to_s,
             text_edit: LanguageServer::Protocol::Interface::TextEdit.new(
               range: range,
               new_text: item.identifier,
-              ),
+            ),
             insert_text_format: LanguageServer::Protocol::Constant::InsertTextFormat::SNIPPET
           )
         end


### PR DESCRIPTION
There are two problems with the current completion function.

- If I want to complete a method such as `default_value`, `def` part will be completed.
- Type parameters are also being completed.

https://user-images.githubusercontent.com/935310/135632516-706616e6-c46a-420e-b804-008274931427.mov

So, the following fixes have been made.

- Remove the `def ` part from the completion target.
- Remove type parameters from the completion target as well. Instead, put type parameters in `detail`.

This solves the problem, but the downside is that the type parameter that used to show up in all completion lists is now only the one you have selected.

https://user-images.githubusercontent.com/935310/135633224-634bcbf4-f61f-4502-bb24-4607656aea62.mov



