### PR TITLE
Fix Unexpected error if record-type receive kwargs

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3798,7 +3798,7 @@ module Steep
     # `record_type` can be nil when the keys are not specified.
     #
     def type_hash_record(hash_node, record_type)
-      raise unless hash_node.type == :hash
+      raise unless hash_node.type == :hash || hash_node.type == :kwargs
 
       constr = self
 

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4442,6 +4442,29 @@ EOF
     end
   end
 
+  def test_hash_with_kwargs
+    with_checker <<EOF do |checker|
+class WithKwargs
+  type t = { a: Integer }
+  def self.call: (t) -> void
+end
+
+EOF
+
+      source = parse_ruby(<<EOF)
+WithKwargs.call(a: "123")
+WithKwargs.call(a: 123)
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_equal 1, typing.errors.size
+        assert_instance_of Diagnostic::Ruby::ArgumentTypeMismatch, typing.errors[0]
+      end
+    end
+  end
+
   def test_polymorphic_method
     with_checker <<-EOF do |checker|
 interface _Ref[X]


### PR DESCRIPTION
https://github.com/ruby/gem_rbs_collection/pull/68 seems raise Unexpected error.
I've investigated and fixed it, because it seems that `Steep::TypeConstruction#type_hash_record` didn't consider the case of kwargs enough.