### PR TITLE
Add a missing attr_reader in the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ end
 
 class Phone
   # @dynamic country, number
+  attr_reader :country, :number
 
   def initialize(country:, number:)
     @country = country


### PR DESCRIPTION
The Phone class should have `attr_reader  :country, :number` if Phone#== uses `other.country` and `other.number`.