### PR TITLE
Should check if positional_params is nil or not

### DIFF
--- a/lib/steep/type_inference/send_args.rb
+++ b/lib/steep/type_inference/send_args.rb
@@ -153,6 +153,7 @@ module Steep
         end
 
         def uniform_type
+          return nil unless positional_params
           if positional_params.each.any? {|param| param.is_a?(Interface::Function::Params::PositionalParams::Rest) }
             AST::Types::Intersection.build(types: positional_params.each.map(&:type))
           end


### PR DESCRIPTION
The following code raises an unexpected error.

```rb
[].each(*a)
```

```
Unexpected error: #<NoMethodError: undefined method `each' for nil:NilClass>
/Users/ksss/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/steep-0.46.0/lib/steep/type_inference/send_args.rb:156:in `uniform_type'
/Users/ksss/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/steep-0.46.0/lib/steep/type_inference/send_args.rb:567:in `block in each'
...
```