### PR TITLE
Relax RBS gemspec requirements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       parallel (>= 1.0.0)
       parser (>= 3.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 1.7.0)
+      rbs (>= 1.7.0)
       terminal-table (>= 2, < 4)
 
 PATH

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", "~> 1.7.0"
+  spec.add_runtime_dependency "rbs", ">= 1.7.0"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
 end


### PR DESCRIPTION
It is intended to require only `1.7.x` with release version of Steep because the new features introduced in RBS 1.8 is not supported yet.

This is only for the `HEAD` version for a while. I will update the code to support the new features, but I don't have time for it now. 👶 