### PR TITLE
Fix errors against RBS 2.0

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -135,7 +135,7 @@ module Steep
             )
           when Name::Alias
             type.args.empty? or raise "alias type with args is not supported"
-            RBS::Types::Alias.new(name: type.name, location: nil)
+            RBS::Types::Alias.new(name: type.name, args: type.args, location: nil)
           when Union
             RBS::Types::Union.new(
               types: type.types.map {|ty| type_1(ty) },

--- a/lib/steep/server/base_worker.rb
+++ b/lib/steep/server/base_worker.rb
@@ -14,6 +14,7 @@ module Steep
         @writer = writer
         @skip_job = false
         @shutdown = false
+        @skip_jobs_after_shutdown = nil
       end
 
       def skip_jobs_after_shutdown!(flag = true)

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -338,7 +338,7 @@ HOVER
         else
           ps = params.each.map do |param|
             s = ""
-            if param.skip_validation
+            if param.unchecked?
               s << "unchecked "
             end
             case param.variance

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -144,7 +144,7 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateAppSignature for guid=#{job.guid}, path=#{job.path}" }
             service.validate_signature(path: project.relative_path(job.path)) do |path, diagnostics|
-              formatter = Diagnostic::LSPFormatter.new({})
+              formatter = Diagnostic::LSPFormatter.new({}, **{})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",
@@ -162,7 +162,7 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateLibrarySignature for guid=#{job.guid}, path=#{job.path}" }
             service.validate_signature(path: job.path) do |path, diagnostics|
-              formatter = Diagnostic::LSPFormatter.new({})
+              formatter = Diagnostic::LSPFormatter.new({}, **{})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",

--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -224,7 +224,7 @@ module Steep
           Steep.measure "Loading new decls" do
             updated_files.each_value do |content|
               case decls = content.decls
-              when RBS::ErrorBase
+              when RBS::BaseError
                 errors << content.decls
               else
                 begin
@@ -283,7 +283,7 @@ module Steep
       def rescue_rbs_error(errors)
         begin
           yield
-        rescue RBS::ErrorBase => exn
+        rescue RBS::BaseError => exn
           errors << exn
         end
       end

--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -294,7 +294,7 @@ module Steep
 
       def rescue_validation_errors(type_name = nil)
         yield
-      rescue RBS::ErrorBase => exn
+      rescue RBS::BaseError => exn
         @errors << Diagnostic::Signature.from_rbs_error(exn, factory: factory)
       end
     end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2385,7 +2385,7 @@ module Steep
             raise "#synthesize should return an instance of Pair: #{pair.class}, node=#{node.inspect}"
           end
         end
-      rescue RBS::ErrorBase => exn
+      rescue RBS::BaseError => exn
         Steep.logger.warn { "Unexpected RBS error: #{exn.message}" }
         exn.backtrace.each {|loc| Steep.logger.warn "  #{loc}" }
         typing.add_error(Diagnostic::Ruby::UnexpectedError.new(node: node, error: exn))

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", ">= 1.7.0"
+  spec.add_runtime_dependency "rbs", ">= 2.0.0"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
 end

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -34,7 +34,7 @@ EOF
 
   def reporter
     -> ((path, diagnostics)) {
-      formatter = Diagnostic::LSPFormatter.new({})
+      formatter = Diagnostic::LSPFormatter.new({}, **{})
       reported_diagnostics[path] = diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq
     }
   end


### PR DESCRIPTION
I tried Steep with RBS 2.0 and got some errors and failures.
This PR fixes errors (but not failures...)

* Rename `RBS::ErrorBase` -> `RBS::BaseError` ( ruby/rbs@1574829 )
* Use unchecked? instead of skip_validation ( ruby/rbs@c5da467 )
* Fix `ArgumentError: missing keyword: :args` in TypeConstructionTest#test_value_case ( ruby/rbs@4a32cf3 )
* Fix some warnings in test (`@skip_jobs_after_shutdown` and keyword args)