### PR TITLE
Fix ActiveSupport requirement in lib/steep.rb

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -2,10 +2,10 @@ require "steep/version"
 
 require "pathname"
 require "parser/ruby30"
+require "active_support"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"
 require "logger"
-require "active_support/tagged_logging"
 require "rainbow"
 require "listen"
 require 'language_server-protocol'


### PR DESCRIPTION
`active_support` must be explictly required according to: https://guides.rubyonrails.org/active_support_core_extensions.html

The requirement of `active_support/tagged_logging` is removed because `active_support` autoloads it.

Closes #466 and #473.