### PR TITLE
Revert "Relax RBS gemspec requirements"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       parallel (>= 1.0.0)
       parser (>= 3.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 1.7.0)
+      rbs (~> 1.7.0)
       terminal-table (>= 2, < 4)
 
 PATH

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", ">= 1.7.0"
+  spec.add_runtime_dependency "rbs", "~> 1.7.0"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
 end


### PR DESCRIPTION
Reverts soutaro/steep#460

This is to release 0.47.1. I'm still working for RBS 2.0 support. 💪 