### PR TITLE
RBS 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       parallel (>= 1.0.0)
       parser (>= 3.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 1.7.0)
+      rbs (~> 2.2.0)
       terminal-table (>= 2, < 4)
 
 PATH
@@ -49,7 +49,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (1.7.1)
+    rbs (2.2.2)
     stackprof (0.2.18)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -210,7 +210,9 @@ module Steep
           alpha_vars = []
           alpha_types = []
 
-          method_type.type_params.map do |name|
+          method_type.type_params.map do |type_param|
+            name = type_param.name
+
             if fvs.include?(name)
               type = Types::Var.fresh(name)
               alpha_vars << name
@@ -262,10 +264,14 @@ module Steep
               type = RBS::Types::Variable.new(name: name, location: nil),
               alpha_vars << name
               alpha_types << type
-              type_params << type.name
-            else
-              type_params << name
             end
+
+            type_params << RBS::AST::TypeParam.new(
+              name: name,
+              variance: :invariant,
+              upper_bound: nil,
+              location: nil
+            )
           end
           subst = Interface::Substitution.build(alpha_vars, alpha_types)
 

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -307,7 +307,7 @@ module Steep
 
         def unfold(type_name)
           type_name.yield_self do |type_name|
-            type(definition_builder.expand_alias(type_name))
+            type(definition_builder.expand_alias1(type_name))
           end
         end
 

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -58,7 +58,7 @@ module Steep
             Name::Interface.new(name: type_name, args: args, location: nil)
           when RBS::Types::Alias
             type_name = type.name
-            Name::Alias.new(name: type_name, args: [], location: nil)
+            Name::Alias.new(name: type_name, location: nil)
           when RBS::Types::Union
             Union.build(types: type.types.map {|ty| type(ty) }, location: nil)
           when RBS::Types::Intersection
@@ -134,8 +134,7 @@ module Steep
               location: nil
             )
           when Name::Alias
-            type.args.empty? or raise "alias type with args is not supported"
-            RBS::Types::Alias.new(name: type.name, location: nil)
+            RBS::Types::Alias.new(name: type.name, args: [], location: nil)
           when Union
             RBS::Types::Union.new(
               types: type.types.map {|ty| type_1(ty) },

--- a/lib/steep/ast/types/name.rb
+++ b/lib/steep/ast/types/name.rb
@@ -109,7 +109,10 @@ module Steep
         class Interface < Applying
         end
 
-        class Alias < Applying
+        class Alias < Base
+          def to_s
+            name.to_s
+          end
         end
       end
     end

--- a/lib/steep/server/base_worker.rb
+++ b/lib/steep/server/base_worker.rb
@@ -14,6 +14,7 @@ module Steep
         @writer = writer
         @skip_job = false
         @shutdown = false
+        @skip_jobs_after_shutdown = nil
       end
 
       def skip_jobs_after_shutdown!(flag = true)

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -338,7 +338,7 @@ HOVER
         else
           ps = params.each.map do |param|
             s = ""
-            if param.skip_validation
+            if param.unchecked?
               s << "unchecked "
             end
             case param.variance

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -144,7 +144,7 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateAppSignature for guid=#{job.guid}, path=#{job.path}" }
             service.validate_signature(path: project.relative_path(job.path)) do |path, diagnostics|
-              formatter = Diagnostic::LSPFormatter.new({})
+              formatter = Diagnostic::LSPFormatter.new({}, **{})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",
@@ -162,7 +162,7 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateLibrarySignature for guid=#{job.guid}, path=#{job.path}" }
             service.validate_signature(path: job.path) do |path, diagnostics|
-              formatter = Diagnostic::LSPFormatter.new({})
+              formatter = Diagnostic::LSPFormatter.new({}, **{})
 
               writer.write(
                 method: :"textDocument/publishDiagnostics",

--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -224,7 +224,7 @@ module Steep
           Steep.measure "Loading new decls" do
             updated_files.each_value do |content|
               case decls = content.decls
-              when RBS::ErrorBase
+              when RBS::BaseError
                 errors << content.decls
               else
                 begin
@@ -283,7 +283,7 @@ module Steep
       def rescue_rbs_error(errors)
         begin
           yield
-        rescue RBS::ErrorBase => exn
+        rescue RBS::BaseError => exn
           errors << exn
         end
       end

--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -280,7 +280,7 @@ module Steep
       def validate_one_alias(name)
         rescue_validation_errors(name) do
           Steep.logger.debug "Validating alias `#{name}`..."
-          builder.expand_alias(name).tap do |type|
+          builder.expand_alias1(name).tap do |type|
             validate_type(type)
           end
         end

--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -294,7 +294,7 @@ module Steep
 
       def rescue_validation_errors(type_name = nil)
         yield
-      rescue RBS::ErrorBase => exn
+      rescue RBS::BaseError => exn
         @errors << Diagnostic::Signature.from_rbs_error(exn, factory: factory)
       end
     end

--- a/lib/steep/subtyping/variable_variance.rb
+++ b/lib/steep/subtyping/variable_variance.rb
@@ -58,7 +58,7 @@ module Steep
           type.types.each do |ty|
             add_type(ty, variance: variance, covariants: covariants, contravariants: contravariants)
           end
-        when AST::Types::Name::Interface, AST::Types::Name::Instance, AST::Types::Name::Alias
+        when AST::Types::Name::Interface, AST::Types::Name::Instance
           type.args.each do |arg|
             add_type(arg, variance: :invariant, covariants: covariants, contravariants: contravariants)
           end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2387,7 +2387,7 @@ module Steep
             raise "#synthesize should return an instance of Pair: #{pair.class}, node=#{node.inspect}"
           end
         end
-      rescue RBS::ErrorBase => exn
+      rescue RBS::BaseError => exn
         Steep.logger.warn { "Unexpected RBS error: #{exn.message}" }
         exn.backtrace.each {|loc| Steep.logger.warn "  #{loc}" }
         typing.add_error(Diagnostic::Ruby::UnexpectedError.new(node: node, error: exn))

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", ">= 1.7.0"
+  spec.add_runtime_dependency "rbs", "~> 2.2.0"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
 end

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -34,7 +34,7 @@ EOF
 
   def reporter
     -> ((path, diagnostics)) {
-      formatter = Diagnostic::LSPFormatter.new({})
+      formatter = Diagnostic::LSPFormatter.new({}, **{})
       reported_diagnostics[path] = diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq
     }
   end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -7946,4 +7946,24 @@ EachNoParam.new.each(*a)
       end
     end
   end
+
+  def test_generic_alias_skip
+    with_checker(<<-RBS) do |checker|
+type list[T] = nil
+             | [ T, list[T] ]
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+# @type var ints: list[Integer]
+ints = [1, [2, nil]]
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+        puts type
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4462,8 +4462,11 @@ EOF
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
 
-        assert_equal 1, typing.errors.size
-        assert_instance_of Diagnostic::Ruby::ArgumentTypeMismatch, typing.errors[0]
+        assert_typing_error(typing, size: 1) do
+          assert_any!(typing.errors) do |error|
+            assert_instance_of Diagnostic::Ruby::ArgumentTypeMismatch, error
+          end
+        end
       end
     end
   end

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -87,7 +87,6 @@ class TypeFactoryTest < Minitest::Test
       factory.type(parse_type("Super::duper")).yield_self do |type|
         assert_instance_of Types::Name::Alias, type
         assert_equal "Super::duper", type.name.to_s
-        assert_equal [], type.args
       end
 
       factory.type(parse_type("Integer | nil")).yield_self do |type|

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -546,4 +546,17 @@ EOF
       end
     end
   end
+
+  def test_generic_alias_skip
+    with_checker <<~RBS do |checker|
+type list[T] = nil
+             | [ T, list[T] ]
+    RBS
+
+      validator = Validator.new(checker: checker)
+      validator.validate_alias
+
+      refute_operator validator, :has_error?
+    end
+  end
 end


### PR DESCRIPTION
This PR makes Steep run with RBS 2.2, without supporting the new features.

* Bounded generics are ignored (the constraint is ignored)
* Generic type alias is ignored (all type parameters are treated as `untyped`)

I'm working to support these type checking features, but you can use Steep with other RBS 2.2 features.