### PR TITLE
Disable contextual typing with bool

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -393,7 +393,7 @@ module Steep
           when AST::Types::Name::Alias
             unwrap_optional(expand_alias(type))
           when AST::Types::Boolean
-            [AST::Builtin.true_type, AST::Builtin.false_type]
+            [type, type]
           else
             [type, nil]
           end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8323,4 +8323,25 @@ end
       end
     end
   end
+
+  def test_context_typing_bool
+    with_checker(<<-RBS) do |checker|
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+flag = false
+
+while flag
+  flag = false
+end 
+
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
Narrowing `bool` type to `false` (or `true`) causes problem when updating flags inside loops.

```rb
flag = true

while flag
  if something
    flag = false       # Reporting error here doesn't make any sense.
  end
end 
```