### PR TITLE
Fix for `#flat_map`

### DIFF
--- a/lib/steep/ast/types/any.rb
+++ b/lib/steep/ast/types/any.rb
@@ -28,6 +28,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [1]
         end

--- a/lib/steep/ast/types/boolean.rb
+++ b/lib/steep/ast/types/boolean.rb
@@ -28,6 +28,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [0]
         end

--- a/lib/steep/ast/types/bot.rb
+++ b/lib/steep/ast/types/bot.rb
@@ -28,6 +28,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [2]
         end

--- a/lib/steep/ast/types/class.rb
+++ b/lib/steep/ast/types/class.rb
@@ -30,6 +30,8 @@ module Steep
           @fvs = Set.new([self])
         end
 
+        include Helper::NoChild
+
         def level
           [0]
         end

--- a/lib/steep/ast/types/helper.rb
+++ b/lib/steep/ast/types/helper.rb
@@ -21,6 +21,14 @@ module Steep
             @fvs ||= Set.new
           end
         end
+
+        module NoChild
+          def each_child(&block)
+            unless block
+              enum_for :each_child
+            end
+          end
+        end
       end
     end
   end

--- a/lib/steep/ast/types/instance.rb
+++ b/lib/steep/ast/types/instance.rb
@@ -26,6 +26,8 @@ module Steep
           @fvs = Set.new([self])
         end
 
+        include Helper::NoChild
+
         def to_s
           "instance"
         end

--- a/lib/steep/ast/types/intersection.rb
+++ b/lib/steep/ast/types/intersection.rb
@@ -72,6 +72,10 @@ module Steep
 
         include Helper::ChildrenLevel
 
+        def each_child(&block)
+          types.each(&block)
+        end
+
         def level
           [0] + level_of_children(types)
         end

--- a/lib/steep/ast/types/literal.rb
+++ b/lib/steep/ast/types/literal.rb
@@ -31,6 +31,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [0]
         end

--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -13,6 +13,8 @@ module Steep
             @fvs ||= Set[]
           end
 
+          include Helper::NoChild
+
           def hash
             self.class.hash
           end

--- a/lib/steep/ast/types/name.rb
+++ b/lib/steep/ast/types/name.rb
@@ -72,6 +72,10 @@ module Steep
             end
           end
 
+          def each_child(&block)
+            args.each(&block)
+          end
+
           include Helper::ChildrenLevel
 
           def level
@@ -98,6 +102,8 @@ module Steep
           def with_location(new_location)
             self.class.new(name: name, location: new_location)
           end
+
+          include Helper::NoChild
         end
 
         class Instance < Applying

--- a/lib/steep/ast/types/nil.rb
+++ b/lib/steep/ast/types/nil.rb
@@ -28,6 +28,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [0]
         end

--- a/lib/steep/ast/types/proc.rb
+++ b/lib/steep/ast/types/proc.rb
@@ -90,6 +90,15 @@ module Steep
         def block_required?
           block && !block.optional?
         end
+
+        def each_child(&block)
+          if block_given?
+            type.each_child(&block)
+            self.block&.type&.each_child(&block)
+          else
+            enum_for :each_child
+          end
+        end
       end
     end
   end

--- a/lib/steep/ast/types/record.rb
+++ b/lib/steep/ast/types/record.rb
@@ -42,6 +42,10 @@ module Steep
 
         include Helper::ChildrenLevel
 
+        def each_child(&block)
+          elements.each_value(&block)
+        end
+
         def level
           [0] + level_of_children(elements.values)
         end

--- a/lib/steep/ast/types/self.rb
+++ b/lib/steep/ast/types/self.rb
@@ -22,6 +22,8 @@ module Steep
           "self"
         end
 
+        include Helper::NoChild
+
         def subst(s)
           s.self_type or raise "Unexpected substitution: #{inspect}"
         end

--- a/lib/steep/ast/types/top.rb
+++ b/lib/steep/ast/types/top.rb
@@ -28,6 +28,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [2]
         end

--- a/lib/steep/ast/types/tuple.rb
+++ b/lib/steep/ast/types/tuple.rb
@@ -40,6 +40,10 @@ module Steep
 
         include Helper::ChildrenLevel
 
+        def each_child(&block)
+          types.each(&block)
+        end
+
         def level
           [0] + level_of_children(types)
         end

--- a/lib/steep/ast/types/union.rb
+++ b/lib/steep/ast/types/union.rb
@@ -70,6 +70,10 @@ module Steep
           end
         end
 
+        def each_child(&block)
+          types.each(&block)
+        end
+
         include Helper::ChildrenLevel
 
         def level

--- a/lib/steep/ast/types/var.rb
+++ b/lib/steep/ast/types/var.rb
@@ -52,6 +52,8 @@ module Steep
           @fvs ||= Set.new([name])
         end
 
+        include Helper::NoChild
+
         def level
           [0]
         end

--- a/lib/steep/ast/types/void.rb
+++ b/lib/steep/ast/types/void.rb
@@ -28,6 +28,8 @@ module Steep
 
         include Helper::NoFreeVariables
 
+        include Helper::NoChild
+
         def level
           [0]
         end

--- a/lib/steep/interface/function.rb
+++ b/lib/steep/interface/function.rb
@@ -952,6 +952,10 @@ module Steep
         )
       end
 
+      def each_child(&block)
+        each_type(&block)
+      end
+
       def each_type(&block)
         if block_given?
           params.each_type(&block)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8419,4 +8419,26 @@ end
       end
     end
   end
+
+  def test_flat_map
+    with_checker(<<-RBS) do |checker|
+class FlatMap
+  def flat_map: [A] () { (String) -> (A | Array[A]) } -> Array[A]
+end
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+# @type var a: FlatMap
+a = _ = nil 
+a.flat_map {|s| [s] }
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+        assert_equal parse_type("::Array[::String]"), type
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Enumerable#flat_map` haven't type checked as expected in Steep.

```
# def flat_map: [A] () { (Element) -> (A | Array[A]) } -> Array[A]

[1,2,3].flat_map {|x| [x.to_s] }          # Steep infers Array[Array[String]] while we need Array[String] here
```

This is because the subtyping relationship `Array[String] <: (A | Array[A])` resolves to a substitution of `A == Array[String]`. If it resolves to a substitution of `A == String`, the type checking will work.

So, we'd like to introduce a function `#hole_path`. It takes two arguments, type and type variables, and returns the shortest path to _unknown_ variable. Giving higher precedence to types with longer path will result more specific (smaller) type variable assignment.

This depends on two intuitions (without any proof):

1. Specific type is better (`A == String` is better than `A == Array[String]`)
2. Longer `#hole_path` implies more specific type

Fingers crossed that this gives a better result.