### PR TITLE
Validate type decendants

### DIFF
--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -89,11 +89,7 @@ module Steep
         end
       end
 
-      def validate_type(type)
-        Steep.logger.debug "#{Location.to_string type.location}: Validating #{type}..."
-
-        validator.validate_type type, context: [RBS::Namespace.root]
-
+      def validate_type_application(type)
         name, type_params, type_args =
           case type
           when RBS::Types::ClassInstance
@@ -123,6 +119,17 @@ module Steep
             validate_type_application_constraints(type.name, type_params, type_args, location: type.location)
           end
         end
+
+        type.each_type do |child|
+          validate_type_application(child)
+        end
+      end
+
+      def validate_type(type)
+        Steep.logger.debug "#{Location.to_string type.location}: Validating #{type}..."
+
+        validator.validate_type type, context: [RBS::Namespace.root]
+        validate_type_application(type)
       end
 
       def ancestor_to_type(ancestor)

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -660,7 +660,7 @@ class Foo[X < Integer]
 end
 
 class Bar[X0 < String]
-  def f: () -> x[X0]
+  def f: () -> Array[x[X0]]
 end
     EOF
 

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -739,6 +739,63 @@ RBS
     end
   end
 
+  def test_validate_type_application_module_self
+    with_checker <<RBS do |checker|
+class Base[X < Numeric]
+end
+
+module M1 : Base[Integer]
+end
+
+module M2 : Base[String]
+end
+
+module M3[X < Integer] : Base[X]
+end
+
+module M4[X < String] : Base[X]
+end
+RBS
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::Base"))
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::M1"))
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::M2"))
+        refute_predicate validator, :no_error?
+
+        assert_any!(validator.each_error, size: 1) do |error|
+          assert_instance_of Diagnostic::Signature::UnsatisfiableTypeApplication, error
+          assert_equal "Type application of `::Base` doesn't satisfy the constraints: ::String <: ::Numeric", error.header_line
+          assert_equal "Base[String]", error.location.source
+        end
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::M3"))
+        assert_predicate validator, :no_error?
+      end
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(TypeName("::M4"))
+        refute_predicate validator, :no_error?
+
+        assert_any!(validator.each_error, size: 1) do |error|
+          assert_instance_of Diagnostic::Signature::UnsatisfiableTypeApplication, error
+          assert_equal "Type application of `::Base` doesn't satisfy the constraints: X <: ::Numeric", error.header_line
+          assert_equal "Base[X]", error.location.source
+        end
+      end
+    end
+  end
+
   def test_validate_type_application_mixin
     with_checker <<RBS do |checker|
 module M[X < Numeric]


### PR DESCRIPTION
```
type x[A < Numeric] = A

class Foo[X0 < String]
  def f: () -> Array[x[X0]]       # Steep didn't detect error here, because `x` is inside `Array`.
end
```