### PR TITLE
Fix print error with absolute path

### DIFF
--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -215,7 +215,7 @@ module Steep
 
           errors.each do |notification|
             path = Pathname(URI.parse(notification[:uri]).path)
-            buffer = RBS::Buffer.new(name: project.relative_path(path), content: project.absolute_path(path).read)
+            buffer = RBS::Buffer.new(name: project.relative_path(path), content: path.read)
             printer = DiagnosticPrinter.new(buffer: buffer, stdout: stdout)
 
             notification[:diagnostics].each do |diag|

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -214,8 +214,8 @@ module Steep
           total = errors.sum {|notification| notification[:diagnostics].size }
 
           errors.each do |notification|
-            path = project.relative_path(Pathname(URI.parse(notification[:uri]).path))
-            buffer = RBS::Buffer.new(name: path, content: path.read)
+            path = Pathname(URI.parse(notification[:uri]).path)
+            buffer = RBS::Buffer.new(name: project.relative_path(path), content: project.absolute_path(path).read)
             printer = DiagnosticPrinter.new(buffer: buffer, stdout: stdout)
 
             notification[:diagnostics].each do |diag|


### PR DESCRIPTION
Steep command is could execute for sub project:

```
$ bundle exec -- steep check --steepfile=sample/Steepfile
# Type checking files:

..................................................................

No type error detected. 🫖
```

But, raise exception when type check is failed:

```
$ bundle exec -- steep check --steepfile=sample/Steepfile
# Type checking files:

...............................................FF.................

#<Errno::ENOENT: No such file or directory @ rb_sysopen - lib/conference.rb>
  /path/to/steep/lib/steep/drivers/check.rb:218:in `read'
  /path/to/steep/lib/steep/drivers/check.rb:218:in `read'
  /path/to/steep/lib/steep/drivers/check.rb:218:in `block in print_result'
  /path/to/steep/lib/steep/drivers/check.rb:216:in `each'
  /path/to/steep/lib/steep/drivers/check.rb:216:in `print_result'
  /path/to/steep/lib/steep/drivers/check.rb:125:in `run'
  /path/to/steep/lib/steep/cli.rb:110:in `process_check'
  /path/to/steep/lib/steep/cli.rb:52:in `run'
  /path/to/steep/exe/steep:11:in `<top (required)>'
  /path/to/steep/vendor/gems/ruby/3.1.0/bin/steep:25:in `load'
  /path/to/steep/vendor/gems/ruby/3.1.0/bin/steep:25:in `<top (required)>'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/cli/exec.rb:58:in `load'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/cli/exec.rb:58:in `kernel_load'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/cli/exec.rb:23:in `run'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/cli.rb:484:in `exec'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/cli.rb:31:in `dispatch'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/cli.rb:25:in `start'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/exe/bundle:48:in `block in <top (required)>'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
  /path/to/steep/vendor/gems/ruby/3.1.0/gems/bundler-2.3.8/exe/bundle:36:in `<top (required)>'
  /.rbenv/versions/3.1.1/bin/bundle:25:in `load'
  /.rbenv/versions/3.1.1/bin/bundle:25:in `<main>'
```

Reason is that use `relative_path` to read file in `print_result`.
So, changed to `absolute_path`.
