### PR TITLE
Skip non-target ruby code on `steep stats`

### DIFF
--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -269,6 +269,8 @@ module Steep
       end
 
       def typecheck_source(path:, target: project.target_for_source_path(path), &block)
+        return unless target
+
         Steep.logger.tagged "#typecheck_source(path=#{path})" do
           Steep.measure "typecheck" do
             signature_service = signature_services[target.name]


### PR DESCRIPTION
Errors were reported when `steep stats` receives non-project Ruby file.

```
[Steep 0.49.0] [typecheck:typecheck@5] [background] Unexpected error: #<NoMethodError: undefined method `name' for nil:NilClass

            signature_service = signature_services[target.name]
                                                         ^^^^^>
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep/services/type_check_service.rb:274:in `block (2 levels) in typecheck_source'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep.rb:166:in `measure'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep/services/type_check_service.rb:273:in `block in typecheck_source'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.2.2/lib/active_support/tagged_logging.rb:99:in `block in tagged'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.2.2/lib/active_support/tagged_logging.rb:37:in `tagged'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.2.2/lib/active_support/tagged_logging.rb:99:in `tagged'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep/services/type_check_service.rb:272:in `typecheck_source'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep/server/type_check_worker.rb:182:in `handle_job'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep/server/base_worker.rb:54:in `block (2 levels) in run'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.2.2/lib/active_support/tagged_logging.rb:99:in `block in tagged'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.2.2/lib/active_support/tagged_logging.rb:37:in `tagged'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.2.2/lib/active_support/tagged_logging.rb:99:in `tagged'
[Steep 0.49.0] [typecheck:typecheck@5] [background]   /Users/soutaro/src/steep/lib/steep/server/base_worker.rb:44:in `block in run'
```