### PR TITLE
CLI option for override steep command at spawn worker

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -72,6 +72,11 @@ module Steep
       opts.on("-j N", "--jobs=N", "Specify the number of type check workers (defaults: #{default})") do |count|
         command.jobs_count = Integer(count) if Integer(count) > 0
       end
+
+      command.steep_command = "steep"
+      opts.on("--steep-command=COMMAND", "Specify command to exec Steep CLI for worker (defaults: steep)") do |cmd|
+        command.steep_command = cmd
+      end
     end
 
     def process_init

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -39,6 +39,7 @@ module Steep
           steepfile: project.steepfile_path,
           args: command_line_patterns,
           delay_shutdown: true,
+          steep_command: steep_command,
           count: jobs_count
         )
 

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -37,8 +37,8 @@ module Steep
       def run
         @project = load_config()
 
-        interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: [], count: jobs_count)
+        interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path, steep_command: steep_command)
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: steep_command, count: jobs_count)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/stats.rb
+++ b/lib/steep/drivers/stats.rb
@@ -129,6 +129,7 @@ module Steep
           steepfile: project.steepfile_path,
           delay_shutdown: true,
           args: command_line_patterns,
+          steep_command: steep_command,
           count: jobs_count
         )
 

--- a/lib/steep/drivers/utils/jobs_count.rb
+++ b/lib/steep/drivers/utils/jobs_count.rb
@@ -2,7 +2,7 @@ module Steep
   module Drivers
     module Utils
       module JobsCount
-        attr_accessor :jobs_count
+        attr_accessor :jobs_count, :steep_command
       end
     end
   end

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -41,7 +41,7 @@ module Steep
         server_reader = LanguageServer::Protocol::Transport::Io::Reader.new(server_read)
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: dirs.map(&:to_s), count: jobs_count)
+        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: dirs.map(&:to_s), steep_command: steep_command, count: jobs_count)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -18,13 +18,13 @@ module Steep
         @index = index
       end
 
-      def self.spawn_worker(type, name:, steepfile:, options: [], delay_shutdown: false, index: nil)
+      def self.spawn_worker(type, name:, steepfile:, steep_command: "steep", options: [], delay_shutdown: false, index: nil)
         log_level = %w(debug info warn error fatal unknown)[Steep.logger.level]
         command = case type
                   when :interaction
-                    ["steep", "worker", "--interaction", "--name=#{name}", "--log-level=#{log_level}", "--steepfile=#{steepfile}", *options]
+                    [steep_command, "worker", "--interaction", "--name=#{name}", "--log-level=#{log_level}", "--steepfile=#{steepfile}", *options]
                   when :typecheck
-                    ["steep", "worker", "--typecheck", "--name=#{name}", "--log-level=#{log_level}", "--steepfile=#{steepfile}", *options]
+                    [steep_command, "worker", "--typecheck", "--name=#{name}", "--log-level=#{log_level}", "--steepfile=#{steepfile}", *options]
                   else
                     raise "Unknown type: #{type}"
                   end
@@ -42,11 +42,12 @@ module Steep
         new(reader: reader, writer: writer, stderr: stderr, wait_thread: thread, name: name, index: index)
       end
 
-      def self.spawn_typecheck_workers(steepfile:, args:, count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
+      def self.spawn_typecheck_workers(steepfile:, args:, steep_command: "steep", count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
         count.times.map do |i|
           spawn_worker(:typecheck,
                        name: "typecheck@#{i}",
                        steepfile: steepfile,
+                       steep_command: steep_command,
                        options: ["--max-index=#{count}", "--index=#{i}", *args],
                        delay_shutdown: delay_shutdown,
                        index: i)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -48,6 +48,31 @@ end
     sub_test.call("check", %w(-j -1))
   end
 
+  def test_steep_command_option
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+        EOF
+
+      (current_dir + "foo.rb").write(<<-EOF)
+1 + 2
+        EOF
+
+      (current_dir + "wrap-steep.sh").write(<<-EOF)
+echo "This is Wrap!"
+steep $@
+        EOF
+      FileUtils.chmod("u+x", current_dir + "wrap-steep.sh")
+
+      stdout, status = sh(*steep, "check", "--steep-command=./wrap-steep.sh")
+
+      assert_predicate status, :success?, stdout
+      assert_match /No type error detected\./, stdout
+    end
+  end
+
   def test_check_success
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)


### PR DESCRIPTION
I think to execute Steep with [Bazel](https://bazel.build/) and [rules_ruby](https://github.com/bazelruby/rules_ruby).
So, I writen Bazel configuration as follows.

```starlark
ruby_test(
    name = "typecheck",
    main = "@bundle_example//:bin/steep",
    args = [
        "check",
        "--steepfile=example/Steepfile",
    ],
    srcs = ["Steepfile", ":lib"] + glob(["sig/**/*.rbs"]),
    deps = [":lib", "@bundle_example//:bin"],
)
```

But, `bazel test` is failed.

```
# Type checking files:

#<Errno::ENOENT: No such file or directory - steep>
  /.rbenv/versions/3.1.1/lib/ruby/3.1.0/open3.rb:222:in `spawn'
  /.rbenv/versions/3.1.1/lib/ruby/3.1.0/open3.rb:222:in `popen_run'
  /.rbenv/versions/3.1.1/lib/ruby/3.1.0/open3.rb:161:in `popen2'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/server/worker_process.rb:36:in `spawn_worker'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/server/worker_process.rb:47:in `block in spawn_typecheck_workers'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/server/worker_process.rb:46:in `times'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/server/worker_process.rb:46:in `each'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/server/worker_process.rb:46:in `map'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/server/worker_process.rb:46:in `spawn_typecheck_workers'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/drivers/check.rb:38:in `run'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/cli.rb:115:in `process_check'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/lib/steep/cli.rb:52:in `run'
  /external/bundle_example/lib/ruby/3.1.0/bundler/gems/steep-64ced3af5657/exe/steep:11:in `<top (required)>'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/bin/steep:14:in `load'
  /execroot/rules_steep/bazel-out/darwin-fastbuild/bin/example/typecheck-test.runfiles/bundle_example/bin/steep:14:in `<main>'
```

Bazel is execute `main` wrapped by Ruby script instead of directly `main` executed.
And, Bazel is not set path of `main` to PATH environment variable in sandbox.
Therefore, Steep cannot spawn worker using `Open3.popen2("steep", ...)`.

To solve this issue, add `--steep-command` option for specify command to spawn worker.
Rewrite Bazel configuration above using `--steep-command` option as follows then [I could execute Steep with Bazel](https://github.com/matsubara0507/rules_steep/blob/375d44e1fc5d6852f95751114904f08cc7408952/example/BUILD.bazel#L19-L29).

```starlark
ruby_test(
    name = "typecheck",
    main = "@bundle_example//:bin/steep",
    args = [
        "check",
        "--steepfile=example/Steepfile",
        "--steep-command=example/typecheck", # this is Ruby script wrapped `main`
    ],
    srcs = ["Steepfile", ":lib"] + glob(["sig/**/*.rbs"]),
    deps = [":lib", "@bundle_example//:bin"],
)
```

I think that need `--steep-command` option to execute Steep with Bazel.
But, I have not idea other use-case...
