### PR TITLE
LSP related improvements for Sublime LSP

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -89,7 +89,7 @@ module Steep
               end
 
               LSP::Interface::Hover.new(
-                contents: { kind: "markdown", value: format_hover(content) },
+                contents: { kind: "markdown", value: format_hover(content)&.gsub(/<!--(?~-->)-->/, "") },
                 range: range
               )
             end

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -271,7 +271,7 @@ HOVER
           ),
           end: LanguageServer::Protocol::Interface::Position.new(
             line: job.line - 1,
-            character: job.column - prefix.size
+            character: job.column
           )
         )
 

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -739,7 +739,7 @@ module Steep
                       { kind: "end" }
                     else
                       progress_string = ("▮"*(percentage/5)) + ("▯"*(20 - percentage/5))
-                      { kind: "report", percentage: percentage, message: "#{progress_string} (#{percentage}%)" }
+                      { kind: "report", percentage: percentage, message: "#{progress_string}" }
                     end
 
             job_queue << SendMessageJob.to_client(

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -268,7 +268,7 @@ module Steep
         line = job.params[:position][:line] + 1
         column = job.params[:position][:character]
 
-        goto_service = Services::GotoService.new(type_check: service)
+        goto_service = Services::GotoService.new(type_check: service, assignment: assignment)
         locations =
           case
           when job.definition?

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -19,12 +19,16 @@ module Steep
       end
 
       def self.spawn_worker(type, name:, steepfile:, options: [], delay_shutdown: false, index: nil)
-        log_level = %w(debug info warn error fatal unknown)[Steep.logger.level]
+        args = ["--name=#{name}", "--steepfile=#{steepfile}"]
+        args << (%w(debug info warn error fatal unknown)[Steep.logger.level].yield_self {|log_level| "--log-level=#{log_level}" })
+        if Steep.log_output.is_a?(String)
+          args << "--log-output=#{Steep.log_output}"
+        end
         command = case type
                   when :interaction
-                    ["steep", "worker", "--interaction", "--name=#{name}", "--log-level=#{log_level}", "--steepfile=#{steepfile}", *options]
+                    ["steep", "worker", "--interaction", *args, *options]
                   when :typecheck
-                    ["steep", "worker", "--typecheck", "--name=#{name}", "--log-level=#{log_level}", "--steepfile=#{steepfile}", *options]
+                    ["steep", "worker", "--typecheck", *args, *options]
                   else
                     raise "Unknown type: #{type}"
                   end

--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -21,10 +21,11 @@ module Steep
       end
       TypeNameQuery = Struct.new(:name, keyword_init: true)
 
-      attr_reader :type_check
+      attr_reader :type_check, :assignment
 
-      def initialize(type_check:)
+      def initialize(type_check:, assignment:)
         @type_check = type_check
+        @assignment = assignment
       end
 
       def project
@@ -78,7 +79,17 @@ module Steep
           end
         end
 
-        locations.uniq
+        # Drop un-assigned paths here.
+        # The path assignment makes sense only for `.rbs` files, because un-assigned `.rb` files are already skipped since they are not type checked.
+        #
+        locations.uniq.select do |loc|
+          case loc
+          when RBS::Location
+            assignment =~ loc.name
+          else
+            true
+          end
+        end
       end
 
       def test_ast_location(loc, line:, column:)


### PR DESCRIPTION
Found minor problems when I was testing with Sublime LSP.

* Pass `--log-output` command line argument to workers so that we can use `tail -f` for LSP logs
* Delete percentage `(55%)` message from LSP progress since Sublime LSP prints the percentage itself (Why VSCode doesn't print it...)
* Strip HTML comment from markdown message since Sublime LSP doesn't handle them
* Filter *Goto definition* results from workers (VSCode automatically de-dup the list, but Sublime LSP doesn't)
* Fix RBS type name completion insertion duplication