### PR TITLE
Add: Support Windows environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,6 @@ gem "without_steep_types", path: "test/gems/without_steep_types"
 gem "rake"
 gem "minitest", "~> 5.15"
 gem "minitest-hooks"
-gem "stackprof" unless Gem.win_platform?
+group :stackprof, optional: true do
+  gem "stackprof"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem "without_steep_types", path: "test/gems/without_steep_types"
 gem "rake"
 gem "minitest", "~> 5.15"
 gem "minitest-hooks"
-gem "stackprof"
+gem "stackprof" unless Gem.win_platform?

--- a/lib/steep/project.rb
+++ b/lib/steep/project.rb
@@ -16,7 +16,21 @@ module Steep
       steepfile_path.parent
     end
 
-    def relative_path(path)
+    def relative_path(orig_path)
+      path = if Gem.win_platform?
+               path_str = URI.decode_www_form_component(
+                 orig_path.to_s.delete_prefix("/")
+               )
+               unless path_str.start_with?(%r{[a-z]:/}i)
+                 # FIXME: Sometimes drive letter is missing, taking from base_dir
+                 path_str = base_dir.to_s.split("/")[0] + "/" + path_str
+               end
+               Pathname.new(
+                 path_str
+               )
+             else
+               orig_path
+             end
       path.relative_path_from(base_dir)
     end
 

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -52,7 +52,6 @@ module Steep
           [library_paths, signature_paths, code_paths].any? do |paths|
             if Gem.win_platform?
               # FIXME: Sometimes drive letter is missing, so comparing without drive letter.
-              #   Maybe language_server-protocol bug?
               paths.any? {|p| p.to_s.split("/", 2)[1] == path.to_s.split("/", 2)[1]}
             else
               paths.include?(path)

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -49,9 +49,15 @@ module Steep
         end
 
         def checking_path?(path)
-          library_paths.include?(path) ||
-            signature_paths.include?(path) ||
-            code_paths.include?(path)
+          [library_paths, signature_paths, code_paths].any? do |paths|
+            if Gem.win_platform?
+              # FIXME: Sometimes drive letter is missing, so comparing without drive letter.
+              #   Maybe language_server-protocol bug?
+              paths.any? {|p| p.to_s.split("/", 2)[1] == path.to_s.split("/", 2)[1]}
+            else
+              paths.include?(path)
+            end
+          end
         end
 
         def checked(path)

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -37,7 +37,11 @@ module Steep
           command << "--delay-shutdown"
         end
 
-        stdin, stdout, thread = Open3.popen2(*command, pgroup: true)
+        stdin, stdout, thread = if Gem.win_platform?
+                                  Open3.popen2(*command, new_pgroup: true)
+                                else
+                                  Open3.popen2(*command, pgroup: true)
+                                end
         stderr = nil
 
         writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdin)


### PR DESCRIPTION
This PR adds support for Windows.
Sometimes drive letter (`e:`) is missing (maybe language_server-protocol bug?), so it may error if the work that is on multiple drives.
![image](https://user-images.githubusercontent.com/59691627/158961960-5773e0c2-f435-4507-b807-a6a1309184cf.png)

This closes #383.