### PR TITLE
Let `&:foo` proc work with methods with optional parameters

### DIFF
--- a/lib/steep/interface/function.rb
+++ b/lib/steep/interface/function.rb
@@ -879,6 +879,11 @@ module Steep
           !has_positional? && !has_keywords?
         end
 
+        # Returns true if all arguments are non-required.
+        def optional?
+          required.empty? && required_keywords.empty?
+        end
+
         # self + params returns a new params for overloading.
         #
         def +(other)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2348,11 +2348,11 @@ module Steep
                   interface = calculate_interface(param_type, private: true)
                   method = interface.methods[value.children[0]]
                   if method
-                    return_types = method.method_types.select {|method_type|
-                      method_type.type.params.empty?
-                    }.map {|method_type|
-                      method_type.type.return_type
-                    }
+                    return_types = method.method_types.filter_map do |method_type|
+                      if method_type.type.params.optional?
+                        method_type.type.return_type
+                      end
+                    end
 
                     unless return_types.empty?
                       type = AST::Types::Proc.new(
@@ -2360,7 +2360,7 @@ module Steep
                           params: Interface::Function::Params.empty.with_first_param(
                             Interface::Function::Params::PositionalParams::Required.new(param_type)
                           ),
-                          return_type: AST::Types::Union.build(types: return_types),
+                          return_type: return_types[0],
                           location: nil
                         ),
                         block: nil

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8508,4 +8508,25 @@ a.flat_map {|s| [s] }
       end
     end
   end
+
+  def test_to_proc_syntax_optional_arg
+    with_checker(<<-RBS) do |checker|
+class OptionalArgMethod
+  def foo: (?untyped, *untyped, ?a: untyped, **untyped) -> String
+         | () -> Integer
+end
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+[OptionalArgMethod.new].map(&:foo)
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+        assert_equal parse_type("::Array[::String]"), type
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Check if there is _required_ (== non-optional) parameters
* Pick the first method return type rather than union