### PR TITLE
Fix unexpected error when or-asgn/and-asgn

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2275,13 +2275,10 @@ module Steep
               type, constr = synthesize(rhs, hint: hint)
               constr.ivasgn(asgn, type)
             when :send
-              rhs_ = node.updated(:send,
-                                  [
-                                    asgn.children[0],
-                                    :"#{asgn.children[1]}=",
-                                    asgn.children[2],
-                                    rhs
-                                  ])
+              children = asgn.children.dup
+              children[1] = :"#{children[1]}="
+              send_arg_nodes = [*children, rhs]
+              rhs_ = node.updated(:send, send_arg_nodes)
               node_type = case node.type
                           when :or_asgn
                             :or


### PR DESCRIPTION
Fix https://github.com/soutaro/steep/issues/515

or-asgn/and-asgn may differ in the number of children under the send node.

```
$ ruby-parse --legacy -e 'a=[]; a[0] ||= 3'
(begin
  (lvasgn :a
    (array))
  (or-asgn
    (send
      (lvar :a) :[]
      (int 0)) # <= `(int 0)` is asgn.children[2]
    (int 3)))

$ ruby-parse --legacy -e 'self.a ||= 3'
(or-asgn
  (send
    (self) :a) # <= not have asgn.children[2]
  (int 3))
```

This PR support both pattern.