### PR TITLE
Fix goto-definition from method call inside block

### DIFF
--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -111,6 +111,7 @@ module Steep
           typing, signature = type_check_path(target: target, path: relative_path, content: source.content, line: line, column: column)
           if typing
             node, *parents = typing.source.find_nodes(line: line, column: column)
+
             if node
               case node.type
               when :const, :casgn
@@ -136,7 +137,10 @@ module Steep
                 end
               when :send
                 if test_ast_location(node.location.selector, line: line, column: column)
-                  node = parents[0] if parents[0]&.type == :block
+                  if (parent = parents[0]) && parent.type == :block && parent.children[0] == node
+                    node = parents[0]
+                  end
+
                   case call = typing.call_of(node: node)
                   when TypeInference::MethodCall::Typed, TypeInference::MethodCall::Error
                     call.method_decls.each do |decl|

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -652,6 +652,24 @@ RBS
     end
   end
 
+  def test_method_block_inner
+    type_check = type_check_service do |changes|
+      changes[Pathname("lib/test.rb")] = [ContentChange.string(<<RBS)]
+[].each do |x|
+  nil.to_s
+end
+RBS
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    service.definition(path: dir + "lib/test.rb", line: 2, column: 8).tap do |locs|
+      assert_any!(locs, size: 1) do |loc|
+        assert_equal Pathname("nil_class.rbs"), Pathname(loc.buffer.name).basename
+      end
+    end
+  end
+
   def test_goto_definition_wrt_assignment
     type_check = type_check_service do |changes|
       changes[Pathname("sig/a.rbs")] = [ContentChange.string(<<RBS)]


### PR DESCRIPTION
```rb
array.each do |x|
  x.foo()       # Goto from the `foo` didn't work
end
```