### PR TITLE
Show available commands when using --help

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -23,6 +23,14 @@ module Steep
 
     def process_global_options
       OptionParser.new do |opts|
+        opts.banner = <<~USAGE
+          Usage: steep [options]
+
+          available commands: #{CLI.available_commands.join(', ')}
+
+          Options:
+        USAGE
+
         opts.on("--version") do
           process_version
           exit 0


### PR DESCRIPTION
This PR adds banner for showing available commands when using `--help` option.


## before

```bash
$> steep --help                                                                                                                                                                         
Usage: steep [options]
        --version
        --log-level=LEVEL            Specify log level: debug, info, warn, error, fatal
        --log-output=PATH            Print logs to given path
        --verbose                    Set log level to debug
```

## after

```bash
$> steep --help                                                                                                                                                        
Usage: steep [options]

available commands: init, check, validate, annotations, version, project, watch, langserver, stats

Options:
        --version
        --log-level=LEVEL            Specify log level: debug, info, warn, error, fatal
        --log-output=PATH            Print logs to given path
        --verbose                    Set log level to debug
```