### PR TITLE
Better constant typing

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2731,6 +2731,14 @@ module Steep
 
               return [type, constr, name]
             end
+          when AST::Types::Any
+            # Couldn't detect the type of the parent constant
+            # Skip reporting error for this node.
+            if node
+              _, constr = add_typing(node, type: parent_type)
+            end
+
+            return [parent_type, constr, nil]
           end
         end
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2744,6 +2744,10 @@ module Steep
           end
         end
 
+        if node
+          _, constr = add_typing(node, type: AST::Builtin.any_type)
+        end
+
         [AST::Builtin.any_type, constr, nil]
       end
     end

--- a/smoke/diagnostics/test_expectations.yml
+++ b/smoke/diagnostics/test_expectations.yml
@@ -559,16 +559,6 @@
     code: Ruby::UnknownConstant
   - range:
       start:
-        line: 4
-        character: 7
-      end:
-        line: 4
-        character: 10
-    severity: ERROR
-    message: 'Cannot find the declaration of constant: `BAR`'
-    code: Ruby::UnknownConstant
-  - range:
-      start:
         line: 6
         character: 4
       end:

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -7061,7 +7061,7 @@ RUBY
 -> (n, &b) do
   # @type var n: Integer
   # @type var b: nil | ^(Integer) -> String
-  
+
   if b
     b[n]
   end
@@ -8169,7 +8169,7 @@ class A
       list[1]
     end
   end
-end 
+end
 
 # @type var a: list[Integer]
 a = [1, [2, [3, nil]]]
@@ -8448,7 +8448,7 @@ class ProcTypeCase
     if callback.is_a?(Proc)
       callback = callback[]
     end
-    
+
     callback
   end
 end
@@ -8564,7 +8564,7 @@ end
 
       source = parse_ruby(<<-'RUBY')
 # @type var a: FlatMap
-a = _ = nil 
+a = _ = nil
 a.flat_map {|s| [s] }
       RUBY
 
@@ -8621,6 +8621,36 @@ c = [*x]
         assert_equal parse_type("::Array[::String]"), constr.context.lvar_env[:a]
         assert_equal parse_type("::Array[::Integer]"), constr.context.lvar_env[:b]
         assert_equal parse_type("::Array[::Integer | ::String]"), constr.context.lvar_env[:c]
+      end
+    end
+  end
+
+  def test_case_const_unexpected_error
+    with_checker(<<-RBS) do |checker|
+class UnexpectedErrorTest
+  def foo: () -> void
+end
+      RBS
+
+      source = parse_ruby(<<-'RUBY')
+class UnexpectedErrorTest
+  def foo
+    field = _ = 123
+    case field.label
+    when Object::FOO
+    end
+  end
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 1) do |errors|
+          assert_any!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+          end
+        end
       end
     end
   end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8654,4 +8654,25 @@ end
       end
     end
   end
+
+  def test_const_one_error
+    with_checker(<<-RBS) do |checker|
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+X::Y::Z
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 1) do |errors|
+          assert_any!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+            assert_equal :X, error.name
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Found and fixed two bugs.

1. The `:const` node didn't have type if it's unknown
2. Reporting all of the constant components look too noisey (see below)

Before:

```
lib/rbs_protobuf/translator/base.rb:17:22: [information] Cannot find the declaration of constant: `Google`
│ Diagnostic ID: Ruby::UnknownConstant
│
└         @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new
                        ~~~~~~

lib/rbs_protobuf/translator/base.rb:17:30: [information] Cannot find the declaration of constant: `Protobuf`
│ Diagnostic ID: Ruby::UnknownConstant
│
└         @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new
                                ~~~~~~~~

lib/rbs_protobuf/translator/base.rb:17:40: [information] Cannot find the declaration of constant: `Compiler`
│ Diagnostic ID: Ruby::UnknownConstant
│
└         @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new
                                          ~~~~~~~~

lib/rbs_protobuf/translator/base.rb:17:50: [information] Cannot find the declaration of constant: `CodeGeneratorResponse`
│ Diagnostic ID: Ruby::UnknownConstant
│
└         @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new
                                                    ~~~~~~~~~~~~~~~~~~~~~
```

After:

```
lib/rbs_protobuf/translator/base.rb:17:22: [information] Cannot find the declaration of constant: `Google`
│ Diagnostic ID: Ruby::UnknownConstant
│
└         @response ||= Google::Protobuf::Compiler::CodeGeneratorResponse.new
                        ~~~~~~
```

This would look better. 💪 