### PR TITLE
Better union-union subtyping

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -347,7 +347,7 @@ module Steep
 
         when relation.super_type.is_a?(AST::Types::Union)
           Any(relation) do |result|
-            relation.super_type.types.sort_by {|ty| (path = hole_path(ty)) ? -path.size : 1 }.each do |super_type|
+            relation.super_type.types.sort_by {|ty| (path = hole_path(ty)) ? -path.size : -Float::INFINITY }.each do |super_type|
               rel = Relation.new(sub_type: relation.sub_type, super_type: super_type)
               result.add(rel) do
                 check_type(rel)
@@ -357,7 +357,7 @@ module Steep
 
         when relation.sub_type.is_a?(AST::Types::Intersection)
           Any(relation) do |result|
-            relation.sub_type.types.sort_by {|ty| (path = hole_path(ty)) ? -path.size : 1 }.each do |sub_type|
+            relation.sub_type.types.sort_by {|ty| (path = hole_path(ty)) ? -path.size : -Float::INFINITY }.each do |sub_type|
               rel = Relation.new(sub_type: sub_type, super_type: relation.super_type)
               result.add(rel) do
                 check_type(rel)


### PR DESCRIPTION
Subtyping between union types can be improved by skipping common types. This happens on `#flat_map`.

Assume the following type definition:

```rbs
class Array[Element]
  def flat_map: [T] () { (Element) -> (T | nil | false) } -> Array[T]
end
```

and a Ruby code

```rb
[1, 2, 3].flat_map do |i|
  if i.odd?
    i.to_s
  end
end
```

We want the type of the expression to be `Array[String]`, but it returns `Array[String | nil]`. A subtyping check happens with `String | nil <: T | nil | false`, and was solved to `T == String | nil`.

The hack is to try types without type variables before types with type variables.

1. `nil <: T | nil | false` tries `nil <: nil` and `nil <: false` before `nil <: T`.
2. The `nil <: nil` holds, and the later `nil <: T` isn't tried.

And we have `Array[String]`! 🎉 