### PR TITLE
Better send support in MethodCall

### DIFF
--- a/lib/steep/server/lsp_formatter.rb
+++ b/lib/steep/server/lsp_formatter.rb
@@ -49,7 +49,10 @@ module Steep
             builder.push do |s|
               case call
               when TypeInference::MethodCall::Typed
-                s << "```rbs\n#{call.actual_method_type.to_s}\n```\n\n"
+                mt = call.actual_method_type.with(
+                  type: call.actual_method_type.type.with(return_type: call.return_type)
+                )
+                s << "```rbs\n#{mt.to_s}\n```\n\n"
               when TypeInference::MethodCall::Error
                 s << "```rbs\n( ??? ) -> #{call.return_type.to_s}\n```\n\n"
               end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2910,6 +2910,11 @@ module Steep
               call = call.with_return_type(typing.type_of(node: arguments.last))
             end
           end
+
+          if node.type == :csend || ((node.type == :block || node.type == :numblock) && node.children[0].type == :csend)
+            optional_type = AST::Types::Union.build(types: [call.return_type, AST::Builtin.nil_type])
+            call = call.with_return_type(optional_type)
+          end
         else
           error = Diagnostic::Ruby::UnresolvedOverloading.new(
             node: node,

--- a/test/ruby_hover_test.rb
+++ b/test/ruby_hover_test.rb
@@ -139,7 +139,7 @@ RUBY
         assert_equal [5, 7]...[5, 11], [content.location.line,content.location.column]...[content.location.last_line, content.location.last_column]
         assert_instance_of TypeInference::MethodCall::Typed, content.method_call
         assert_equal [MethodName("::Array#join")], content.method_call.method_decls.map(&:method_name)
-        assert_equal "::String", content.method_call.return_type.to_s
+        assert_equal "(::String | nil)", content.method_call.return_type.to_s
       end
     end
   end

--- a/test/server/lsp_formatter_test.rb
+++ b/test/server/lsp_formatter_test.rb
@@ -68,6 +68,47 @@ EOM
     end
   end
 
+  def test_ruby_hover_method_call_csend
+    with_factory do
+      typing = type_check(<<RUBY)
+""&.gsub(/foo/, "bar")
+RUBY
+
+      call = typing.call_of(node: typing.source.node)
+
+      content = Services::HoverProvider::Ruby::MethodCallContent.new(
+        node: nil,
+        method_call: call,
+        location: nil
+      )
+
+      comment = Server::LSPFormatter.format_hover_content(content)
+      assert_equal <<EOM.chomp, comment
+```rbs
+((::Regexp | ::string), ::string) -> (::String | nil)
+```
+
+- `::String#gsub`
+
+----
+
+**::String#gsub**
+
+```rbs
+(::Regexp | ::string pattern, ::string replacement) -> ::String
+```
+
+Returns a copy of `self` with all occurrences of the given `pattern` replaced.
+
+See [Substitution Methods](#class-String-label-Substitution+Methods).
+
+Returns an Enumerator if no `replacement` and no block given.
+
+Related: String#sub, String#sub!, String#gsub!.
+EOM
+    end
+  end
+
   def test_ruby_hover_method_def
     with_factory do
       content = Services::HoverProvider::Ruby::DefinitionContent.new(

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3468,6 +3468,7 @@ EOF
 
         assert_equal parse_type("::Integer?"), pair.type
         assert_equal parse_type("::Integer?"), pair.context.lvar_env[:z]
+        assert_equal parse_type("::Integer?"), typing.call_of(node: dig(source.node, 1, 1)).return_type
       end
     end
   end


### PR DESCRIPTION
* Let `MethodCall#return_type` have optional type
* Print the optional type in LSP hover