### PR TITLE
Make `NilClass#!` a special method

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -431,7 +431,8 @@ module Steep
               case defined_in
               when RBS::BuiltinNames::BasicObject.name,
                 RBS::BuiltinNames::TrueClass.name,
-                RBS::BuiltinNames::FalseClass.name
+                RBS::BuiltinNames::FalseClass.name,
+                AST::Builtin::NilClass.module_name
                 return method_type.with(
                   type: method_type.type.with(
                     return_type: AST::Types::Logic::Not.new(location: method_type.type.return_type.location)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8723,4 +8723,28 @@ X::Y::Z
       end
     end
   end
+
+  def test_flow_sensitive_not
+    with_checker(<<-RBS) do |checker|
+class String
+  def empty?: () -> bool
+end
+
+class NilClass
+  def !: () -> true
+end
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+doc = 1 ? "" : nil
+doc = (2 ? "" : nil) if !doc || doc.empty?
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error(typing)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows the following code to type check.

```rb
doc = foo()                             # doc: String?
doc = bar() unless !doc || doc.empty?   # !doc may call NilClass#! which prevents flow-sensitive typing working
```

This PR makes `NilClass#!` special method.