### PR TITLE
Remove `to_a` error message

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3981,6 +3981,11 @@ module Steep
     end
 
     def try_convert(type, method)
+      case type
+      when AST::Types::Any, AST::Types::Bot, AST::Types::Top, AST::Types::Var
+        return
+      end
+
       interface = checker.factory.interface(type, private: false)
       if entry = interface.methods[method]
         method_type = entry.method_types.find do |method_type|

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8673,6 +8673,32 @@ c = [*x]
     end
   end
 
+  def test_to_a_untyped
+    with_checker(<<-RBS) do |checker|
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+# @type var a: untyped
+a = _ = nil
+[*a]
+
+# @type var b: top
+b = _ = nil
+[*b]
+
+# @type var c: bot
+c = _ = nil 
+[*c]
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        _, constr = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_case_const_unexpected_error
     with_checker(<<-RBS) do |checker|
 class UnexpectedErrorTest


### PR DESCRIPTION
The error message is printed because `Factory#interface` is called with unsupported types. This commit adds a guard.

Fixes #542 