### PR TITLE
Fix method parameter type checking

### DIFF
--- a/lib/steep/type_inference/method_params.rb
+++ b/lib/steep/type_inference/method_params.rb
@@ -315,6 +315,7 @@ module Steep
             when Interface::Function::Params::PositionalParams::Rest
               rest_types << param.type
               positional_params = nil
+              args.shift
               break
             when nil
               has_error = true

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8796,4 +8796,30 @@ end
       end
     end
   end
+
+  def test_keyword_param_methods
+    with_checker(<<-RBS) do |checker|
+module KeywordParamMethod
+  class Foo
+    def bar: (*String, name: Symbol) -> void
+  end 
+end
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+module KeywordParamMethod
+  class Foo
+    def bar(*args, name:)
+    end
+  end
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error(typing)
+      end
+    end
+  end
 end


### PR DESCRIPTION
With rest and keyword params.

Type checking the following type definition fails.

```rbs
class Foo
  def bar: (*String, name: String) -> void
end
```

```rb
class Foo
  def bar(*args, name:)      # <- type error reported here
  end
end
```