### PR TITLE
Better masgn

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2662,11 +2662,13 @@ module Steep
           when :ivasgn
             _, constr = constr.ivasgn(assignment, element_type)
           when :splat
-            case assignment.children[0].type
+            case assignment.children[0]&.type
             when :lvasgn
               _, constr = constr.lvasgn(assignment.children[0], unwrap_rhs_type)
             when :ivasgn
               _, constr = constr.ivasgn(assignment.children[0], unwrap_rhs_type)
+            when nil
+              # foo, * = bar
             else
               raise
             end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1645,6 +1645,28 @@ a, *b, c = x
     end
   end
 
+  def test_masgn_splat_unnamed
+    with_checker do |checker|
+      source = parse_ruby(<<-RUBY)
+# @type var x: Array[Integer]
+x = []
+a, *, c = x
+      RUBY
+
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("::Array[::Integer]"), type
+        assert_equal parse_type("::Integer?"), context.lvar_env[:a]
+        assert_nil context.lvar_env[:b]
+        assert_equal parse_type("::Integer?"), context.lvar_env[:c]
+      end
+    end
+  end
+
   def test_masgn_optional
     with_checker do |checker|
       source = parse_ruby(<<-EOF)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1697,17 +1697,16 @@ a, @b = _ = nil
       EOF
 
       with_standard_construction(checker, source) do |construction, typing|
-        construction.synthesize(source.node)
-
-        assert_equal 1, typing.errors.size
+        type, constr, context = construction.synthesize(source.node)
 
         assert_all!(typing.errors) do |error|
           assert_instance_of Diagnostic::Ruby::FallbackAny, error
         end
+
+        assert_equal parse_type("untyped"), context.lvar_env[:a]
       end
     end
   end
-
 
   def test_union_send_error
     with_checker do |checker|


### PR DESCRIPTION
```rb
a, b, c = _ = nil         # Defines local variables on lhs even if rhs is `untyped`

a, * = foo()              # Splat assignment may be unnamed
```