### PR TITLE
Fix conflict test class name

### DIFF
--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SourceIndexTest < Minitest::Test
+class IndexTest < Minitest::Test
   include TestHelper
   include FactoryHelper
   include SubtypingHelper


### PR DESCRIPTION
SourceIndexTest have 2 definitions in different files.