### PR TITLE
Support shorthand hash for ruby 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       language_server-protocol (>= 3.15, < 4.0)
       listen (~> 3.0)
       parallel (>= 1.0.0)
-      parser (>= 3.0)
+      parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
       rbs (>= 2.3.2)
       terminal-table (>= 2, < 4)

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -1,7 +1,7 @@
 require "steep/version"
 
 require "pathname"
-require "parser/ruby30"
+require "parser/ruby31"
 require "active_support"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -39,7 +39,7 @@ module Steep
     end
 
     def self.new_parser
-      ::Parser::Ruby30.new(Builder.new).tap do |parser|
+      ::Parser::Ruby31.new(Builder.new).tap do |parser|
         parser.diagnostics.all_errors_are_fatal = true
         parser.diagnostics.ignore_warnings = true
       end

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_runtime_dependency "parser", ">= 3.0"
+  spec.add_runtime_dependency "parser", ">= 3.1"
   spec.add_runtime_dependency "activesupport", ">= 5.1"
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"

--- a/test/lsp_formatter_test.rb
+++ b/test/lsp_formatter_test.rb
@@ -8,7 +8,7 @@ class LSPFormatterTest < Minitest::Test
   LSPFormatter = Diagnostic::LSPFormatter
 
   def node
-    ::Parser::Ruby30.parse("1+2")
+    ::Parser::Ruby31.parse("1+2")
   end
 
   def test_severity_for

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8873,4 +8873,21 @@ end
       end
     end
   end
+
+  def test_ruby31_shorthand_hash
+    with_checker do |checker|
+      source = parse_ruby(<<RUBY)
+x = 1
+{ x: }
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_equal parse_type("::Hash[::Symbol, ::Integer]"), type
+
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
I have just started using steep. Thanks for the great project 😄 
This PR implements support for ruby3.1 shorthand hash.

**before output**

```
lib/a.rb:6:14: [error] SyntaxError: unexpected token tRPAREN
│ Diagnostic ID: Ruby::SyntaxError
│
└ Hello.world(x:)

Detected 1 problem from 1 file
```

**after output**

```
No type error detected. 🧉
```