### PR TITLE
Fix super and zsuper with block

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -296,7 +296,7 @@ module Steep
         attr_reader :method_type
 
         def initialize(node:, method_type:)
-          super(node: node, location: node.type == :super ? node.loc.keyword : node.loc.selector)
+          super(node: node, location: (node.type == :super || node.type == :zsuper) ? node.loc.keyword : node.loc.selector)
           @method_type = method_type
         end
 

--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -296,7 +296,7 @@ module Steep
         attr_reader :method_type
 
         def initialize(node:, method_type:)
-          super(node: node, location: node.loc.selector)
+          super(node: node, location: node.type == :super ? node.loc.keyword : node.loc.selector)
           @method_type = method_type
         end
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3093,6 +3093,15 @@ module Steep
                                                          private: private,
                                                          self_type: AST::Types::Self.new)
 
+                         if send_node.type == :super || send_node.type == :zsuper
+                            method_name = method_context.name
+                            unless method_context.super_method
+                              return fallback_to_any(send_node) do
+                                Diagnostic::Ruby::UnexpectedSuper.new(node: send_node, method: method_name)
+                              end
+                            end
+                         end
+
                          constr.type_send_interface(node,
                                                     interface: interface,
                                                     receiver: receiver,

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4104,6 +4104,138 @@ EOF
     end
   end
 
+  def test_super_correct_block
+    with_checker <<-EOF do |checker|
+class TestSuper
+  def initialize: () { () -> nil } -> nil
+end
+
+class TestSuperChild < TestSuper
+  def initialize: () { () -> nil } -> nil
+end
+    EOF
+      source = parse_ruby(<<EOF)
+class TestSuperChild < TestSuper
+  def initialize
+    super do
+    end
+    super() {}
+  end
+end
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_super_wrong_block
+    with_checker <<-EOF do |checker|
+class TestSuper
+  def initialize: () { () -> nil } -> nil
+end
+
+class TestSuperChild < TestSuper
+  def initialize: () { () -> nil } -> nil
+end
+    EOF
+      source = parse_ruby(<<EOF)
+class TestSuperChild
+  def initialize
+    super { 42 }
+    super() { 42 }
+  end
+end
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 2) do |errors|
+          assert_all!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::BlockBodyTypeMismatch, error
+            assert_equal "{ 42 }", error.location.source
+          end
+        end
+      end
+    end
+  end
+
+  def test_issue_512
+    with_checker <<-EOF do |checker|
+module Issue512
+  class TestSuper
+    def foo: () -> Integer
+    def bar: () { (Integer) -> void } -> Integer
+  end
+
+  class TestSuperChild < TestSuper
+    def foo: () -> Integer
+    def bar: () { (Integer) -> void } -> Integer
+  end
+end
+    EOF
+
+      source = parse_ruby(<<-'RUBY')
+module Issue512
+  class TestSuperChild
+    def foo
+      super + 3
+      super() + 1
+    end
+
+    def bar
+      super do
+      end + 1
+      super() {} + 2
+    end
+  end
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_super_missing_super
+    with_checker <<-EOF do |checker|
+class TestSuper
+end
+
+class TestSuperChild < TestSuper
+  def bar: () { () -> nil } -> nil
+end
+    EOF
+      source = parse_ruby(<<EOF)
+class TestSuperChild
+  def bar
+    super
+    super {} + 1
+    super() {} + 2
+  end
+end
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 3) do |errors|
+          assert_all!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::UnexpectedSuper, error
+            assert_equal :bar, error.method
+          end
+        end
+      end
+    end
+  end
+
   def test_empty_array_is_error
     with_checker do |checker|
       source = parse_ruby(<<EOF)


### PR DESCRIPTION
Currently empty arguments passing to super makes UnexpectedError as below. So I needed to avoid the syntax as https://github.com/kachick/ruby-ulid/pull/189#discussion_r886930433

```
UnexpectedError: undefined method `selector' for #<Parser::Source::Map::Keyword:0x00007f53d402d878 @keyword=#<Parser::Source::Range lib/ulid/monotonic_generator.rb 269...274>, @end=#<Parser::Source::Range lib/ulid/monotonic_generator.rb 275...276>, @begin=#<Parser::Source::Range lib/ulid/monotonic_generator.rb 274...275>, @expression=#<Parser::Source::Range lib/ulid/monotonic_generator.rb 269...276>, @node=s(:super)>

          super(node: node, location: node.loc.selector)
                                              ^^^^^^^^^(Ruby::UnexpectedError)
```

When digging "super and zsuper with block", I found #512. So this PR tries to care the issue too.

Fixes #512