### PR TITLE
Apply logic-type evaluation only if the node is `:send`

### DIFF
--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -132,9 +132,12 @@ module Steep
               end
             end
           when AST::Types::Logic::Not
-            receiver, * = value_node.children
-            receiver_type = typing.type_of(node: receiver)
-            falsy_env, truthy_env = eval(env: env, type: receiver_type, node: receiver)
+            case value_node.type
+            when :send
+              receiver, * = value_node.children
+              receiver_type = typing.type_of(node: receiver)
+              falsy_env, truthy_env = eval(env: env, type: receiver_type, node: receiver)
+            end
           end
         else
           _, vars = decompose_value(node)

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -5877,6 +5877,21 @@ a+1
     end
   end
 
+  def test_logic_not2
+    with_checker(<<-RBS) do |checker|
+    RBS
+      source = parse_ruby(<<-RUBY)
+a = !Object.new
+a || true
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_logic_and
     with_checker(<<-RBS) do |checker|
     RBS


### PR DESCRIPTION
The `LogicTypeInterpreter` code assumes the `value_node` is `send` but doesn't confirm that. It resulted `Unknown node for type:` error.