### PR TITLE
Add support for `Hash#compact`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -367,7 +367,7 @@ class Array[unchecked out A]
   def last: () -> A?
 end
 
-class Hash[A, B]
+class Hash[unchecked out A, unchecked out B]
   def `[]`: (A) -> B
   def `[]=`: (A, B) -> B
   def each: { ([A, B]) -> void } -> self

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8646,7 +8646,7 @@ a.filter_map(&:itself)
     end
   end
 
-  def test_compact
+  def test_array_compact
     with_checker(<<-RBS) do |checker|
 class Array[unchecked out Element]
   def compact: () -> Array[Element]
@@ -8664,6 +8664,36 @@ a = ["1", nil]
 result = a.compact
 
 # @type var b: Array2
+b = _ = nil
+result = b.compact
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, _ = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_hash_compact
+    with_checker(<<-RBS) do |checker|
+class Hash[unchecked out K, unchecked out V]
+  def compact: () -> Hash[K, V]
+end
+
+class Hash2 < Hash[Symbol, String?]
+end
+    RBS
+
+      source = parse_ruby(<<-'RUBY')
+# @type var result: Hash[Symbol, String]
+result = _ = nil
+
+a = {foo: "1", bar: nil}
+result = a.compact
+
+# @type var b: Hash2
 b = _ = nil
 result = b.compact
       RUBY


### PR DESCRIPTION
#555 added support for `Array#compact`. This branch adds similar support for `Hash#compact`.