### PR TITLE
Use given const_env when making a new `ModuleContext`

### DIFF
--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -9,6 +9,12 @@ module Steep
 
         attr_reader :type_interface_cache
 
+        def inspect
+          s = "#<%s:%#018x " % [self.class, object_id]
+          s << "@definition_builder=#<%s:%#018x>" % [definition_builder.class, definition_builder.object_id]
+          s + ">"
+        end
+
         def initialize(builder:)
           @definition_builder = builder
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -320,7 +320,7 @@ module Steep
           instance_type: nil,
           module_type: nil,
           implement_name: nil,
-          const_env: self.module_context.const_env,
+          const_env: const_env,
           class_name: self.module_context.class_name,
           module_definition: nil,
           instance_definition: nil

--- a/smoke/regression/lambda.rb
+++ b/smoke/regression/lambda.rb
@@ -1,0 +1,3 @@
+module Mod
+  ->(){}
+end

--- a/smoke/regression/test_expectations.yml
+++ b/smoke/regression/test_expectations.yml
@@ -40,6 +40,18 @@
              | (::Numeric) -> ::Time
              | (::Time) -> ::Float
     code: Ruby::UnresolvedOverloading
+- file: lambda.rb
+  diagnostics:
+  - range:
+      start:
+        line: 1
+        character: 7
+      end:
+        line: 1
+        character: 10
+    severity: ERROR
+    message: 'Cannot find the declaration of module: `Mod`'
+    code: Ruby::UnknownConstant
 - file: set_divide.rb
   diagnostics:
   - range:

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9099,4 +9099,26 @@ RUBY
       end
     end
   end
+
+  def test_module_annotation_merge_error
+    with_checker do |checker|
+      source = parse_ruby(<<RUBY)
+module Mod
+
+  ->(){}
+
+end
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 1) do |errors|
+          errors[0].tap do |error|
+            assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/soutaro/steep/issues/551