### PR TITLE
Graceful (??) error handling with undefined outer module

### DIFF
--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -335,6 +335,9 @@ module Steep
         SourceFile.with_syntax_error(path: path, content: text, error: error)
       rescue EncodingError => exn
         SourceFile.no_data(path: path, content: "")
+      rescue RuntimeError => exn
+        Steep.log_error(exn)
+        SourceFile.no_data(path: path, content: text)
       end
 
       def self.type_check(source:, subtyping:)


### PR DESCRIPTION
It reports no error on Ruby code, but RBS error message will help the developer to understand what is happening.

![errors](https://user-images.githubusercontent.com/139089/173288780-169cd5cc-3843-4fef-b77a-3a690a209737.gif)

Fixes https://github.com/soutaro/steep/issues/547