### PR TITLE
Avoid UnexpectedError when assigning untyped singleton class

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1579,8 +1579,7 @@ module Steep
                     message: "sclass receiver must be instance type or singleton type, but type given `#{type}`"
                   )
                 )
-                constr.add_typing(node, type: AST::Builtin.nil_type)
-                return
+                return constr.add_typing(node, type: AST::Builtin.nil_type)
               end
 
               constructor.typing.add_context_for_node(node, context: constructor.context)


### PR DESCRIPTION
Currently assigning untyped singleton class making UnexpectedError and UnsupportedSyntax.

```
UnexpectedError: undefined method `constr' for nil:NilClass

              constr = rhs_result.constr.update_lvar_env do |lvar_env|
                                 ^^^^^^^(Ruby::UnexpectedError)
sclass receiver must be instance type or singleton type, but type given `untyped`(Ruby::UnsupportedSyntax)
```

I personally want correct signature from the assigning sclass, however it looks intentionally ommited in https://github.com/soutaro/steep/pull/211.
So this PR just suppress the UnexpectedError and keep UnsupportedSyntax.

