### PR TITLE
Fix super with block makes UnexpectedError when no super definition

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3000,6 +3000,17 @@ module Steep
           )
         end
 
+        if node.type == :block
+          send_node = node.children[0]
+          case send_node.type
+          when :super, :zsuper
+            method_name = method_context.name
+            return fallback_to_any(send_node) do
+              Diagnostic::Ruby::UnexpectedSuper.new(node: send_node, method: method_name)
+            end
+          end
+        end
+
         constr.add_call(
           TypeInference::MethodCall::NoMethodError.new(
             node: node,
@@ -3574,10 +3585,18 @@ module Steep
               errors << error
             end
 
-            errors << Diagnostic::Ruby::UnexpectedBlockGiven.new(
-              node: node,
-              method_type: method_type
-            )
+            case node.children[0].type
+            when :super, :zsuper
+              errors << Diagnostic::Ruby::UnexpectedSuper.new(
+                node: node.children[0],
+                method: method_name
+              )
+            else
+              errors << Diagnostic::Ruby::UnexpectedBlockGiven.new(
+                node: node,
+                method_type: method_type
+              )
+            end
 
             method_type = eliminate_vars(method_type, type_param_names)
             return_type = method_type.type.return_type

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3587,10 +3587,12 @@ module Steep
 
             case node.children[0].type
             when :super, :zsuper
-              errors << Diagnostic::Ruby::UnexpectedSuper.new(
-                node: node.children[0],
-                method: method_name
-              )
+              unless method_context.super_method
+                errors << Diagnostic::Ruby::UnexpectedSuper.new(
+                  node: node.children[0],
+                  method: method_name
+                )
+              end
             else
               errors << Diagnostic::Ruby::UnexpectedBlockGiven.new(
                 node: node,


### PR DESCRIPTION
Currently super with block called on no super definition makes following errors

```ruby
super do
end #=> UnexpectedBlockGiven

super() do
end #=> UnexpectedBlockGiven

super(42) do
end #=> UnexpectedError: undefined method `selector' ...
```

So I want suppress them in this PR. 🙏 