### PR TITLE
Appends "done!" to the watch output when the type check is complete

### DIFF
--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -79,7 +79,7 @@ module Steep
         file_paths = Set.new(dirs.select(&:file?).map(&:realpath))
 
         listener = Listen.to(*watch_paths.map(&:to_s)) do |modified, added, removed|
-          stdout.puts Rainbow("🔬 Type checking updated files...").bold
+          stdout.print Rainbow("🔬 Type checking updated files...").bold
 
           version = Time.now.to_i
           Steep.logger.tagged "watch" do
@@ -112,6 +112,8 @@ module Steep
           end
 
           client_writer.write(method: "$/typecheck", params: { guid: nil })
+          
+          stdout.puts Rainbow("done!").bold
         end.tap(&:start)
 
         begin


### PR DESCRIPTION
Initially I wasn't sure if `🔬 Type checking updated files...` was a process that was taking a while to complete or not (it's not :)) but I've made a change to make it clear that the type-check is complete, which most of the time is almost instant. 

<img width="353" alt="Screenshot 2022-07-01 at 16 41 15" src="https://user-images.githubusercontent.com/218674/176926789-60f25f59-43f7-422b-8a9c-d7c83ea7a86d.png">

