### PR TITLE
Fix LogicTypeInterpreter implementation

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1679,7 +1679,7 @@ module Steep
             left_type, constr, left_context = synthesize(left_node, hint: hint, condition: true).to_ary
 
             interpreter = TypeInference::LogicTypeInterpreter.new(subtyping: checker, typing: typing)
-            left_truthy_env, left_falsy_env = interpreter.eval(env: left_context.type_env, type: left_type, node: left_node)
+            left_truthy_env, left_falsy_env = interpreter.eval(env: left_context.type_env, node: left_node)
 
             if left_type.is_a?(AST::Types::Logic::Env)
               left_type = left_type.type
@@ -1692,7 +1692,7 @@ module Steep
                 .for_branch(right_node)
                 .synthesize(right_node, hint: hint, condition: true).to_ary
 
-            right_truthy_env, right_falsy_env = interpreter.eval(env: right_context.type_env, type: right_type, node: right_node)
+            right_truthy_env, right_falsy_env = interpreter.eval(env: right_context.type_env, node: right_node)
 
             env =
               if right_type.is_a?(AST::Types::Bot)
@@ -1727,7 +1727,7 @@ module Steep
             left_type, constr, left_context = synthesize(left_node, hint: hint, condition: true).to_ary
 
             interpreter = TypeInference::LogicTypeInterpreter.new(subtyping: checker, typing: typing)
-            left_truthy_env, left_falsy_env = interpreter.eval(env: left_context.type_env, type: left_type, node: left_node)
+            left_truthy_env, left_falsy_env = interpreter.eval(env: left_context.type_env, node: left_node)
 
             if left_type.is_a?(AST::Types::Logic::Env)
               left_type = left_type.type
@@ -1741,7 +1741,7 @@ module Steep
                 .for_branch(right_node)
                 .synthesize(right_node, hint: left_type, condition: true).to_ary
 
-            right_truthy_env, right_falsy_env = interpreter.eval(env: left_falsy_env, type: right_type, node: right_node)
+            right_truthy_env, right_falsy_env = interpreter.eval(env: left_falsy_env, node: right_node)
 
             env = if right_type.is_a?(AST::Types::Bot)
                     left_truthy_env
@@ -1774,7 +1774,7 @@ module Steep
 
             cond_type, constr = synthesize(cond, condition: true).to_ary
             interpreter = TypeInference::LogicTypeInterpreter.new(subtyping: checker, typing: constr.typing)
-            truthy_env, falsy_env = interpreter.eval(env: constr.context.type_env, type: cond_type, node: cond)
+            truthy_env, falsy_env = interpreter.eval(env: constr.context.type_env, node: cond)
 
             if true_clause
               true_pair =
@@ -1846,7 +1846,7 @@ module Steep
                 tests.each do |test|
                   test_node = test.updated(:send, [test, :===, cond])
                   test_type, test_constr = test_constr.synthesize(test_node, condition: true).to_ary
-                  truthy_env, falsy_env = interpreter.eval(type: test_type, node: test_node, env: test_constr.context.type_env)
+                  truthy_env, falsy_env = interpreter.eval(node: test_node, env: test_constr.context.type_env)
 
                   test_envs << truthy_env
 
@@ -1905,7 +1905,7 @@ module Steep
 
                 tests.each do |test|
                   test_type, condition_constr = condition_constr.synthesize(test, condition: true).to_ary
-                  truthy_env, falsy_env = interpreter.eval(env: condition_constr.context.type_env, type: test_type, node: test)
+                  truthy_env, falsy_env = interpreter.eval(env: condition_constr.context.type_env, node: test)
 
                   condition_constr = condition_constr.update_type_env { falsy_env }
                   body_envs << truthy_env
@@ -2103,7 +2103,7 @@ module Steep
             cond_type, constr = synthesize(cond, condition: true).to_ary
 
             interpreter = TypeInference::LogicTypeInterpreter.new(subtyping: checker, typing: typing)
-            truthy_env, falsy_env = interpreter.eval(env: constr.context.type_env, node: cond, type: cond_type)
+            truthy_env, falsy_env = interpreter.eval(env: constr.context.type_env, node: cond)
 
             case node.type
             when :while

--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -138,7 +138,7 @@ module Steep
           local_variable_updates[name] = [type, enforced_type(name)]
         end
 
-        invalidated_nodes = Set.new(pure_method_calls.each_key)
+        invalidated_nodes = Set.new(pure_call_types.each_key)
         local_variable_types.each_key do |name|
           invalidated_nodes.merge(invalidated_pure_nodes(Parser::AST::Node.new(:lvar, [name])))
         end

--- a/sig/steep/ast/types/logic.rbs
+++ b/sig/steep/ast/types/logic.rbs
@@ -22,30 +22,37 @@ module Steep
           def to_s: () -> ::String
         end
 
+        # A type for `!` (not) operator results.
         class Not < Base
           def initialize: (?location: untyped?) -> void
         end
 
+        # A type for `foo.nil?` call results.
         class ReceiverIsNil < Base
           def initialize: (?location: untyped?) -> void
         end
 
+        #
         class ReceiverIsNotNil < Base
           def initialize: (?location: untyped?) -> void
         end
 
+        # A type for `receiver.is_a?(C)` call results.
         class ReceiverIsArg < Base
           def initialize: (?location: untyped?) -> void
         end
 
+        # A type for `Class#===` call results.
         class ArgIsReceiver < Base
           def initialize: (?location: untyped?) -> void
         end
 
+        # A type for `Object#===` call results.
         class ArgEqualsReceiver < Base
           def initialize: (?location: untyped?) -> void
         end
 
+        # A type with truthy/falsy type environment.
         class Env < Base
           attr_reader truthy: TypeInference::TypeEnv
 

--- a/sig/steep/ast/types/tuple.rbs
+++ b/sig/steep/ast/types/tuple.rbs
@@ -2,31 +2,32 @@ module Steep
   module AST
     module Types
       class Tuple
-        attr_reader types: untyped
+        attr_reader types: Array[t]
 
-        attr_reader location: untyped
+        attr_reader location: RBS::Location[untyped, untyped]?
 
-        def initialize: (types: untyped, ?location: untyped?) -> void
+        def initialize: (types: Array[t], ?location: RBS::Location[untyped, untyped]?) -> void
 
-        def ==: (untyped other) -> untyped
+        def ==: (untyped other) -> bool
 
-        def hash: () -> untyped
+        def hash: () -> Integer
 
         alias eql? ==
 
-        def subst: (untyped s) -> untyped
+        def subst: (Interface::Substitution s) -> Tuple
 
         def to_s: () -> ::String
 
-        def free_variables: () -> untyped
+        def free_variables: () -> Set[Symbol]
 
         include Helper::ChildrenLevel
 
-        def each_child: () ?{ () -> untyped } -> untyped
+        def each_child: () { (t) -> void } -> void
+                      | () -> Enumerator[t, void]
 
         def level: () -> untyped
 
-        def with_location: (untyped new_location) -> untyped
+        def with_location: (RBS::Location[untyped, untyped] new_location) -> Tuple
       end
     end
   end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -96,7 +96,7 @@ module Steep
 
     def add_call: (untyped call) -> untyped
 
-    def synthesize: (Parser::AST::Node node, ?hint: untyped?, ?condition: bool) -> Pair
+    def synthesize: (Parser::AST::Node node, ?hint: AST::Types::t?, ?condition: bool) -> Pair
 
     def check: (Parser::AST::Node node, untyped `type`, ?constraints: untyped) { (untyped, untyped, untyped) -> untyped } -> bool
 

--- a/sig/steep/type_inference/logic_type_interpreter.rbs
+++ b/sig/steep/type_inference/logic_type_interpreter.rbs
@@ -9,9 +9,23 @@ module Steep
 
       def initialize: (subtyping: Subtyping::Check, typing: Typing) -> void
 
-      def eval: (env: TypeEnv, type: AST::Types::t, node: Parser::AST::Node) -> [TypeEnv, TypeEnv]
+      def eval: (env: TypeEnv, node: Parser::AST::Node) -> [TypeEnv, TypeEnv, Set[Symbol | Parser::AST::Node], AST::Types::t, AST::Types::t]
 
-      def evaluate_method_call: (env: TypeEnv, type: AST::Types::Logic::Base, receiver: Parser::AST::Node?, arguments: Array[Parser::AST::Node]) -> [TypeEnv, TypeEnv]?
+      def evaluate_node: (env: TypeEnv, node: Parser::AST::Node, refined_objects: Set[Symbol | Parser::AST::Node]) -> [AST::Types::t, AST::Types::t, TypeEnv, TypeEnv]
+
+      def evaluate_method_call: (env: TypeEnv, type: AST::Types::Logic::Base, receiver: Parser::AST::Node?, arguments: Array[Parser::AST::Node], refined_objects: Set[Symbol | Parser::AST::Node]) -> [TypeEnv, TypeEnv]?
+
+      # Apply type refinement to `node` as `truthy_type` and `falsy_type`.
+      #
+      # This is done by top-down manner.
+      #
+      # Assignes given two types to the node when:
+      #
+      # * `node` is a `lvar`
+      # * `node` is a `lvasgn`
+      # * `node` is a _pure_ method call
+      #
+      def refine_node_type: (env: TypeEnv, node: Parser::AST::Node, truthy_type: AST::Types::t, falsy_type: AST::Types::t, refined_objects: Set[Symbol | Parser::AST::Node]) -> [TypeEnv, TypeEnv]
 
       # Returns a pair of a node and set of local variable names.
       #
@@ -29,10 +43,6 @@ module Steep
 
       private
 
-      def update_type_env: (Enumerable[Symbol] variables, truthy_type: AST::Types::t, falsy_type: AST::Types::t, truthy_env: TypeEnv, falsy_env: TypeEnv) -> [TypeEnv, TypeEnv]
-
-      def refine_vars: (TypeEnv, ?node: Parser::AST::Node?, vars: Enumerable[Symbol], type: AST::Types::t) -> TypeEnv
-
       def guess_type_from_method: (Parser::AST::Node node) -> (AST::Types::Logic::ReceiverIsArg | AST::Types::Logic::ReceiverIsNil | AST::Types::Logic::Not | AST::Types::Logic::ArgIsReceiver | nil)
 
       # Decompose to given type to truthy and falsy types.
@@ -48,7 +58,7 @@ module Steep
       # end
       # ```
       #
-      def literal_var_type_case_select: (Parser::AST::Node value_node, AST::Types::t arg_type) -> [Array[AST::Types::t], Array[AST::Types::t]]
+      def literal_var_type_case_select: (Parser::AST::Node value_node, AST::Types::t arg_type) -> [Array[AST::Types::t], Array[AST::Types::t]]?
 
       def type_case_select: (AST::Types::t `type`, RBS::TypeName klass) -> [AST::Types::t, AST::Types::t]
 


### PR DESCRIPTION
Write it in a simple recursion:

* Straightforward implementation :+1:
* Precise variable assignment :+1:
* More meta data: returns a set of _refined objects_ too :+1:
* More `TypeEnv` instance allocations :-1:

Related to https://github.com/soutaro/steep/issues/590