### PR TITLE
Fix Issue 610

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3700,6 +3700,7 @@ module Steep
       type_env = TypeInference::TypeEnvBuilder.new(
         TypeInference::TypeEnvBuilder::Command::ImportLocalVariableAnnotations.new(block_annotations).merge!.on_duplicate! do |name, outer_type, inner_type|
           next if outer_type.is_a?(AST::Types::Var) || inner_type.is_a?(AST::Types::Var)
+          next unless body_node
 
           if result = no_subtyping?(sub_type: outer_type, super_type: inner_type)
             typing.add_error Diagnostic::Ruby::IncompatibleAnnotation.new(

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3243,6 +3243,15 @@ module Steep
 
       constr = self
 
+      constr = constr.with(
+        context: context.with(
+          variable_context: TypeInference::Context::TypeVariableContext.new(
+            type_params,
+            parent_context: context.variable_context
+          )
+        )
+      )
+
       method_type = method_type.instantiate(instantiation)
 
       variance = Subtyping::VariableVariance.from_method_type(method_type)
@@ -3597,6 +3606,12 @@ module Steep
                    errors: errors
                  )
                end
+
+        constr = constr.with(
+          context: constr.context.with(
+            variable_context: context.variable_context
+          )
+        )
 
         [
           call,

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3408,15 +3408,11 @@ module Steep
                 # Ready for type check the body of the block
                 block_constr = block_constr.update_type_env {|env| env.subst(s) }
 
-                if block_body
-                  block_body_type = block_constr.synthesize_block(
-                    node: node,
-                    block_body: block_body,
-                    block_type_hint: method_type.block.type.return_type
-                  )
-                else
-                  block_body_type = AST::Builtin.nil_type
-                end
+                block_body_type = block_constr.synthesize_block(
+                  node: node,
+                  block_body: block_body,
+                  block_type_hint: method_type.block.type.return_type
+                )
 
                 result = check_relation(sub_type: block_body_type,
                                         super_type: method_type.block.type.return_type,

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3407,6 +3407,13 @@ module Steep
               if solved
                 # Ready for type check the body of the block
                 block_constr = block_constr.update_type_env {|env| env.subst(s) }
+                block_constr = block_constr.update_context {|context|
+                  context.with(
+                    type_env: context.type_env.subst(s),
+                    block_context: context.block_context&.subst(s),
+                    break_context: context.break_context&.subst(s)
+                  )
+                }
 
                 block_body_type = block_constr.synthesize_block(
                   node: node,

--- a/lib/steep/type_inference/context.rb
+++ b/lib/steep/type_inference/context.rb
@@ -29,6 +29,10 @@ module Steep
         def initialize(body_type:)
           @body_type = body_type
         end
+
+        def subst(s)
+          BlockContext.new(body_type: body_type&.subst(s))
+        end
       end
 
       class BreakContext
@@ -38,6 +42,10 @@ module Steep
         def initialize(break_type:, next_type:)
           @break_type = break_type
           @next_type = next_type
+        end
+
+        def subst(s)
+          BreakContext.new(break_type: break_type.subst(s), next_type: next_type&.subst(s))
         end
       end
 

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -128,11 +128,11 @@ module Steep
       end
 
       class NoMethod < Base
-        attr_reader type: untyped
+        attr_reader type: AST::Types::t
 
-        attr_reader method: untyped
+        attr_reader method: Symbol
 
-        def initialize: (node: untyped, type: untyped, method: untyped) -> void
+        def initialize: (node: Parser::AST::Node, type: AST::Types::t, method: Symbol) -> void
 
         def header_line: () -> ::String
       end
@@ -441,7 +441,7 @@ module Steep
       #
       # ```ruby
       # a, b = foo()
-      #        ^^^^^ 
+      #        ^^^^^
       # ```
       #
       class MultipleAssignmentConversionError < Base

--- a/sig/steep/interface/block.rbs
+++ b/sig/steep/interface/block.rbs
@@ -1,35 +1,35 @@
 module Steep
   module Interface
     class Block
-      attr_reader type: untyped
+      attr_reader type: Function
 
-      attr_reader optional: untyped
+      attr_reader optional: bool
 
-      def initialize: (type: untyped, optional: untyped) -> void
+      def initialize: (type: Function, optional: bool) -> void
 
-      def optional?: () -> untyped
+      def optional?: () -> bool
 
-      def required?: () -> untyped
+      def required?: () -> bool
 
-      def to_optional: () -> untyped
+      def to_optional: () -> Block
 
-      def ==: (untyped other) -> untyped
+      def ==: (untyped other) -> bool
 
       alias eql? ==
 
-      def hash: () -> untyped
+      def hash: () -> Integer
 
-      def closed?: () -> untyped
+      def closed?: () -> bool
 
-      def subst: (untyped s) -> untyped
+      def subst: (Substitution s) -> Block
 
-      def free_variables: () -> untyped
+      def free_variables: () -> Set[Symbol]
 
       def to_s: () -> ::String
 
-      def map_type: () { () -> untyped } -> untyped
+      def map_type: () { (AST::Types::t) -> AST::Types::t } -> Block
 
-      def +: (untyped other) -> untyped
+      def +: (Block other) -> Block
     end
   end
 end

--- a/sig/steep/interface/function.rbs
+++ b/sig/steep/interface/function.rbs
@@ -128,15 +128,15 @@ module Steep
           def &: (untyped other) -> (nil | untyped)
         end
 
-        def required: () -> untyped
+        def required: () -> Array[AST::Types::t]
 
-        def optional: () -> untyped
+        def optional: () -> Array[AST::Types::t]
 
-        def rest: () -> untyped
+        def rest: () -> AST::Types::t?
 
-        attr_reader positional_params: untyped
+        attr_reader positional_params: PositionalParams
 
-        attr_reader keyword_params: untyped
+        attr_reader keyword_params: KeywordParams
 
         def self.build: (?required: untyped, ?optional: untyped, ?rest: untyped?, ?required_keywords: ::Hash[untyped, untyped], ?optional_keywords: ::Hash[untyped, untyped], ?rest_keywords: untyped?) -> untyped
 
@@ -221,7 +221,7 @@ module Steep
 
       attr_reader params: untyped
 
-      attr_reader return_type: untyped
+      attr_reader return_type: AST::Types::t
 
       attr_reader location: untyped
 
@@ -233,9 +233,9 @@ module Steep
 
       def hash: () -> untyped
 
-      def free_variables: () -> untyped
+      def free_variables: () -> Set[Symbol]
 
-      def subst: (untyped s) -> untyped
+      def subst: (Substitution s) -> Function
 
       def each_child: () { () -> untyped } -> untyped
 
@@ -247,7 +247,7 @@ module Steep
 
       def to_s: () -> ::String
 
-      def closed?: () -> untyped
+      def closed?: () -> bool
     end
   end
 end

--- a/sig/steep/interface/method_type.rbs
+++ b/sig/steep/interface/method_type.rbs
@@ -3,9 +3,9 @@ module Steep
     class MethodType
       attr_reader type_params: Array[TypeParam]
 
-      attr_reader type: untyped
+      attr_reader type: Function
 
-      attr_reader block: untyped
+      attr_reader block: Block
 
       attr_reader method_decls: untyped
 
@@ -15,21 +15,21 @@ module Steep
 
       alias eql? ==
 
-      def hash: () -> untyped
+      def hash: () -> Integer
 
-      def free_variables: () -> untyped
+      def free_variables: () -> Set[Symbol]
 
-      def subst: (untyped s) -> (self | untyped)
+      def subst: (Substitution s) -> MethodType
 
       def each_type: () { (untyped) -> untyped } -> untyped
 
-      def instantiate: (untyped s) -> untyped
+      def instantiate: (Substitution s) -> MethodType
 
-      def with: (?type_params: untyped, ?type: untyped, ?block: untyped, ?method_decls: untyped) -> untyped
+      def with: (?type_params: untyped, ?type: untyped, ?block: untyped, ?method_decls: untyped) -> MethodType
 
       def to_s: () -> ::String
 
-      def map_type: () ?{ () -> untyped } -> untyped
+      def map_type: () { (AST::Types::t) -> AST::Types::t } -> MethodType
 
       # Returns a new method type which can be used for the method implementation type of both `self` and `other`.
       #

--- a/sig/steep/subtyping/constraints.rbs
+++ b/sig/steep/subtyping/constraints.rbs
@@ -53,41 +53,59 @@ module Steep
         def initialize: (var: untyped, sub_type: untyped, super_type: untyped, result: untyped) -> void
       end
 
-      attr_reader dictionary: untyped
+      class Context
+        attr_reader variance: untyped
 
-      attr_reader vars: untyped
+        attr_reader self_type: AST::Types::t
 
-      def initialize: (unknowns: untyped) -> void
+        attr_reader instance_type: AST::Types::t
 
-      def self.empty: () -> untyped
+        attr_reader class_type: AST::Types::t
 
-      def add_var: (*untyped vars) -> untyped
+        def initialize: (variance: untyped, self_type: AST::Types::t, instance_type: AST::Types::t, class_type: AST::Types::t) -> void
+      end
 
-      def add: (untyped var, ?sub_type: untyped?, ?super_type: untyped?, ?skip: bool) -> untyped
+      attr_reader dictionary: Hash[Symbol, [Set[AST::Types::t], Set[AST::Types::t], Set[AST::Types::t]]]
+
+      attr_reader vars: Set[Symbol]
+
+      def initialize: (unknowns: _Each[Symbol]) -> void
+
+      def self.empty: () -> Constraints
+
+      def add_var: (*Symbol vars) -> void
+
+      def add: (Symbol var, ?sub_type: untyped?, ?super_type: untyped?, ?skip: bool) -> untyped
 
       def eliminate_variable: (AST::Types::t `type`, to: AST::Types::t) -> AST::Types::t
 
-      def unknown?: (untyped var) -> untyped
+      def unknown?: (Symbol var) -> bool
 
-      def unknowns: () -> untyped
+      def unknowns: () -> Set[Symbol]
 
-      def unknown!: (untyped var) -> (untyped | nil)
+      def unknown!: (Symbol var) -> void
 
-      def empty?: () -> untyped
+      def empty?: () -> bool
 
-      def upper_bound: (untyped var, ?skip: bool) -> untyped
+      def upper_bound: (Symbol var, ?skip: bool) -> AST::Types::t
 
-      def lower_bound: (untyped var, ?skip: bool) -> untyped
+      def lower_bound: (Symbol var, ?skip: bool) -> AST::Types::t
 
-      Context: untyped
+      def solution: (Check checker, variables: Enumerable[Symbol], variance: VariableVariance, self_type: AST::Types::t, instance_type: AST::Types::t, class_type: AST::Types::t) -> Interface::Substitution
+                  | (Check checker, variables: Enumerable[Symbol], context: Context) -> Interface::Substitution
 
-      def solution: (untyped checker, variables: untyped, ?variance: untyped?, ?self_type: untyped?, ?instance_type: untyped?, ?class_type: untyped?, ?context: untyped?) -> untyped
+      def has_constraint?: (Symbol var) -> bool
 
-      def has_constraint?: (untyped var) -> untyped
-
-      def each: () { (untyped, untyped, untyped) -> untyped } -> untyped
+      def each: () { ([Symbol, AST::Types::t, AST::Types::t]) -> void } -> void
+              | () -> Enumerator[[Symbol, AST::Types::t, AST::Types::t], void]
 
       def to_s: () -> ::String
+
+      private
+
+      def lower_bound_types: (Symbol var_name) -> Set[AST::Types::t]
+
+      def upper_bound_types: (Symbol var_name) -> Set[AST::Types::t]
     end
   end
 end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -183,20 +183,22 @@ module Steep
         block_params: TypeInference::BlockParams,
         block_param_hint: TypeInference::MethodParams?,
         block_type_hint: AST::Types::t?,
-        block_block_hint: AST::Types::t?,
+        block_block_hint: Interface::Block?,
         block_annotations: AST::Annotation::Collection,
         node_type_hint: AST::Types::t?
       ) -> TypeConstruction
 
-    # Synthesize the block body and returns a Pair of after evaluating the body.
+    # Synthesize the block body and returns the type of the body
     #
-    def synthesize_block: (node: Parser::AST::Node, block_type_hint: AST::Types::t?, block_body: Parser::AST::Node) -> Pair
+    # The constructor can be discarded because it cannot change anything outer than block.
+    #
+    def synthesize_block: (node: Parser::AST::Node, block_type_hint: AST::Types::t?, block_body: Parser::AST::Node?) -> AST::Types::t
 
     def nesting: () -> RBS::Resolver::context
 
     def absolute_name: (untyped name) -> untyped
 
-    def union_type: (*untyped types) -> untyped
+    def union_type: (*AST::Types::t types) -> AST::Types::t
 
     def validate_method_definitions: (untyped node, untyped module_name) -> (nil | untyped)
 

--- a/sig/steep/type_inference/context.rbs
+++ b/sig/steep/type_inference/context.rbs
@@ -20,17 +20,31 @@ module Steep
       end
 
       class BlockContext
-        attr_reader body_type: untyped
+        # The type of block itself
+        #
+        # Returns `nil` if no type is specified.
+        #
+        attr_reader body_type: AST::Types::t?
 
-        def initialize: (body_type: untyped) -> void
+        def initialize: (body_type: AST::Types::t?) -> void
+
+        def subst: (Interface::Substitution) -> BlockContext
       end
 
       class BreakContext
-        attr_reader break_type: untyped
+        # Type of arguments to `break` statement
+        #
+        attr_reader break_type: AST::Types::t
 
-        attr_reader next_type: untyped
+        # Type of arguments to `next` statement
+        #
+        # `nil` means the passed value will be ignored.
+        #
+        attr_reader next_type: AST::Types::t?
 
-        def initialize: (break_type: untyped, next_type: untyped) -> void
+        def initialize: (break_type: AST::Types::t, next_type: AST::Types::t?) -> void
+
+        def subst: (Interface::Substitution) -> BreakContext
       end
 
       class ModuleContext
@@ -60,26 +74,30 @@ module Steep
       end
 
       class TypeVariableContext
-        attr_reader table: untyped
+        attr_reader table: Hash[Symbol, Interface::TypeParam]
 
-        attr_reader type_params: untyped
+        attr_reader type_params: Array[Interface::TypeParam]
 
-        def initialize: (untyped type_params, ?parent_context: untyped?) -> void
+        def initialize: (Array[Interface::TypeParam] type_params, ?parent_context: TypeVariableContext?) -> void
 
-        def []: (untyped name) -> untyped
+        def []: (Symbol name) -> AST::Types::t?
 
-        def upper_bounds: () -> untyped
+        def upper_bounds: () -> Hash[Symbol, AST::Types::t]
 
-        def self.empty: () -> untyped
+        def self.empty: () -> TypeVariableContext
       end
 
       attr_reader call_context: untyped
 
       attr_reader method_context: untyped
 
-      attr_reader block_context: untyped
+      # BlockContext for current execution point
+      #
+      # `nil` when not in iterator block.
+      #
+      attr_reader block_context: BlockContext?
 
-      attr_reader break_context: untyped
+      attr_reader break_context: BreakContext?
 
       attr_reader module_context: untyped
 
@@ -87,11 +105,29 @@ module Steep
 
       attr_reader type_env: TypeEnv
 
-      attr_reader variable_context: untyped
+      attr_reader variable_context: TypeVariableContext
 
-      def initialize: (method_context: untyped, block_context: untyped, break_context: untyped, module_context: untyped, self_type: untyped, type_env: TypeEnv, call_context: untyped, variable_context: untyped) -> void
+      def initialize: (
+        method_context: untyped,
+        block_context: BlockContext?,
+        break_context: BreakContext?,
+        module_context: untyped,
+        self_type: untyped,
+        type_env: TypeEnv,
+        call_context: untyped,
+        variable_context: TypeVariableContext
+      ) -> void
 
-      def with: (?method_context: untyped, ?block_context: untyped, ?break_context: untyped, ?module_context: untyped, ?self_type: untyped, ?type_env: TypeEnv, ?call_context: untyped, ?variable_context: untyped) -> untyped
+      def with: (
+        ?method_context: untyped,
+        ?block_context: BlockContext?,
+        ?break_context: BreakContext?,
+        ?module_context: untyped,
+        ?self_type: untyped,
+        ?type_env: TypeEnv,
+        ?call_context: untyped,
+        ?variable_context: untyped
+      ) -> Context
 
       def factory: () -> AST::Types::Factory
 

--- a/smoke/diagnostics/test_expectations.yml
+++ b/smoke/diagnostics/test_expectations.yml
@@ -489,8 +489,10 @@
         line: 2
         character: 10
     severity: ERROR
-    message: The value given to break will be ignored
-    code: Ruby::UnexpectedJumpValue
+    message: |-
+      Cannot break with a value of type `::Integer` because type `nil` is assumed
+        ::Integer <: nil
+    code: Ruby::BreakTypeMismatch
 - file: unexpected_keyword.rb
   diagnostics:
   - range:

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1940,10 +1940,7 @@ end
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
 
-        assert_equal 1, typing.errors.size
-        assert_any typing.errors do |error|
-          error.is_a?(Diagnostic::Ruby::UnexpectedJumpValue)
-        end
+        assert_no_error typing
       end
     end
   end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9699,7 +9699,7 @@ reader.read("123", -> () { 123 })
 module Issue610
   class Foo
     def ok: [T] (T) { () -> ^(::Integer) -> T } -> T
-    def ng: [T < Integer] (T) { () -> ^(T) -> T } -> T
+    def ng: [T] (T) { () -> ^(T) -> T } -> T
   end
 end
       RBS
@@ -9711,7 +9711,12 @@ ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
       with_standard_construction(checker, source) do |construction, typing|
         type, _, context = construction.synthesize(source.node)
 
-        assert_no_error typing
+        assert_typing_error(typing, size: 1) do |errors|
+          errors[0].tap do |error|
+            assert_instance_of Diagnostic::Ruby::NoMethod, error
+            assert_equal :+, error.method
+          end
+        end
 
         assert_equal parse_type("::Integer"), context.type_env[:ok]
         assert_equal parse_type("::Integer"), context.type_env[:ng]

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9711,13 +9711,6 @@ ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
       with_standard_construction(checker, source) do |construction, typing|
         type, _, context = construction.synthesize(source.node)
 
-        assert_typing_error(typing, size: 1) do |errors|
-          errors[0].tap do |error|
-            assert_instance_of Diagnostic::Ruby::NoMethod, error
-            assert_equal :+, error.method
-          end
-        end
-
         assert_equal parse_type("::Integer"), context.type_env[:ok]
         assert_equal parse_type("::Integer"), context.type_env[:ng]
       end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9723,4 +9723,26 @@ ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
       end
     end
   end
+
+  def test_issue_610_type_param_block_param_generic_constraint
+    with_checker(<<-RBS) do |checker|
+module Issue610
+  class Foo
+    def ng: [T < Integer] (T) { () -> ^(T) -> T } -> T
+  end
+end
+      RBS
+      source = parse_ruby(<<-RUBY)
+ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("::Integer"), context.type_env[:ng]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #610 

Fix various random bugs uncovered with #610.

```rbs
# RBS
class Foo
  def ng: [T] (T) { () -> ^(T) -> T } -> T
end
```

```rb
# Code
Foo.new.ng(42) {-> int { int.to_int } }.to_int
```

* The original problem was `UnexpectedError` that is caused by accessing unknown type variable. This is fixed by updating `TypeVariableContext` on generic method call type inference. (ac3909023fa19ecf2e6f5d2801e2f6d7c367f740)
* Writing the type of some **Context classes uncovered `BreakContext` problems. (844b5aed4f003d067f873323069a2f8dbfe178db)
* _But, how about adding upper bound on generics type parameter?_ Resulted another bug of ignoring collected constraints during type inference by upper bound of generics type parameter. (af9ff2cb1044641e4229c10dd52548d30bd9e629)
* Adding generic upper bound for this case??? `def ng: [T < Integer] (T) { () -> ^(T) -> T } -> T` Looks weird. How can we know `T` is bounded by Integer beforehand. ☹️ So, the instantiation of `T` should occur before block type checking! This is the bug! Apply the substitution also to contexts. (bc2356a313e50dc092330290989106de04e3c8fd)

🎉 