### PR TITLE
Fix special local variable handling

### DIFF
--- a/lib/steep/type_inference/multiple_assignment.rb
+++ b/lib/steep/type_inference/multiple_assignment.rb
@@ -177,7 +177,12 @@ module Steep
           AST::Types::Tuple.new(types: types)
         when :lvasgn, :ivasgn, :gvasgn
           name = mlhs.children[0]
-          env[name] || AST::Builtin.any_type
+          
+          unless TypeConstruction::SPECIAL_LVAR_NAMES.include?(name)
+            env[name] || AST::Builtin.any_type
+          else
+            AST::Builtin.any_type
+          end
         when :splat
           return
         else

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -16,6 +16,8 @@ module Steep
       def to_ary: () -> [AST::Types::t, TypeConstruction, TypeInference::Context]
     end
 
+    SPECIAL_LVAR_NAMES: Set[Symbol]
+
     include NodeHelper
 
     attr_reader checker: Subtyping::Check

--- a/sig/steep/type_inference/type_env.rbs
+++ b/sig/steep/type_inference/type_env.rbs
@@ -150,6 +150,8 @@ module Steep
 
       def local_variable_name?: (Symbol) -> bool
 
+      def local_variable_name!: (Symbol) -> void
+
       def instance_variable_name?: (Symbol) -> bool
 
       def global_name?: (Symbol) -> bool

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9738,4 +9738,33 @@ ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
       end
     end
   end
+
+  def test_lvar_special
+    with_checker(<<-RBS) do |checker|
+      RBS
+      source = parse_ruby(<<-RUBY)
+_ = 123
+_ + 1
+
+__skip__ = 123
+__skip__ + 123
+
+__any__ = :foo
+__any__ + 123
+
+_, __any__ = [123, :foo]
+
+[1,2,3].each do |_|
+end
+
+-> (_) { 123 }
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
Special local variables — `_`, `__skip__`, and `__any` — always have `untyped` type.