### PR TITLE
Fix type narrowing on assignment

### DIFF
--- a/sig/steep/node_helper.rbs
+++ b/sig/steep/node_helper.rbs
@@ -6,6 +6,8 @@ module Steep
     def each_descendant_node: (Parser::AST::Node) -> Enumerator[Parser::AST::Node, void]
                             | (Parser::AST::Node) { (Parser::AST::Node) -> void } -> void
 
+    # Returns true if given node is a syntactic-value node
+    #
     def value_node?: (Parser::AST::Node) -> bool
   end
 end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -283,5 +283,18 @@ module Steep
     # * All of the arguments are _pure_
     #
     def pure_send?: (TypeInference::MethodCall::Typed call, Parser::AST::Node receiver, Array[Parser::AST::Node] arguments) -> bool
+
+    # Transform given `node` to a node that has a local variable instead of the outer most call/non-value node
+    #
+    # Returns a pair of transformed node and the outer most call/non-value node if present.
+    #
+    # ```rb
+    # x = y = foo()   # Call `#transform_value_node` with the node and var_name `:__foo__`
+    #                 # => Returns [x = y = __foo__, foo()]
+    # ```
+    #
+    # This is typically used for transforming assginment node for case condition.
+    #
+    def extract_outermost_call: (Parser::AST::Node node, Symbol) -> [Parser::AST::Node, Parser::AST::Node?]
   end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9758,12 +9758,36 @@ _, __any__ = [123, :foo]
 end
 
 -> (_) { 123 }
+RUBY
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_type_narrowing_assignment
+    with_checker(<<-RBS) do |checker|
+class NarrowingAssignmentTest
+  def foo: () -> (Integer | String)
+end
+      RBS
+      source = parse_ruby(<<-RUBY)
+case value = NarrowingAssignmentTest.new.foo()
+when Integer
+  "hello"
+when String
+  value
+end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
         type, _, context = construction.synthesize(source.node)
 
         assert_no_error typing
+
+        assert_equal parse_type("::String"), type
       end
     end
   end


### PR DESCRIPTION
Type narrowing on assignment is not working. 🤕 

```rb
if x = array.sample
  x + 1     # Type error is reported unless `#sample` is _pure_ method call
end
```