### PR TITLE
Make more multiple assignments type check

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -4072,25 +4072,26 @@ module Steep
       synthesize(node, hint: hint)
     end
 
-    def try_tuple_type(node, hint)
-      if hint
-        if node.children.size != hint.types.size
-          return
-        end
-      end
+    def try_tuple_type(array_node, hint)
+      raise unless array_node.type == :array
 
       constr = self
+      # @type var element_types: Array[AST::Types::t]
       element_types = []
 
-      each_child_node(node).with_index do |child, index|
-        child_hint = if hint
-                       hint.types[index]
-                     end
+      array_node.children.each_with_index do |child, index|
+        return if child.type == :splat
+
+        child_hint =
+          if hint
+            hint.types[index]
+          end
+
         type, constr = constr.synthesize(child, hint: child_hint)
         element_types << type
       end
 
-      constr.add_typing(node, type: AST::Types::Tuple.new(types: element_types))
+      constr.add_typing(array_node, type: AST::Types::Tuple.new(types: element_types))
     end
 
     def try_convert(type, method)

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -202,6 +202,25 @@ module Steep
 
     def union_type: (*AST::Types::t types) -> AST::Types::t
 
+    # Returns union type of given types
+    #
+    # If one of the types is a subtype of another type, the _subtype_ will be ignored.
+    #
+    # ```ruby
+    # union_type(`String`, `Object`)   # => `Object`
+    # union_type(`String`, `Integer`)   # => `String | Integer`
+    # ```
+    #
+    def union_type_unify: (*AST::Types::t types) -> AST::Types::t
+
+    # Translate a union of tuple types to a tuple of union types
+    #
+    # * ([A, B] | [C, D, E]) => [A | C, B | D, E?]
+    #
+    # Returns `nil` if the translation cannot apply.
+    #
+    def union_of_tuple_to_tuple_of_union: (AST::Types::Union) -> AST::Types::Tuple?
+
     def validate_method_definitions: (untyped node, untyped module_name) -> (nil | untyped)
 
     def fallback_to_any: (Parser::AST::Node node) ?{ () -> Diagnostic::Ruby::Base } -> Pair

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -251,9 +251,26 @@ module Steep
 
     def to_instance_type: (untyped `type`, ?args: untyped?) -> untyped
 
-    def try_tuple_type!: (Parser::AST::Node node, ?hint: AST::Types::t?) -> Pair
+    def try_tuple_type!: (Parser::AST::Node node, ?hint: AST::Types::Tuple?) -> Pair
 
-    def try_tuple_type: (Parser::AST::Node node, AST::Types::Tuple? hint) -> (nil | untyped)
+    # Try to give `array_node` a tuple type
+    #
+    # * If `hint` is given, the array element would receive a hint of element of `hint` type.
+    # * If `hint` it not given, `array_node` is assumed to have a tuple type, but no assumption on element types.
+    #
+    # Returns `nil` when `array_node` includes `*` (splat) node.
+    #
+    # ```ruby
+    # try_tuple_type(`[1, 2]`, nil)               # => `[Integer, Integer, Integer]`
+    # try_tuple_type(`[1]`, `[Integer, Integer]`) # => `[Integer]`
+    # try_tuple_type(`[1, 2]`, `[Integer]`)       # => `[Integer, Integer]`
+    # try_tuple_type(`[1, *]`, `[Integer]`)       # => nil
+    # ```
+    #
+    # Note that `typing` will be updated even when it returns `nil`.
+    # You probably should try `with_new_typing` to make the result _atomic_.
+    #
+    def try_tuple_type: (Parser::AST::Node array_node, AST::Types::Tuple? hint) -> Pair?
 
     # Try to convert a object of `type` with zero-arity method `method`.
     #

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9860,4 +9860,28 @@ x, y =
       end
     end
   end
+
+  def test_masgn_union_tuple2
+    with_checker(<<-RBS) do |checker|
+      RBS
+      source = parse_ruby(<<-RUBY)
+x, y =
+  if 123
+    ["String", 123]
+  else
+    [nil]
+  end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("[::String?, ::Integer?]"), type
+        assert_equal parse_type("::String?"), context.type_env[:x]
+        assert_equal parse_type("::Integer?"), context.type_env[:y]
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9836,4 +9836,28 @@ end
       end
     end
   end
+
+  def test_masgn_union_tuple
+    with_checker(<<-RBS) do |checker|
+      RBS
+      source = parse_ruby(<<-RUBY)
+x, y =
+  if 123
+    ["String", 123]
+  else
+    [nil, nil]
+  end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("[::String?, ::Integer?]"), type
+        assert_equal parse_type("::String?"), context.type_env[:x]
+        assert_equal parse_type("::Integer?"), context.type_env[:y]
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9793,4 +9793,47 @@ end
       end
     end
   end
+
+  def test_type_if_union_unify
+    with_checker(<<-RBS) do |checker|
+      RBS
+      source = parse_ruby(<<-RUBY)
+if _ = 123
+  Object.new
+else
+  String.new
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("::Object"), type
+      end
+    end
+  end
+
+  def test_type_case_union_unify
+    with_checker(<<-RBS) do |checker|
+      RBS
+      source = parse_ruby(<<-RUBY)
+case x = 123
+when String
+  Object.new
+else
+  String.new
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+
+        assert_equal parse_type("::Object"), type
+      end
+    end
+  end
 end


### PR DESCRIPTION
The motivating example is the following:

```ruby
positionals, keywords = 
  if keyword_hash?(array_content.last)
    [array_content.take(array_content.size - 1), array_content.last || raise]
  else
    [array_content, nil]
  end
```

The _then_ branch has type of `[Array[node], node]`, the _else_ branch has type of `[Array[node, nil]`, and the `if` node has type of of `[Array[node], node] | [Array[node], nil]`. However, we want `positional` to have type of `Array[node]` and `keywords` to have type of `node?`.

We add a transformation on multiple assignment:

1. If the type of right hand side is a union of tuple types `[A, B] | [C, D]`,
2. The right hand side will be translated to a tuple of union types `[A | B, C | D]`

We can justify the transformation because `[A | B, C | D]` is a super type `[A, B] | [C, D]` where we have a contra-variant semantics of unions and tuples.

The other two commits are tweaks around tuple types that makes it more flexible.