### PR TITLE
Refactor `Interface::Shape` calculation

### DIFF
--- a/bin/steep-prof
+++ b/bin/steep-prof
@@ -4,12 +4,13 @@ require "stackprof"
 
 mode = (ENV["STEEP_STACKPROF_MODE"] || :wall).to_sym
 out = ENV["STEEP_STACKPROF_OUT"] || "tmp/stackprof-#{mode}-steep.dump"
+interval = ENV["STEEP_STACKPROF_INTERVAL"]&.to_i || 1000
 
 def exit(*)
 
 end
 
 STDERR.puts "Running profiler: mode=#{mode}, out=#{out}"
-StackProf.run(mode: mode, out: out, raw: true) do
+StackProf.run(mode: mode, out: out, raw: true, interval: interval) do
   load File.join(__dir__, "../exe/steep")
 end

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -61,6 +61,7 @@ require "steep/interface/block"
 require "steep/interface/method_type"
 require "steep/interface/substitution"
 require "steep/interface/shape"
+require "steep/interface/builder"
 
 require "steep/subtyping/result"
 require "steep/subtyping/check"

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -253,7 +253,9 @@ klasses = [
 
 klasses.each do |klass|
   klass.instance_eval do
-    def self.new(*, **, &) = super
+    def self.new(*_, **__, &___)
+      super
+    end
   end
 end
 

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -245,3 +245,68 @@ module Steep
     result
   end
 end
+
+klasses = [
+  # Steep::Interface::MethodType
+]
+
+klasses.each do |klass|
+  klass.instance_eval do
+    def self.new(*, **, &) = super
+  end
+end
+
+module GCCounter
+  module_function
+
+  def count_objects(title, regexp = /^Steep/, skip: false)
+    if ENV["COUNT_GC_OBJECTS"] && !skip
+      unless GC.disable
+        GC.start(immediate_sweep: true, immediate_mark: true, full_mark: true)
+
+        begin
+          yield
+        ensure
+          Steep.logger.fatal "===== #{title} ==============================="
+
+          klasses = []
+
+          ObjectSpace.each_object(Class) do |klass|
+            if (klass.name || "") =~ regexp
+              klasses << klass
+            end
+          end
+
+          before = {}
+
+          klasses.each do |klass|
+            count = ObjectSpace.each_object(klass).count
+            before[klass] = count
+          end
+
+          GC.start(immediate_sweep: true, immediate_mark: true, full_mark: true)
+
+          gceds = []
+
+          klasses.each do |klass|
+            count = ObjectSpace.each_object(klass).count
+            gced = (before[klass] || 0) - count
+
+            gceds << [klass, gced] if gced > 0
+          end
+
+          gceds.sort_by! {|_, count| -count }
+          gceds.each do |klass, count|
+            Steep.logger.fatal { "#{klass.name} => #{count}"}
+          end
+
+          GC.enable
+        end
+      else
+        yield
+      end
+    else
+      yield
+    end
+  end
+end

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -60,7 +60,7 @@ require "steep/interface/function"
 require "steep/interface/block"
 require "steep/interface/method_type"
 require "steep/interface/substitution"
-require "steep/interface/interface"
+require "steep/interface/shape"
 
 require "steep/subtyping/result"
 require "steep/subtyping/check"

--- a/lib/steep/annotation_parser.rb
+++ b/lib/steep/annotation_parser.rb
@@ -76,7 +76,7 @@ module Steep
           name = match[:name]
           type = match[:type]
 
-          method_type = factory.method_type(RBS::Parser.parse_method_type(type), self_type: AST::Types::Self.new, method_decls: Set[])
+          method_type = factory.method_type(RBS::Parser.parse_method_type(type), method_decls: Set[])
 
           AST::Annotation::MethodType.new(name: name.to_sym,
                                           type: method_type,

--- a/lib/steep/ast/types/class.rb
+++ b/lib/steep/ast/types/class.rb
@@ -8,6 +8,10 @@ module Steep
           @location = location
         end
 
+        def self.instance
+          @instance ||= new()
+        end
+
         def to_s
           "class"
         end

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -4,10 +4,7 @@ module Steep
       class Factory
         attr_reader :definition_builder
 
-        attr_reader :type_name_cache
         attr_reader :type_cache
-
-        attr_reader :type_interface_cache
 
         def inspect
           s = "#<%s:%#018x " % [self.class, object_id]
@@ -18,9 +15,9 @@ module Steep
         def initialize(builder:)
           @definition_builder = builder
 
-          @type_name_cache = {}
           @type_cache = {}
-          @type_interface_cache = {}
+          @method_type_cache = {}
+          @method_type_cache.compare_by_identity
         end
 
         def type_name_resolver
@@ -224,7 +221,7 @@ module Steep
         def type_param(type_param)
           Interface::TypeParam.new(
             name: type_param.name,
-            upper_bound: type_param.upper_bound&.yield_self {|u| type(u) },
+            upper_bound: type_opt(type_param.upper_bound),
             variance: type_param.variance,
             unchecked: type_param.unchecked?
           )
@@ -239,135 +236,75 @@ module Steep
           ).unchecked!(type_param.unchecked)
         end
 
-        def method_type(method_type, self_type:, subst2: nil, method_decls:)
-          fvs = self_type.free_variables()
-
-          type_params = []
-          conflicting_names = []
-
-          type_params = method_type.type_params.map do |type_param|
-            if fvs.include?(type_param.name)
-              conflicting_names << type_param.name
-            end
-
-            type_param(type_param)
-          end
-
-          type_params, subst = Interface::TypeParam.rename(type_params, conflicting_names)
-          subst.merge!(subst2, overwrite: true) if subst2
-
-          type =
+        def method_type(method_type, method_decls:)
+          mt = @method_type_cache[method_type] ||=
             Interface::MethodType.new(
-              type_params: type_params,
+              type_params: method_type.type_params.map {|param| type_param(param) },
               type: Interface::Function.new(
-                params: params(method_type.type).subst(subst),
-                return_type: type(method_type.type.return_type).subst(subst),
+                params: params(method_type.type),
+                return_type: type(method_type.type.return_type),
                 location: method_type.location
               ),
               block: method_type.block&.yield_self do |block|
                 Interface::Block.new(
                   optional: !block.required,
                   type: Interface::Function.new(
-                    params: params(block.type).subst(subst),
-                    return_type: type(block.type.return_type).subst(subst),
+                    params: params(block.type),
+                    return_type: type(block.type.return_type),
                     location: nil
                   )
                 )
               end,
-              method_decls: method_decls
+              method_decls: Set[]
             )
 
-          if block_given?
-            yield type
-          else
-            type
-          end
+          mt.with(method_decls: method_decls)
         end
 
-        def method_type_1(method_type, self_type:)
-          fvs = self_type.free_variables()
-
-          type_params = []
-
-          conflicting_names = method_type.type_params.each.with_object([]) do |param, names|
-            names << params.name if fvs.include?(param.name)
-          end
-
-          type_params, subst = Interface::TypeParam.rename(method_type.type_params, conflicting_names)
-
-          type = RBS::MethodType.new(
-            type_params: type_params.map {|param| type_param_1(param) },
-            type: function_1(method_type.type.subst(subst)),
+        def method_type_1(method_type)
+          RBS::MethodType.new(
+            type_params: method_type.type_params.map {|param| type_param_1(param) },
+            type: function_1(method_type.type),
             block: method_type.block&.yield_self do |block|
-              block_type = block.type.subst(subst)
-
-              RBS::Types::Block.new(
-                type: function_1(block_type),
-                required: !block.optional
-              )
+              RBS::Types::Block.new(type: function_1(block.type), required: !block.optional)
             end,
             location: nil
           )
-
-          if block_given?
-            yield type
-          else
-            type
-          end
-        end
-
-        class InterfaceCalculationError < StandardError
-          attr_reader :type
-
-          def initialize(type:, message:)
-            @type = type
-            super message
-          end
         end
 
         def unfold(type_name, args)
           type(
             definition_builder.expand_alias2(
               type_name,
-              args.empty? ? args : args.map {|t| type_1(t) }
+              args.empty? ? [] : args.map {|t| type_1(t) }
             )
           )
         end
 
         def expand_alias(type)
-          unfolded = case type
-                     when AST::Types::Name::Alias
-                       unfold(type.name, type.args)
-                     else
-                       type
-                     end
-
-          if block_given?
-            yield unfolded
+          case type
+          when AST::Types::Name::Alias
+            unfold(type.name, type.args)
           else
-            unfolded
+            type
           end
         end
 
-        def deep_expand_alias(type, recursive: Set.new, &block)
-          raise "Recursive type definition: #{type}" if recursive.member?(type)
-
-          ty = case type
-               when AST::Types::Name::Alias
-                 deep_expand_alias(expand_alias(type), recursive: recursive.union([type]))
-               when AST::Types::Union
-                 AST::Types::Union.build(
-                   types: type.types.map {|ty| deep_expand_alias(ty, recursive: recursive, &block) },
-                   location: type.location
-                 )
-               else
-                 type
-               end
-
-          if block_given?
-            yield ty
+        def deep_expand_alias(type, recursive: Set.new)
+          case type
+          when AST::Types::Name::Alias
+            unless recursive.member?(type.name)
+              unfolded = expand_alias(type)
+              deep_expand_alias(unfolded, recursive: recursive.union([type.name]))
+            end
+          when AST::Types::Union
+            types = type.types.map {|ty| deep_expand_alias(ty, recursive: recursive) or return }
+            AST::Types::Union.build(types: types, location: type.location)
+          when AST::Types::Intersection
+            types = type.types.map {|ty| deep_expand_alias(ty, recursive: recursive) or return }
+            AST::Types::Intersection.build(types: types, location: type.location)
           else
-            ty
+            type
           end
         end
 
@@ -403,515 +340,24 @@ module Steep
           end
         end
 
-        NilClassName = TypeName("::NilClass")
-
-        def setup_primitives(method_name, method_def, method_type)
-          defined_in = method_def.defined_in
-          member = method_def.member
-
-          if member.is_a?(RBS::AST::Members::MethodDefinition)
-            case method_name
-            when :is_a?, :kind_of?, :instance_of?
-              if defined_in == RBS::BuiltinNames::Object.name && member.instance?
-                return method_type.with(
-                  type: method_type.type.with(
-                    return_type: AST::Types::Logic::ReceiverIsArg.new(location: method_type.type.return_type.location)
-                  )
-                )
-              end
-
-            when :nil?
-              case defined_in
-              when RBS::BuiltinNames::Object.name,
-                NilClassName
-                return method_type.with(
-                  type: method_type.type.with(
-                    return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.type.return_type.location)
-                  )
-                )
-              end
-
-            when :!
-              case defined_in
-              when RBS::BuiltinNames::BasicObject.name,
-                RBS::BuiltinNames::TrueClass.name,
-                RBS::BuiltinNames::FalseClass.name,
-                AST::Builtin::NilClass.module_name
-                return method_type.with(
-                  type: method_type.type.with(
-                    return_type: AST::Types::Logic::Not.new(location: method_type.type.return_type.location)
-                  )
-                )
-              end
-
-            when :===
-              case defined_in
-              when RBS::BuiltinNames::Module.name
-                return method_type.with(
-                  type: method_type.type.with(
-                    return_type: AST::Types::Logic::ArgIsReceiver.new(location: method_type.type.return_type.location)
-                  )
-                )
-              when RBS::BuiltinNames::Object.name, RBS::BuiltinNames::String.name, RBS::BuiltinNames::Integer.name, RBS::BuiltinNames::Symbol.name,
-                RBS::BuiltinNames::TrueClass.name, RBS::BuiltinNames::FalseClass.name, TypeName("::NilClass")
-                # Value based type-case works on literal types which is available for String, Integer, Symbol, TrueClass, FalseClass, and NilClass
-                return method_type.with(
-                  type: method_type.type.with(
-                    return_type: AST::Types::Logic::ArgEqualsReceiver.new(location: method_type.type.return_type.location)
-                  )
-                )
-              end
-            end
-          end
-
-          method_type
-        end
-
-        def interface(type, private:, self_type: type)
-          Steep.logger.debug { "Factory#interface: #{type}, private=#{private}, self_type=#{self_type}" }
-
-          cache_key = [type, self_type, private]
-          if type_interface_cache.key?(cache_key)
-            return type_interface_cache[cache_key]
-          end
-
-          case type
-          when Name::Alias
-            interface(expand_alias(type), private: private, self_type: self_type)
-
-          when Self
-            if self_type != type
-              interface self_type, private: private, self_type: Self.new
-            else
-              raise "Unexpected `self` type interface"
-            end
-
-          when Name::Instance
-            Interface::Shape.new(type: self_type, private: private).tap do |interface|
-              definition = definition_builder.build_instance(type.name)
-
-              instance_type = Name::Instance.new(name: type.name,
-                                                 args: type.args.map { Any.new(location: nil) },
-                                                 location: nil)
-              module_type = type.to_module()
-
-              subst = Interface::Substitution.build(
-                definition.type_params,
-                type.args,
-                instance_type: instance_type,
-                module_type: module_type,
-                self_type: self_type
-              )
-
-              definition.methods.each do |name, method|
-                Steep.logger.tagged "method = #{name}" do
-                  next if method.private? && !private
-
-                  interface.methods[name] = Interface::Shape::Entry.new(
-                    method_types: method.defs.map do |type_def|
-                      method_name = InstanceMethodName.new(type_name: type_def.implemented_in || type_def.defined_in, method_name: name)
-                      decl = TypeInference::MethodCall::MethodDecl.new(method_name: method_name, method_def: type_def)
-                      setup_primitives(
-                        name,
-                        type_def,
-                        method_type(type_def.type,
-                                    method_decls: Set[decl],
-                                    self_type: self_type,
-                                    subst2: subst)
-                      )
-                    end
-                  )
-                end
-              end
-            end
-
-          when Name::Interface
-            Interface::Shape.new(type: self_type, private: private).tap do |interface|
-              type_name = type.name
-              definition = definition_builder.build_interface(type_name)
-
-              subst = Interface::Substitution.build(
-                definition.type_params,
-                type.args,
-                self_type: self_type
-              )
-
-              definition.methods.each do |name, method|
-                interface.methods[name] = Interface::Shape::Entry.new(
-                  method_types: method.defs.map do |type_def|
-                    decls = Set[TypeInference::MethodCall::MethodDecl.new(
-                      method_name: InstanceMethodName.new(type_name: type_def.implemented_in || type_def.defined_in, method_name: name),
-                      method_def: type_def
-                    )]
-                    method_type(type_def.type, method_decls: decls, self_type: self_type, subst2: subst)
-                  end
-                )
-              end
-            end
-
-          when Name::Singleton
-            Interface::Shape.new(type: self_type, private: private).tap do |interface|
-              definition = definition_builder.build_singleton(type.name)
-
-              instance_type = Name::Instance.new(name: type.name,
-                                                 args: definition.type_params.map {Any.new(location: nil)},
-                                                 location: nil)
-              subst = Interface::Substitution.build(
-                [],
-                instance_type: instance_type,
-                module_type: type,
-                self_type: self_type
-              )
-
-              definition.methods.each do |name, method|
-                next if !private && method.private?
-
-                interface.methods[name] = Interface::Shape::Entry.new(
-                  method_types: method.defs.map do |type_def|
-                    decl = TypeInference::MethodCall::MethodDecl.new(
-                      method_name: SingletonMethodName.new(type_name: type_def.implemented_in || type_def.defined_in,
-                                                           method_name: name),
-                      method_def: type_def
-                    )
-                    setup_primitives(
-                      name,
-                      type_def,
-                      method_type(type_def.type,
-                                  method_decls: Set[decl],
-                                  self_type: self_type,
-                                  subst2: subst)
-                    )
-                  end
-                )
-              end
-            end
-
-          when Literal
-            interface type.back_type, private: private, self_type: self_type
-
-          when Nil
-            interface Builtin::NilClass.instance_type, private: private, self_type: self_type
-
-          when Boolean
-            interface(AST::Types::Union.build(types: [Builtin::TrueClass.instance_type, Builtin::FalseClass.instance_type]),
-                      private: private,
-                      self_type: self_type)
-
-          when Union
-            yield_self do
-              interfaces = type.types.map {|ty| interface(ty, private: private, self_type: self_type) }
-              interfaces.inject do |interface1, interface2|
-                Interface::Shape.new(type: self_type, private: private).tap do |interface|
-                  common_methods = Set.new(interface1.methods.keys) & Set.new(interface2.methods.keys)
-                  common_methods.each do |name|
-                    types1 = interface1.methods[name].method_types
-                    types2 = interface2.methods[name].method_types
-
-                    if types1 == types2
-                      interface.methods[name] = interface1.methods[name]
-                    else
-                      method_types = {}
-
-                      types1.each do |type1|
-                        types2.each do |type2|
-                          type = type1 | type2 or next
-                          method_types[type] = true
-                        end
-                      end
-
-                      unless method_types.empty?
-                        interface.methods[name] = Interface::Shape::Entry.new(method_types: method_types.keys)
-                      end
-                    end
-                  end
-                end
-              end
-            end
-
-          when Intersection
-            yield_self do
-              interfaces = type.types.map {|ty| interface(ty, private: private, self_type: self_type) }
-              interfaces.inject do |interface1, interface2|
-                Interface::Shape.new(type: self_type, private: private).tap do |interface|
-                  interface.methods.merge!(interface1.methods)
-                  interface.methods.merge!(interface2.methods)
-                end
-              end
-            end
-
-          when Tuple
-            yield_self do
-              element_type = Union.build(types: type.types, location: nil)
-              array_type = Builtin::Array.instance_type(element_type)
-              interface(array_type, private: private, self_type: self_type).tap do |array_interface|
-                array_interface.methods[:[]] = array_interface.methods[:[]].yield_self do |aref|
-                  Interface::Shape::Entry.new(
-                    method_types: type.types.map.with_index {|elem_type, index|
-                      Interface::MethodType.new(
-                        type_params: [],
-                        type: Interface::Function.new(
-                          params: Interface::Function::Params.build(required: [AST::Types::Literal.new(value: index)]),
-                          return_type: elem_type,
-                          location: nil
-                        ),
-                        block: nil,
-                        method_decls: Set[]
-                      )
-                    } + aref.method_types
-                  )
-                end
-
-                array_interface.methods[:[]=] = array_interface.methods[:[]=].yield_self do |update|
-                  Interface::Shape::Entry.new(
-                    method_types: type.types.map.with_index {|elem_type, index|
-                      Interface::MethodType.new(
-                        type_params: [],
-                        type: Interface::Function.new(
-                          params: Interface::Function::Params.build(required: [AST::Types::Literal.new(value: index), elem_type]),
-                          return_type: elem_type,
-                          location: nil
-                        ),
-                        block: nil,
-                        method_decls: Set[]
-                      )
-                    } + update.method_types
-                  )
-                end
-
-                array_interface.methods[:fetch] = array_interface.methods[:fetch].yield_self do |fetch|
-                  Interface::Shape::Entry.new(
-                    method_types: type.types.flat_map.with_index {|elem_type, index|
-                      [
-                        Interface::MethodType.new(
-                          type_params: [],
-                          type: Interface::Function.new(
-                            params: Interface::Function::Params.build(required: [AST::Types::Literal.new(value: index)]),
-                            return_type: elem_type,
-                            location: nil
-                          ),
-                          block: nil,
-                          method_decls: Set[]
-                        ),
-                        Interface::MethodType.new(
-                          type_params: [Interface::TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
-                          type: Interface::Function.new(
-                            params: Interface::Function::Params.build(
-                              required: [
-                                AST::Types::Literal.new(value: index),
-                                AST::Types::Var.new(name: :T)
-                              ]
-                            ),
-                            return_type: AST::Types::Union.build(types: [elem_type, AST::Types::Var.new(name: :T)]),
-                            location: nil
-                          ),
-                          block: nil,
-                          method_decls: Set[]
-                        ),
-                        Interface::MethodType.new(
-                          type_params: [Interface::TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
-                          type: Interface::Function.new(
-                            params: Interface::Function::Params.build(required: [AST::Types::Literal.new(value: index)]),
-                            return_type: AST::Types::Union.build(types: [elem_type, AST::Types::Var.new(name: :T)]),
-                            location: nil
-                          ),
-                          block: Interface::Block.new(
-                            type: Interface::Function.new(
-                              params: Interface::Function::Params.build(required: [AST::Builtin::Integer.instance_type]),
-                              return_type: AST::Types::Var.new(name: :T),
-                              location: nil
-                            ),
-                            optional: false
-                          ),
-                          method_decls: Set[]
-                        )
-                      ]
-                    } + fetch.method_types
-                  )
-                end
-
-                array_interface.methods[:first] = array_interface.methods[:first].yield_self do |first|
-                  Interface::Shape::Entry.new(
-                    method_types: [
-                      Interface::MethodType.new(
-                        type_params: [],
-                        type: Interface::Function.new(
-                          params: Interface::Function::Params.empty,
-                          return_type: type.types[0] || AST::Builtin.nil_type,
-                          location: nil
-                        ),
-                        block: nil,
-                        method_decls: Set[]
-                      )
-                    ]
-                  )
-                end
-
-                array_interface.methods[:last] = array_interface.methods[:last].yield_self do |last|
-                  Interface::Shape::Entry.new(
-                    method_types: [
-                      Interface::MethodType.new(
-                        type_params: [],
-                        type: Interface::Function.new(
-                          params: Interface::Function::Params.empty,
-                          return_type: type.types.last || AST::Builtin.nil_type,
-                          location: nil
-                        ),
-                        block: nil,
-                        method_decls: Set[]
-                      )
-                    ]
-                  )
-                end
-              end
-            end
-
-          when Record
-            yield_self do
-              all_key_type = type.elements.keys.map {|value| Literal.new(value: value, location: nil) }.yield_self do |types|
-                Union.build(types: types, location: nil)
-              end
-              all_value_type = Union.build(types: type.elements.values, location: nil)
-              hash_type = Builtin::Hash.instance_type(all_key_type, all_value_type)
-
-              interface(hash_type, private: private, self_type: self_type).tap do |hash_interface|
-                hash_interface.methods[:[]] = hash_interface.methods[:[]].yield_self do |ref|
-                  Interface::Shape::Entry.new(
-                    method_types: type.elements.map {|key_value, value_type|
-                      key_type = Literal.new(value: key_value, location: nil)
-
-                      Interface::MethodType.new(
-                        type_params: [],
-                        type: Interface::Function.new(
-                          params: Interface::Function::Params.build(
-                            required: [key_type],
-                            optional: [],
-                            rest: nil,
-                            required_keywords: {},
-                            optional_keywords: {},
-                            rest_keywords: nil
-                          ),
-                          return_type: value_type,
-                          location: nil
-                        ),
-                        block: nil,
-                        method_decls: Set[]
-                      )
-                    } + ref.method_types
-                  )
-                end
-
-                hash_interface.methods[:[]=] = hash_interface.methods[:[]=].yield_self do |update|
-                  Interface::Shape::Entry.new(
-                    method_types: type.elements.map {|key_value, value_type|
-                      key_type = Literal.new(value: key_value, location: nil)
-                      Interface::MethodType.new(
-                        type_params: [],
-                        type: Interface::Function.new(
-                          params: Interface::Function::Params.build(
-                            required: [key_type, value_type],
-                            optional: [],
-                            rest: nil,
-                            required_keywords: {},
-                            optional_keywords: {},
-                            rest_keywords: nil
-                          ),
-                          return_type: value_type,
-                          location: nil),
-                        block: nil,
-                        method_decls: Set[]
-                      )
-                    } + update.method_types
-                  )
-                end
-
-                hash_interface.methods[:fetch] = hash_interface.methods[:fetch].yield_self do |update|
-                  Interface::Shape::Entry.new(
-                    method_types: type.elements.flat_map {|key_value, value_type|
-                      key_type = Literal.new(value: key_value, location: nil)
-
-                      [
-                        Interface::MethodType.new(
-                          type_params: [],
-                          type: Interface::Function.new(
-                            params: Interface::Function::Params.build(required: [key_type]),
-                            return_type: value_type,
-                            location: nil
-                          ),
-                          block: nil,
-                          method_decls: Set[]
-                        ),
-                        Interface::MethodType.new(
-                          type_params: [Interface::TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
-                          type: Interface::Function.new(
-                            params: Interface::Function::Params.build(required: [key_type, AST::Types::Var.new(name: :T)]),
-                            return_type: AST::Types::Union.build(types: [value_type, AST::Types::Var.new(name: :T)]),
-                            location: nil
-                          ),
-                          block: nil,
-                          method_decls: Set[]
-                        ),
-                        Interface::MethodType.new(
-                          type_params: [Interface::TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
-                          type: Interface::Function.new(
-                            params: Interface::Function::Params.build(required: [key_type]),
-                            return_type: AST::Types::Union.build(types: [value_type, AST::Types::Var.new(name: :T)]),
-                            location: nil
-                          ),
-                          block: Interface::Block.new(
-                            type: Interface::Function.new(
-                              params: Interface::Function::Params.build(required: [all_key_type]),
-                              return_type: AST::Types::Var.new(name: :T),
-                              location: nil
-                            ),
-                            optional: false
-                          ),
-                          method_decls: Set[]
-                        )
-                      ]
-                    } + update.method_types
-                  )
-                end
-              end
-            end
-
-          when Proc
-            interface(Builtin::Proc.instance_type, private: private, self_type: self_type).tap do |interface|
-              method_type = Interface::MethodType.new(
-                type_params: [],
-                type: type.type,
-                block: type.block,
-                method_decls: Set[]
-              )
-
-              interface.methods[:call] = Interface::Shape::Entry.new(method_types: [method_type])
-
-              if type.block_required?
-                interface.methods.delete(:[])
-              else
-                interface.methods[:[]] = Interface::Shape::Entry.new(method_types: [method_type.with(block: nil)])
-              end
-            end
-
-          when Logic::Base
-            interface(AST::Builtin.bool_type, private: private, self_type: self_type)
-
-          else
-            raise "Unexpected type for interface: #{type}"
-          end.tap do |interface|
-            type_interface_cache[cache_key] = interface
-          end
-        end
-
         def module_name?(type_name)
-          entry = env.class_decls[type_name] and entry.is_a?(RBS::Environment::ModuleEntry)
+          if entry = env.class_decls[type_name]
+            entry.is_a?(RBS::Environment::ModuleEntry)
+          else
+            false
+          end
         end
 
         def class_name?(type_name)
-          entry = env.class_decls[type_name] and entry.is_a?(RBS::Environment::ClassEntry)
+          if entry = env.class_decls[type_name]
+            entry.is_a?(RBS::Environment::ClassEntry)
+          else
+            false
+          end
         end
 
         def env
-          @env ||= definition_builder.env
+          definition_builder.env
         end
 
         def absolute_type(type, context:)

--- a/lib/steep/ast/types/instance.rb
+++ b/lib/steep/ast/types/instance.rb
@@ -8,6 +8,10 @@ module Steep
           @location = location
         end
 
+        def self.instance
+          @instance ||= new()
+        end
+
         def ==(other)
           other.is_a?(Instance)
         end

--- a/lib/steep/ast/types/literal.rb
+++ b/lib/steep/ast/types/literal.rb
@@ -38,7 +38,7 @@ module Steep
         end
 
         def with_location(new_location)
-          self.class.new(location: new_location)
+          _ = self.class.new(value: value, location: new_location)
         end
 
         def back_type

--- a/lib/steep/ast/types/self.rb
+++ b/lib/steep/ast/types/self.rb
@@ -8,6 +8,10 @@ module Steep
           @location = location
         end
 
+        def self.instance
+          @instance ||= new()
+        end
+
         def ==(other)
           other.is_a?(Self)
         end

--- a/lib/steep/ast/types/union.rb
+++ b/lib/steep/ast/types/union.rb
@@ -49,7 +49,7 @@ module Steep
         end
 
         def hash
-          @hash ||= self.class.hash ^ types.sort_by(&:to_s).hash
+          @hash ||= types.inject(self.class.hash) {|c, type| type.hash ^ c }
         end
 
         alias eql? ==

--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -512,7 +512,11 @@ module Steep
         end
 
         def header_line
-          "No superclass method `#{method}` defined"
+          if method
+            "No superclass method `#{method}` defined"
+          else
+            "`super` is not allowed from outside of method"
+          end
         end
       end
 

--- a/lib/steep/drivers/validate.rb
+++ b/lib/steep/drivers/validate.rb
@@ -29,7 +29,9 @@ module Steep
               when Services::SignatureService::SyntaxErrorStatus, Services::SignatureService::AncestorErrorStatus
                 controller.status.diagnostics
               when Services::SignatureService::LoadedStatus
-                check = Subtyping::Check.new(factory: AST::Types::Factory.new(builder: controller.latest_builder))
+                factory = AST::Types::Factory.new(builder: controller.latest_builder)
+                builder = Interface::Builder.new(factory)
+                check = Subtyping::Check.new(builder: builder)
                 Signature::Validator.new(checker: check).tap {|v| v.validate() }.each_error.to_a
               end
             end

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -1,0 +1,660 @@
+
+module Steep
+  module Interface
+    class Builder
+      class Config
+        attr_reader :resolve_self, :resolve_class_type, :resolve_instance_type, :variable_bounds
+
+        def initialize(resolve_self:, resolve_class_type:, resolve_instance_type:, variable_bounds:)
+          @resolve_self = resolve_self
+          @resolve_class_type = resolve_class_type
+          @resolve_instance_type = resolve_instance_type
+          @variable_bounds = variable_bounds
+        end
+
+        def update(resolve_self: self.resolve_self, resolve_class_type: self.resolve_class_type, resolve_instance_type: self.resolve_instance_type, variable_bounds: self.variable_bounds)
+          _ = self.class.new(
+            resolve_self: resolve_self,
+            resolve_class_type: resolve_class_type,
+            resolve_instance_type: resolve_instance_type,
+            variable_bounds: variable_bounds
+          )
+        end
+
+        def ==(other)
+          other.is_a?(Config) &&
+            other.resolve_self == resolve_self &&
+            other.resolve_class_type == resolve_class_type &&
+            other.resolve_instance_type == resolve_instance_type &&
+            other.variable_bounds == variable_bounds
+        end
+
+        alias eql? ==
+
+        def hash
+          resolve_self.hash ^ resolve_class_type.hash ^ resolve_instance_type.hash ^ variable_bounds.hash
+        end
+
+        def subst
+          @subst ||= begin
+            self_type =
+              case resolve_self
+              when true, nil
+                AST::Types::Self.instance
+              else
+                resolve_self
+              end
+
+            class_type =
+              case resolve_class_type
+              when true, nil
+                AST::Types::Class.instance
+              else
+                resolve_class_type
+              end
+
+            instance_type =
+              case resolve_instance_type
+              when true, nil
+                AST::Types::Instance.instance
+              else
+                resolve_instance_type
+              end
+
+            Substitution.build([], [], self_type: self_type, module_type: class_type, instance_type: instance_type)
+          end
+        end
+      end
+
+      attr_reader :factory, :cache, :raw_object_cache
+      attr_reader :raw_instance_object_shape_cache, :raw_singleton_object_shape_cache, :raw_interface_object_shape_cache
+
+      def initialize(factory)
+        @factory = factory
+        @cache = {}
+        @raw_instance_object_shape_cache = {}
+        @raw_singleton_object_shape_cache = {}
+        @raw_interface_object_shape_cache = {}
+      end
+
+      def include_self?(type)
+        case type
+        when AST::Types::Self, AST::Types::Instance, AST::Types::Class
+          true
+        else
+          type.each_child.any? {|t| include_self?(t) }
+        end
+      end
+
+      def fetch_cache(type, public_only, config)
+        has_self = include_self?(type)
+        fvs = type.free_variables
+
+        # @type var key: cache_key
+        key = [
+          type,
+          public_only,
+          has_self ? config.resolve_self : nil,
+          has_self ? config.resolve_class_type : nil,
+          has_self ? config.resolve_instance_type : nil,
+          if config.variable_bounds.each_key.any? {|var| fvs.include?(var)}
+            config.variable_bounds.select {|var, _| fvs.include?(var) }
+          else
+            nil
+          end
+        ]
+
+        if cache.key?(key)
+          cache[key]
+        else
+          cache[key] =
+            GCCounter.count_objects(type.to_s, /^Steep::Interface/, skip: false) do
+              yield
+            end
+        end
+      end
+
+      def shape(type, public_only:, config:)
+        fetch_cache(type, public_only, config) do
+          case type
+          when AST::Types::Self
+            case config.resolve_self
+            when true, nil
+              nil
+            else
+              self_type = config.resolve_self.subst(config.subst)
+              shape(self_type, public_only: public_only, config: config.update(resolve_self: nil))
+            end
+          when AST::Types::Instance
+            case config.resolve_instance_type
+            when true, nil
+              nil
+            else
+              self_type = config.resolve_instance_type.subst(config.subst)
+              shape(
+                self_type,
+                public_only: public_only,
+                config: config.update(resolve_instance_type: nil)
+              )
+            end
+          when AST::Types::Class
+            case config.resolve_class_type
+            when true, nil
+              nil
+            else
+              self_type = config.resolve_class_type.subst(config.subst)
+              shape(
+                self_type,
+                public_only: public_only,
+                config: config.update(resolve_class_type: nil)
+              )
+            end
+          when AST::Types::Name::Instance, AST::Types::Name::Interface, AST::Types::Name::Singleton
+            object_shape(
+              type.subst(config.subst),
+              public_only,
+              config.resolve_self.nil?,
+              config.resolve_instance_type.nil?,
+              config.resolve_class_type.nil?
+            )
+          when AST::Types::Name::Alias
+            if expanded = factory.deep_expand_alias(type)
+              shape(expanded, public_only: public_only, config: config)&.update(type: type)
+            end
+          when AST::Types::Any, AST::Types::Bot, AST::Types::Void, AST::Types::Top
+            nil
+          when AST::Types::Var
+            if bound = config.variable_bounds[type.name]
+              shape(bound, public_only: public_only, config: config)
+            end
+          when AST::Types::Union
+            shapes = type.types.map {|type| shape(type, public_only: public_only, config: config) or return }
+            union_shape(type, shapes, public_only)
+          when AST::Types::Intersection
+            shapes = type.types.map {|type| shape(type, public_only: public_only, config: config) or return }
+            intersection_shape(type, shapes, public_only)
+          when AST::Types::Tuple
+            tuple_shape(type, public_only, config)
+          when AST::Types::Record
+            record_shape(type, public_only, config)
+          when AST::Types::Literal
+            shape(type.back_type, public_only: public_only, config: config)&.update(type: type)
+          when AST::Types::Boolean, AST::Types::Logic::Base
+            union_shape(
+              type,
+              [
+                object_shape(AST::Builtin::TrueClass.instance_type, public_only, false, false, false),
+                object_shape(AST::Builtin::FalseClass.instance_type, public_only, false, false, false)
+              ],
+              public_only
+            )
+          when AST::Types::Nil
+            object_shape(AST::Builtin::NilClass.instance_type, public_only, false, false, false)&.update(type: type)
+          when AST::Types::Proc
+            proc_shape(type, public_only, config)
+          else
+            raise "Unknown type is given: #{type}"
+          end
+        end
+      end
+
+      def definition_builder
+        factory.definition_builder
+      end
+
+      def object_shape(type, public_only, keep_self, keep_instance, keep_singleton)
+        case type
+        when AST::Types::Name::Instance
+          definition = definition_builder.build_instance(type.name)
+          subst = Interface::Substitution.build(
+            definition.type_params,
+            type.args,
+            self_type: keep_self ? AST::Types::Self.instance : type,
+            module_type: keep_singleton ? AST::Types::Class.instance : AST::Types::Name::Singleton.new(name: type.name),
+            instance_type: keep_instance ? AST::Types::Instance.instance : factory.instance_type(type.name)
+          )
+        when AST::Types::Name::Interface
+          definition = definition_builder.build_interface(type.name)
+          subst = Interface::Substitution.build(
+            definition.type_params,
+            type.args,
+            self_type: keep_self ? AST::Types::Self.instance : type
+          )
+        when AST::Types::Name::Singleton
+          subst = Interface::Substitution.build(
+            [],
+            [],
+            self_type: keep_self ? AST::Types::Self.instance : type,
+            module_type: keep_singleton ? AST::Types::Class.instance : AST::Types::Name::Singleton.new(name: type.name),
+            instance_type: keep_instance ? AST::Types::Instance.instance : factory.instance_type(type.name)
+          )
+        end
+
+        raw_object_shape(type, public_only, subst)
+      end
+
+      def raw_object_shape(type, public_only, subst)
+        cache =
+          case type
+          when AST::Types::Name::Instance
+            raw_instance_object_shape_cache
+          when AST::Types::Name::Interface
+            raw_interface_object_shape_cache
+          when AST::Types::Name::Singleton
+            raw_singleton_object_shape_cache
+          end
+
+        raw_shape = cache[[type.name, public_only]] ||= begin
+          shape = Interface::Shape.new(type: AST::Builtin.bottom_type, private: !public_only)
+
+          case type
+          when AST::Types::Name::Instance
+            definition = definition_builder.build_instance(type.name)
+          when AST::Types::Name::Interface
+            definition = definition_builder.build_interface(type.name)
+          when AST::Types::Name::Singleton
+            definition = definition_builder.build_singleton(type.name)
+          end
+
+          definition.methods.each do |name, method|
+            next if method.private? && public_only
+
+            Steep.logger.tagged "method = #{type}##{name}" do
+              shape.methods[name] = Interface::Shape::Entry.new(
+                method_types: method.defs.map do |type_def|
+                  method_name = method_name_for(type_def, name)
+                  decl = TypeInference::MethodCall::MethodDecl.new(method_name: method_name, method_def: type_def)
+                  method_type = factory.method_type(type_def.type, method_decls: Set[decl])
+                  replace_primitive_method(method_name, type_def, method_type)
+                end
+              )
+            end
+          end
+
+          shape
+        end
+
+        raw_shape.subst(subst, type: type)
+      end
+
+      def method_name_for(type_def, name)
+        type_name = type_def.implemented_in || type_def.defined_in
+
+        if name == :new && type_def.member.is_a?(RBS::AST::Members::MethodDefinition) && type_def.member.name == :initialize
+          return SingletonMethodName.new(type_name: type_name, method_name: name)
+        end
+
+        case type_def.member.kind
+        when :instance
+          InstanceMethodName.new(type_name: type_name, method_name: name)
+        when :singleton
+          SingletonMethodName.new(type_name: type_name, method_name: name)
+        when :singleton_instance
+          # Assume it a instance method, because `module_function` methods are typically defined with `def`
+          InstanceMethodName.new(type_name: type_name, method_name: name)
+        else
+          raise
+        end
+      end
+
+      def union_shape(shape_type, shapes, public_only)
+        shapes.inject do |shape1, shape2|
+          Interface::Shape.new(type: shape_type, private: !public_only).tap do |shape|
+            common_methods = Set.new(shape1.methods.each_name) & Set.new(shape2.methods.each_name)
+            common_methods.each do |name|
+              types1 = shape1.methods[name]&.method_types or raise
+              types2 = shape2.methods[name]&.method_types or raise
+
+              if types1 == types2
+                shape.methods[name] = (shape1.methods[name] or raise)
+              else
+                method_types = {}
+
+                types1.each do |type1|
+                  types2.each do |type2|
+                    if type = type1 | type2
+                      method_types[type] = true
+                    end
+                  end
+                end
+
+                unless method_types.empty?
+                  shape.methods[name] = Interface::Shape::Entry.new(method_types: method_types.keys)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def intersection_shape(type, shapes, public_only)
+        shapes.inject do |shape1, shape2|
+          Interface::Shape.new(type: type, private: !public_only).tap do |shape|
+            shape.methods.merge!(shape1.methods)
+            shape.methods.merge!(shape2.methods)
+          end
+        end
+      end
+
+      def tuple_shape(tuple, public_only, config)
+        element_type = AST::Types::Union.build(types: tuple.types, location: nil)
+        array_type = AST::Builtin::Array.instance_type(element_type)
+
+        array_shape = shape(array_type, public_only: public_only, config: config) or raise
+        shape = Shape.new(type: tuple, private: !public_only)
+        shape.methods.merge!(array_shape.methods)
+
+        aref_entry = array_shape.methods[:[]].yield_self do |aref|
+          raise unless aref
+
+          Shape::Entry.new(
+            method_types: tuple.types.map.with_index {|elem_type, index|
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.build(required: [AST::Types::Literal.new(value: index)]),
+                  return_type: elem_type,
+                  location: nil
+                ),
+                block: nil,
+                method_decls: Set[]
+              )
+            } + aref.method_types
+          )
+        end
+
+        aref_update_entry = array_shape.methods[:[]=].yield_self do |update|
+          raise unless update
+
+          Shape::Entry.new(
+            method_types: tuple.types.map.with_index {|elem_type, index|
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.build(required: [AST::Types::Literal.new(value: index), elem_type]),
+                  return_type: elem_type,
+                  location: nil
+                ),
+                block: nil,
+                method_decls: Set[]
+              )
+            } + update.method_types
+          )
+        end
+
+        fetch_entry = array_shape.methods[:fetch].yield_self do |fetch|
+          raise unless fetch
+
+          Shape::Entry.new(
+            method_types: tuple.types.flat_map.with_index {|elem_type, index|
+              [
+                MethodType.new(
+                  type_params: [],
+                  type: Function.new(
+                    params: Function::Params.build(required: [AST::Types::Literal.new(value: index)]),
+                    return_type: elem_type,
+                    location: nil
+                  ),
+                  block: nil,
+                  method_decls: Set[]
+                ),
+                MethodType.new(
+                  type_params: [TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
+                  type: Function.new(
+                    params: Function::Params.build(
+                      required: [
+                        AST::Types::Literal.new(value: index),
+                        AST::Types::Var.new(name: :T)
+                      ]
+                    ),
+                    return_type: AST::Types::Union.build(types: [elem_type, AST::Types::Var.new(name: :T)]),
+                    location: nil
+                  ),
+                  block: nil,
+                  method_decls: Set[]
+                ),
+                MethodType.new(
+                  type_params: [TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
+                  type: Function.new(
+                    params: Function::Params.build(required: [AST::Types::Literal.new(value: index)]),
+                    return_type: AST::Types::Union.build(types: [elem_type, AST::Types::Var.new(name: :T)]),
+                    location: nil
+                  ),
+                  block: Block.new(
+                    type: Function.new(
+                      params: Function::Params.build(required: [AST::Builtin::Integer.instance_type]),
+                      return_type: AST::Types::Var.new(name: :T),
+                      location: nil
+                    ),
+                    optional: false
+                  ),
+                  method_decls: Set[]
+                )
+              ]
+            } + fetch.method_types
+          )
+        end
+
+        first_entry = array_shape.methods[:first].yield_self do |first|
+          Shape::Entry.new(
+            method_types: [
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.empty,
+                  return_type: tuple.types[0] || AST::Builtin.nil_type,
+                  location: nil
+                ),
+                block: nil,
+                method_decls: Set[]
+              )
+            ]
+          )
+        end
+
+        last_entry = array_shape.methods[:last].yield_self do |last|
+          Shape::Entry.new(
+            method_types: [
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.empty,
+                  return_type: tuple.types.last || AST::Builtin.nil_type,
+                  location: nil
+                ),
+                block: nil,
+                method_decls: Set[]
+              )
+            ]
+          )
+        end
+
+        shape.methods[:[]] = aref_entry
+        shape.methods[:[]=] = aref_update_entry
+        shape.methods[:fetch] = fetch_entry
+        shape.methods[:first] = first_entry
+        shape.methods[:last] = last_entry
+
+        shape
+      end
+
+      def record_shape(record, public_only, config)
+        all_key_type = AST::Types::Union.build(
+          types: record.elements.each_key.map {|value| AST::Types::Literal.new(value: value, location: nil) },
+          location: nil
+        )
+        all_value_type = AST::Types::Union.build(types: record.elements.values, location: nil)
+        hash_type = AST::Builtin::Hash.instance_type(all_key_type, all_value_type)
+
+        hash_shape = shape(hash_type, public_only: public_only, config: config) or raise
+        shape = Shape.new(type: record, private: !public_only)
+        shape.methods.merge!(hash_shape.methods)
+
+        shape.methods[:[]] = hash_shape.methods[:[]].yield_self do |aref|
+          aref or raise
+          Shape::Entry.new(
+            method_types: record.elements.map do |key_value, value_type|
+              key_type = AST::Types::Literal.new(value: key_value, location: nil)
+
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.build(required: [key_type]),
+                  return_type: value_type,
+                  location: nil
+                ),
+                block: nil,
+                method_decls: Set[]
+              )
+            end + aref.method_types
+          )
+        end
+
+        shape.methods[:[]=] = hash_shape.methods[:[]=].yield_self do |update|
+          update or raise
+
+          Shape::Entry.new(
+            method_types: record.elements.map do |key_value, value_type|
+              key_type = AST::Types::Literal.new(value: key_value, location: nil)
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.build(required: [key_type, value_type]),
+                  return_type: value_type,
+                  location: nil),
+                block: nil,
+                method_decls: Set[]
+              )
+            end + update.method_types
+          )
+        end
+
+        shape.methods[:fetch] = hash_shape.methods[:fetch].yield_self do |update|
+          update or raise
+
+          Shape::Entry.new(
+            method_types: record.elements.flat_map {|key_value, value_type|
+              key_type = AST::Types::Literal.new(value: key_value, location: nil)
+
+              [
+                MethodType.new(
+                  type_params: [],
+                  type: Function.new(
+                    params: Function::Params.build(required: [key_type]),
+                    return_type: value_type,
+                    location: nil
+                  ),
+                  block: nil,
+                  method_decls: Set[]
+                ),
+                MethodType.new(
+                  type_params: [TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
+                  type: Function.new(
+                    params: Function::Params.build(required: [key_type, AST::Types::Var.new(name: :T)]),
+                    return_type: AST::Types::Union.build(types: [value_type, AST::Types::Var.new(name: :T)]),
+                    location: nil
+                  ),
+                  block: nil,
+                  method_decls: Set[]
+                ),
+                MethodType.new(
+                  type_params: [TypeParam.new(name: :T, upper_bound: nil, variance: :invariant, unchecked: false)],
+                  type: Function.new(
+                    params: Function::Params.build(required: [key_type]),
+                    return_type: AST::Types::Union.build(types: [value_type, AST::Types::Var.new(name: :T)]),
+                    location: nil
+                  ),
+                  block: Block.new(
+                    type: Function.new(
+                      params: Function::Params.build(required: [all_key_type]),
+                      return_type: AST::Types::Var.new(name: :T),
+                      location: nil
+                    ),
+                    optional: false
+                  ),
+                  method_decls: Set[]
+                )
+              ]
+            } + update.method_types
+          )
+        end
+
+        shape
+      end
+
+      def proc_shape(proc, public_only, config)
+        proc_shape = shape(AST::Builtin::Proc.instance_type, public_only: public_only, config: config) or raise
+
+        shape = Shape.new(type: proc, private: !public_only)
+        shape.methods.merge!(proc_shape.methods)
+
+        shape.methods[:[]] = shape.methods[:call] = Shape::Entry.new(
+          method_types: [MethodType.new(type_params: [], type: proc.type, block: proc.block, method_decls: Set[])]
+        )
+
+        shape
+      end
+
+      def replace_primitive_method(method_name, method_def, method_type)
+        defined_in = method_def.defined_in
+        member = method_def.member
+
+        if member.is_a?(RBS::AST::Members::MethodDefinition)
+          case method_name.method_name
+          when :is_a?, :kind_of?, :instance_of?
+            if defined_in == RBS::BuiltinNames::Object.name && member.instance?
+              return method_type.with(
+                type: method_type.type.with(
+                  return_type: AST::Types::Logic::ReceiverIsArg.new(location: method_type.type.return_type.location)
+                )
+              )
+            end
+
+          when :nil?
+            case defined_in
+            when RBS::BuiltinNames::Object.name, AST::Builtin::NilClass.module_name
+              return method_type.with(
+                type: method_type.type.with(
+                  return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.type.return_type.location)
+                )
+              )
+            end
+
+          when :!
+            case defined_in
+            when RBS::BuiltinNames::BasicObject.name,
+              RBS::BuiltinNames::TrueClass.name,
+              RBS::BuiltinNames::FalseClass.name,
+              AST::Builtin::NilClass.module_name
+              return method_type.with(
+                type: method_type.type.with(
+                  return_type: AST::Types::Logic::Not.new(location: method_type.type.return_type.location)
+                )
+              )
+            end
+
+          when :===
+            case defined_in
+            when RBS::BuiltinNames::Module.name
+              return method_type.with(
+                type: method_type.type.with(
+                  return_type: AST::Types::Logic::ArgIsReceiver.new(location: method_type.type.return_type.location)
+                )
+              )
+            when RBS::BuiltinNames::Object.name, RBS::BuiltinNames::String.name, RBS::BuiltinNames::Integer.name, RBS::BuiltinNames::Symbol.name,
+              RBS::BuiltinNames::TrueClass.name, RBS::BuiltinNames::FalseClass.name, TypeName("::NilClass")
+              # Value based type-case works on literal types which is available for String, Integer, Symbol, TrueClass, FalseClass, and NilClass
+              return method_type.with(
+                type: method_type.type.with(
+                  return_type: AST::Types::Logic::ArgEqualsReceiver.new(location: method_type.type.return_type.location)
+                )
+              )
+            end
+          end
+        end
+
+        method_type
+      end
+    end
+  end
+end

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -107,10 +107,7 @@ module Steep
         if cache.key?(key)
           cache[key]
         else
-          cache[key] =
-            GCCounter.count_objects(type.to_s, /^Steep::Interface/, skip: false) do
-              yield
-            end
+          cache[key] = yield
         end
       end
 

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -38,7 +38,7 @@ module Steep
 
       def subst(s)
         return self if s.empty?
-        return self if free_variables.disjoint?(s.domain)
+        return self if each_type.none? {|t| s.apply?(t) }
 
         if type_params.any? {|param| s.key?(param.name) }
           s_ = s.except(type_params.map(&:name))

--- a/lib/steep/interface/shape.rb
+++ b/lib/steep/interface/shape.rb
@@ -13,13 +13,111 @@ module Steep
         end
       end
 
+      class Methods
+        attr_reader :substs, :methods, :resolved_methods
+
+        include Enumerable
+
+        def initialize(substs:, methods:)
+          @substs = substs
+          @methods = methods
+          @resolved_methods = methods.transform_values { nil }
+        end
+
+        def key?(name)
+          methods.key?(name)
+        end
+
+        def []=(name, entry)
+          resolved_methods[name] = nil
+          methods[name] = entry
+        end
+
+        def [](name)
+          return nil unless key?(name)
+
+          resolved_methods[name] ||= begin
+            Entry.new(
+              method_types: methods[name].method_types.map do |method_type|
+                method_type.subst(subst)
+              end
+            )
+          end
+        end
+
+        def each(&block)
+          if block
+            methods.each_key do |name|
+              entry = self[name] or raise
+              yield [name, entry]
+            end
+          else
+            enum_for :each
+          end
+        end
+
+        def each_name(&block)
+          if block
+            methods.each_key(&block)
+          else
+            enum_for :each_name
+          end
+        end
+
+        def subst
+          @subst ||= begin
+            substs.each_with_object(Substitution.empty) do |s, ss|
+              ss.merge!(s, overwrite: true)
+            end
+          end
+        end
+
+        def push_substitution(subst)
+          Methods.new(substs: [*substs, subst], methods: methods)
+        end
+
+        def merge!(other)
+          other.each do |name, entry|
+            methods[name] = entry
+          end
+        end
+
+        def +(other)
+          methods = Methods.new(substs: [], methods: {})
+
+          methods.merge!(self)
+          methods.merge!(other)
+
+          methods
+        end
+      end
+
       attr_reader :type
       attr_reader :methods
 
-      def initialize(type:, private:)
+      def initialize(type:, private:, methods: nil)
         @type = type
         @private = private
-        @methods = {}
+        @methods = methods || Methods.new(substs: [], methods: {})
+      end
+
+      def to_s
+        "#<#{self.class.name}: type=#{type}, private?=#{@private}, methods={#{methods.each_name.sort.join(", ")}}"
+      end
+
+      def update(type: self.type, methods: self.methods)
+        _ = self.class.new(type: type, private: private?, methods: methods)
+      end
+
+      def subst(s, type: nil)
+        ty =
+          if type
+            type
+          else
+            self.type.subst(s)
+          end
+
+        Shape.new(type: ty, private: private?, methods: methods.push_substitution(s))
       end
 
       def private?

--- a/lib/steep/interface/shape.rb
+++ b/lib/steep/interface/shape.rb
@@ -1,6 +1,6 @@
 module Steep
   module Interface
-    class Interface
+    class Shape
       class Entry
         attr_reader :method_types
 

--- a/lib/steep/interface/substitution.rb
+++ b/lib/steep/interface/substitution.rb
@@ -27,9 +27,9 @@ module Steep
 
       def self.empty
         new(dictionary: {},
-            instance_type: INSTANCE_TYPE,
-            module_type: CLASS_TYPE,
-            self_type: SELF_TYPE)
+            instance_type: AST::Types::Instance.instance,
+            module_type: AST::Types::Class.instance,
+            self_type: AST::Types::Self.instance)
       end
 
       def empty?
@@ -39,17 +39,13 @@ module Steep
           self_type.is_a?(AST::Types::Self)
       end
 
-      INSTANCE_TYPE = AST::Types::Instance.new
-      CLASS_TYPE = AST::Types::Class.new
-      SELF_TYPE = AST::Types::Self.new
-
       def domain
         set = Set.new
 
         set.merge(dictionary.keys)
-        set << INSTANCE_TYPE unless instance_type.is_a?(AST::Types::Instance)
-        set << CLASS_TYPE unless instance_type.is_a?(AST::Types::Class)
-        set << SELF_TYPE unless instance_type.is_a?(AST::Types::Self)
+        set << AST::Types::Instance.instance unless instance_type.is_a?(AST::Types::Instance)
+        set << AST::Types::Class.instance unless instance_type.is_a?(AST::Types::Class)
+        set << AST::Types::Instance.instance unless instance_type.is_a?(AST::Types::Self)
 
         set
       end
@@ -76,7 +72,7 @@ module Steep
         dictionary.key?(var)
       end
 
-      def self.build(vars, types = nil, instance_type: AST::Types::Instance.new, module_type: AST::Types::Class.new, self_type: AST::Types::Self.new)
+      def self.build(vars, types = nil, instance_type: AST::Types::Instance.instance, module_type: AST::Types::Class.instance, self_type: AST::Types::Self.instance)
         types ||= vars.map {|var| AST::Types::Var.fresh(var) }
 
         raise InvalidSubstitutionError.new(vars_size: vars.size, types_size: types.size) unless vars.size == types.size

--- a/lib/steep/interface/substitution.rb
+++ b/lib/steep/interface/substitution.rb
@@ -72,6 +72,21 @@ module Steep
         dictionary.key?(var)
       end
 
+      def apply?(type)
+        case type
+        when AST::Types::Var
+          key?(type.name)
+        when AST::Types::Self
+          !self_type.is_a?(AST::Types::Self)
+        when AST::Types::Instance
+          !instance_type.is_a?(AST::Types::Instance)
+        when AST::Types::Class
+          !module_type.is_a?(AST::Types::Class)
+        else
+          type.each_child.any? {|t| apply?(t) }
+        end
+      end
+
       def self.build(vars, types = nil, instance_type: AST::Types::Instance.instance, module_type: AST::Types::Class.instance, self_type: AST::Types::Self.instance)
         types ||= vars.map {|var| AST::Types::Var.fresh(var) }
 
@@ -86,7 +101,7 @@ module Steep
 
       def except(vars)
         self.class.new(
-          dictionary: dictionary,
+          dictionary: dictionary.dup,
           instance_type: instance_type,
           module_type: module_type,
           self_type: self_type

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -177,25 +177,23 @@ module Steep
           end
 
         when TypeCheckCodeJob
-          GCCounter.count_objects("TypeCheckCodeJob: #{job.class} :: #{job.path}", /^(Steep)::/, skip: true) do
-            if job.guid == current_type_check_guid
-              Steep.logger.info { "Processing TypeCheckCodeJob for guid=#{job.guid}, path=#{job.path}" }
-              service.typecheck_source(path: project.relative_path(job.path)) do |path, diagnostics|
-                target = project.target_for_source_path(path)
-                formatter = Diagnostic::LSPFormatter.new(target&.code_diagnostics_config || {})
+          if job.guid == current_type_check_guid
+            Steep.logger.info { "Processing TypeCheckCodeJob for guid=#{job.guid}, path=#{job.path}" }
+            service.typecheck_source(path: project.relative_path(job.path)) do |path, diagnostics|
+              target = project.target_for_source_path(path)
+              formatter = Diagnostic::LSPFormatter.new(target&.code_diagnostics_config || {})
 
-                writer.write(
-                  method: :"textDocument/publishDiagnostics",
-                  params: LSP::Interface::PublishDiagnosticsParams.new(
-                    uri: Steep::PathHelper.to_uri(job.path),
-                    diagnostics: diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq.compact
-                  )
+              writer.write(
+                method: :"textDocument/publishDiagnostics",
+                params: LSP::Interface::PublishDiagnosticsParams.new(
+                  uri: Steep::PathHelper.to_uri(job.path),
+                  diagnostics: diagnostics.map {|diagnostic| formatter.format(diagnostic) }.uniq.compact
                 )
-              end
+              )
+            end
 
-              typecheck_progress(path: job.path, guid: job.guid)
-            end
-            end
+            typecheck_progress(path: job.path, guid: job.guid)
+          end
 
         when WorkspaceSymbolJob
           writer.write(

--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -48,7 +48,11 @@ module Steep
         end
 
         def subtyping
-          @subtyping ||= Subtyping::Check.new(factory: AST::Types::Factory.new(builder: builder))
+          @subtyping ||= begin
+            factory = AST::Types::Factory.new(builder: builder)
+            interface_builder = Interface::Builder.new(factory)
+            Subtyping::Check.new(builder: interface_builder)
+          end
         end
 
         def rbs_index

--- a/lib/steep/subtyping/relation.rb
+++ b/lib/steep/subtyping/relation.rb
@@ -32,12 +32,12 @@ module Steep
       end
 
       def interface?
-        sub_type.is_a?(Interface::Interface) && super_type.is_a?(Interface::Interface)
+        sub_type.is_a?(Interface::Shape) && super_type.is_a?(Interface::Shape)
       end
 
       def method?
-        (sub_type.is_a?(Interface::Interface::Entry) || sub_type.is_a?(Interface::MethodType)) &&
-          (super_type.is_a?(Interface::Interface::Entry) || super_type.is_a?(Interface::MethodType))
+        (sub_type.is_a?(Interface::Shape::Entry) || sub_type.is_a?(Interface::MethodType)) &&
+          (super_type.is_a?(Interface::Shape::Entry) || super_type.is_a?(Interface::MethodType))
       end
 
       def function?

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -885,7 +885,7 @@ module Steep
                   synthesize(child)
                 end
 
-                super_method = Interface::Interface::Entry.new(
+                super_method = Interface::Shape::Entry.new(
                   method_types: method_context.super_method.method_types.map {|method_type|
                     decl = TypeInference::MethodCall::MethodDecl.new(
                       method_name: InstanceMethodName.new(type_name: super_def.implemented_in || super_def.defined_in,

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2950,6 +2950,8 @@ module Steep
     end
 
     def type_send(node, send_node:, block_params:, block_body:, unwrap: false)
+      # @type var constr: TypeConstruction
+
       case send_node.type
       when :super, :zsuper
         receiver = nil
@@ -2998,54 +3000,6 @@ module Steep
                          )
                        )
 
-                     when AST::Types::Var
-                       if interface = calculate_interface(receiver_type, private: false)
-                         constr.type_send_interface(
-                           node,
-                           interface: interface,
-                           receiver: receiver,
-                           receiver_type: receiver_type,
-                           method_name: method_name,
-                           arguments: arguments,
-                           block_params: block_params,
-                           block_body: block_body
-                         )
-                       else
-                         constr = constr.synthesize_children(node, skips: [receiver])
-                         constr.add_call(
-                           TypeInference::MethodCall::NoMethodError.new(
-                             node: node,
-                             context: context.method_context,
-                             method_name: method_name,
-                             receiver_type: receiver_type,
-                             error: Diagnostic::Ruby::NoMethod.new(node: node, method: method_name, type: receiver_type)
-                           )
-                         )
-                       end
-                     when AST::Types::Void, AST::Types::Bot, AST::Types::Top
-                       constr = constr.synthesize_children(node, skips: [receiver])
-                       constr.add_call(
-                         TypeInference::MethodCall::NoMethodError.new(
-                           node: node,
-                           context: context.method_context,
-                           method_name: method_name,
-                           receiver_type: receiver_type,
-                           error: Diagnostic::Ruby::NoMethod.new(node: node, method: method_name, type: receiver_type)
-                         )
-                       )
-
-                     when AST::Types::Self
-                        interface = calculate_interface(receiver_type, private: private) or raise
-                        constr.type_send_interface(
-                          node,
-                          interface: interface,
-                          receiver: receiver,
-                          receiver_type: receiver_type,
-                          method_name: method_name,
-                          arguments: arguments,
-                          block_params: block_params,
-                          block_body: block_body
-                        )
                      else
                        if interface = calculate_interface(receiver_type, private: private)
                          constr.type_send_interface(

--- a/sig/shims/tagged_logging.rbs
+++ b/sig/shims/tagged_logging.rbs
@@ -1,0 +1,4 @@
+module ActiveSupport::TaggedLogging
+  def tagged: [A] (*String) { () -> A } -> A
+            | ...
+end

--- a/sig/steep.rbs
+++ b/sig/steep.rbs
@@ -1,5 +1,5 @@
 module Steep
-  def self.logger: () -> Logger
+  def self.logger: () -> ActiveSupport::TaggedLogging
 
   def self.new_logger: (untyped output, untyped prev_level) -> untyped
 
@@ -29,3 +29,4 @@ module Steep
 
   def self.measure2: (untyped message, ?level: ::Symbol) { (untyped) -> untyped } -> untyped
 end
+

--- a/sig/steep/ast/types/class.rbs
+++ b/sig/steep/ast/types/class.rbs
@@ -23,6 +23,9 @@ module Steep
         def level: () -> ::Array[0]
 
         def with_location: (untyped new_location) -> untyped
+
+        self.@instance: Class
+        def self.instance: () -> Class
       end
     end
   end

--- a/sig/steep/ast/types/factory.rbs
+++ b/sig/steep/ast/types/factory.rbs
@@ -4,70 +4,66 @@ module Steep
       class Factory
         attr_reader definition_builder: RBS::DefinitionBuilder
 
-        attr_reader type_name_cache: untyped
-
-        attr_reader type_cache: untyped
+        attr_reader type_cache: Hash[RBS::Types::t, t]
 
         attr_reader type_interface_cache: untyped
+
+        @type_name_resolver: RBS::Resolver::TypeNameResolver?
 
         def inspect: () -> String
 
         def initialize: (builder: RBS::DefinitionBuilder) -> void
 
-        def type_name_resolver: () -> untyped
+        def type_name_resolver: () -> RBS::Resolver::TypeNameResolver
 
-        def type_opt: (untyped `type`) -> (untyped | nil)
+        def type_opt: (RBS::Types::t? `type`) -> t?
 
-        def type: (RBS::Types::t `type`) -> AST::Types::t
+        def type: (RBS::Types::t `type`) -> t
 
-        def type_1: (AST::Types::t `type`) -> RBS::Types::t
+        def type_1: (t `type`) -> RBS::Types::t
 
-        def function_1: (untyped func) -> untyped
+        def function_1: (Interface::Function func) -> RBS::Types::Function
 
-        def params: (untyped `type`) -> untyped
+        def params: (RBS::Types::Function `type`) -> Interface::Function::Params
 
-        def type_param: (untyped type_param) -> untyped
+        def type_param: (RBS::AST::TypeParam type_param) -> Interface::TypeParam
 
-        def type_param_1: (untyped type_param) -> untyped
+        def type_param_1: (Interface::TypeParam type_param) -> RBS::AST::TypeParam
 
-        def method_type: (RBS::MethodType method_type, self_type: AST::Types::t, method_decls: untyped, ?subst2: Interface::Substitution?) -> Interface::MethodType
-                       | [A] (RBS::MethodType method_type, self_type: AST::Types::t, method_decls: untyped, ?subst2: Interface::Substitution?) { (Interface::MethodType) -> A } -> A
+        @method_type_cache: Hash[RBS::MethodType, Interface::MethodType]
+        
+        def method_type: (RBS::MethodType method_type, method_decls: Set[TypeInference::MethodCall::MethodDecl]) -> Interface::MethodType
 
-        def method_type_1: (untyped method_type, self_type: untyped) { (untyped) -> untyped } -> untyped
-
-        class InterfaceCalculationError < StandardError
-          attr_reader type: untyped
-
-          def initialize: (type: untyped, message: untyped) -> void
-        end
+        def method_type_1: (Interface::MethodType method_type) -> RBS::MethodType
 
         def unfold: (RBS::TypeName type_name, Array[t] args) -> t
 
+        # Unfold type alias one step, or returns itself
+        #
         def expand_alias: (t `type`) -> t
-                        | [A] (t) { (t) -> A } -> A
 
-        def deep_expand_alias: (t `type`, ?recursive: Set[t]) -> t
-                             | [A] (t `type`, ?recursive: Set[t]) { (t) -> A }-> A
+        # Unfold type alias until non alias type
+        #
+        # * Unions and intersections are expanded
+        # * Returns `nil` if it is recursive
+        #
+        def deep_expand_alias: (t `type`, ?recursive: Set[RBS::TypeName]) -> t?
 
-        def flatten_union: (untyped `type`, ?untyped acc) -> untyped
+        # Convert union types to array of types
+        #
+        def flatten_union: (t `type`, ?Array[t] acc) -> Array[t]
 
         def unwrap_optional: (Types::t `type`) -> [Types::t, Types::t]
 
-        NilClassName: untyped
+        def module_name?: (RBS::TypeName type_name) -> bool
 
-        def setup_primitives: (untyped method_name, untyped method_def, untyped method_type) -> untyped
-
-        def interface: (untyped `type`, private: untyped, ?self_type: untyped) -> untyped
-
-        def module_name?: (untyped type_name) -> untyped
-
-        def class_name?: (untyped type_name) -> untyped
+        def class_name?: (RBS::TypeName type_name) -> bool
 
         def env: () -> RBS::Environment
 
-        def absolute_type: (untyped `type`, context: untyped) -> untyped
+        def absolute_type: (t `type`, context: RBS::Resolver::context) -> t
 
-        def absolute_type_name: (untyped type_name, context: untyped) -> untyped
+        def absolute_type_name: (RBS::TypeName type_name, context: RBS::Resolver::context) -> RBS::TypeName?
 
         def instance_type: (RBS::TypeName type_name, ?args: Array[t]?, ?location: untyped?) -> t
       end

--- a/sig/steep/ast/types/instance.rbs
+++ b/sig/steep/ast/types/instance.rbs
@@ -23,6 +23,9 @@ module Steep
         def level: () -> ::Array[0]
 
         def with_location: (untyped new_location) -> untyped
+
+        self.@instance: Instance
+        def self.instance: () -> Instance
       end
     end
   end

--- a/sig/steep/ast/types/literal.rbs
+++ b/sig/steep/ast/types/literal.rbs
@@ -8,25 +8,25 @@ module Steep
 
         def initialize: (value: untyped, ?location: untyped?) -> void
 
-        def ==: (untyped other) -> untyped
+        def ==: (untyped other) -> bool
 
-        def hash: () -> untyped
+        def hash: () -> Integer
 
         alias eql? ==
 
-        def subst: (untyped s) -> self
+        def subst: (Interface::Substitution s) -> self
 
-        def to_s: () -> untyped
+        def to_s: () -> String
 
         include Helper::NoFreeVariables
 
         include Helper::NoChild
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
-        def with_location: (untyped new_location) -> untyped
+        def with_location: (untyped new_location) -> self
 
-        def back_type: () -> untyped
+        def back_type: () -> AST::Types::Name::Instance
       end
     end
   end

--- a/sig/steep/ast/types/self.rbs
+++ b/sig/steep/ast/types/self.rbs
@@ -23,6 +23,9 @@ module Steep
         def level: () -> ::Array[0]
 
         def with_location: (untyped new_location) -> untyped
+
+        self.@instance: Self
+        def self.instance: () -> Self
       end
     end
   end

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -302,9 +302,9 @@ module Steep
       end
 
       class UnexpectedSuper < Base
-        attr_reader method: untyped
+        attr_reader method: Symbol?
 
-        def initialize: (node: untyped, method: untyped) -> void
+        def initialize: (node: Parser::AST::Node, method: Symbol?) -> void
 
         def header_line: () -> ::String
       end

--- a/sig/steep/index/rbs_index.rbs
+++ b/sig/steep/index/rbs_index.rbs
@@ -1,0 +1,91 @@
+module Steep
+  module Index
+    class RBSIndex
+      class TypeEntry
+        attr_reader type_name: untyped
+
+        attr_reader declarations: untyped
+
+        attr_reader references: untyped
+
+        def initialize: (type_name: untyped) -> void
+
+        def add_declaration: (untyped decl) -> untyped
+
+        def add_reference: (untyped ref) -> untyped
+      end
+
+      class MethodEntry
+        attr_reader method_name: untyped
+
+        attr_reader declarations: untyped
+
+        attr_reader references: untyped
+
+        def initialize: (method_name: untyped) -> void
+
+        def add_declaration: (untyped decl) -> untyped
+      end
+
+      class ConstantEntry
+        attr_reader const_name: untyped
+
+        attr_reader declarations: untyped
+
+        def initialize: (const_name: untyped) -> void
+
+        def add_declaration: (untyped decl) -> untyped
+      end
+
+      class GlobalEntry
+        attr_reader global_name: untyped
+
+        attr_reader declarations: untyped
+
+        def initialize: (global_name: untyped) -> void
+
+        def add_declaration: (untyped decl) -> untyped
+      end
+
+      attr_reader type_index: untyped
+
+      attr_reader method_index: untyped
+
+      attr_reader const_index: untyped
+
+      attr_reader global_index: untyped
+
+      def initialize: () -> void
+
+      def entry: (?type_name: untyped?, ?method_name: untyped?, ?const_name: untyped?, ?global_name: untyped?) -> untyped
+
+      def each_entry: () { () -> untyped } -> untyped
+
+      def add_type_declaration: (untyped type_name, untyped declaration) -> untyped
+
+      def add_method_declaration: (untyped method_name, untyped member) -> untyped
+
+      def add_constant_declaration: (untyped const_name, untyped decl) -> untyped
+
+      def add_global_declaration: (untyped global_name, untyped decl) -> untyped
+
+      def each_declaration: (?type_name: untyped?, ?method_name: untyped?, ?const_name: untyped?, ?global_name: untyped?) { () -> untyped } -> untyped
+
+      def add_type_reference: (untyped type_name, untyped ref) -> untyped
+
+      def each_reference: (?type_name: untyped?) { () -> untyped } -> untyped
+
+      class Builder
+        attr_reader index: untyped
+
+        def initialize: (index: untyped) -> void
+
+        def member: (untyped type_name, untyped member) -> untyped
+
+        def type_reference: (untyped `type`, from: untyped) -> untyped
+
+        def env: (untyped env) -> untyped
+      end
+    end
+  end
+end

--- a/sig/steep/index/signature_symbol_provider.rbs
+++ b/sig/steep/index/signature_symbol_provider.rbs
@@ -1,0 +1,29 @@
+module Steep
+  module Index
+    class SignatureSymbolProvider
+      LSP: untyped
+
+      SymbolInformation: untyped
+
+      attr_reader project: untyped
+
+      attr_reader indexes: untyped
+
+      attr_reader assignment: untyped
+
+      def initialize: (project: untyped, assignment: untyped) -> void
+
+      def self.test_type_name: (untyped query, untyped type_name) -> untyped
+
+      alias self.test_const_name self.test_type_name
+
+      alias self.test_global_name self.test_type_name
+
+      def self.test_method_name: (untyped query, untyped method_name) -> untyped
+
+      def assigned?: (untyped path) -> untyped
+
+      def query_symbol: (untyped query) -> untyped
+    end
+  end
+end

--- a/sig/steep/index/source_index.rbs
+++ b/sig/steep/index/source_index.rbs
@@ -1,0 +1,63 @@
+module Steep
+  module Index
+    class SourceIndex
+      class ConstantEntry
+        attr_reader name: untyped
+
+        attr_reader definitions: untyped
+
+        attr_reader references: untyped
+
+        def initialize: (name: untyped) -> void
+
+        def add_definition: (untyped node) -> untyped
+
+        def add_reference: (untyped node) -> untyped
+
+        def merge!: (untyped other) -> untyped
+      end
+
+      class MethodEntry
+        attr_reader name: untyped
+
+        attr_reader definitions: untyped
+
+        attr_reader references: untyped
+
+        def initialize: (name: untyped) -> void
+
+        def add_definition: (untyped node) -> untyped
+
+        def add_reference: (untyped node) -> untyped
+
+        def merge!: (untyped other) -> untyped
+      end
+
+      attr_reader source: untyped
+
+      attr_reader constant_index: untyped
+
+      attr_reader method_index: untyped
+
+      attr_reader parent: untyped
+
+      attr_reader count: untyped
+
+      attr_reader parent_count: untyped
+
+      def initialize: (source: untyped, ?parent: untyped?) -> void
+
+      def new_child: () -> untyped
+
+      def merge!: (untyped child) -> untyped
+
+      def add_definition: (definition: untyped, ?constant: untyped?, ?method: untyped?) -> untyped
+
+      def add_reference: (ref: untyped, ?constant: untyped?, ?method: untyped?) -> untyped
+
+      def entry: (?constant: untyped?, ?method: untyped?) -> untyped
+
+      def reference: (?constant_node: untyped?) -> untyped
+    end
+  end
+end

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -1,0 +1,111 @@
+module Steep
+  module Interface
+    class Builder
+      class Config
+        attr_reader resolve_self: AST::Types::t | true | nil
+
+        attr_reader resolve_class_type: AST::Types::t | true | nil
+
+        attr_reader resolve_instance_type: AST::Types::t | true | nil
+
+        attr_reader variable_bounds: Hash[Symbol, AST::Types::t?]
+
+        def initialize: (
+          resolve_self: AST::Types::t | true | nil,
+          resolve_class_type: AST::Types::t | true | nil,
+          resolve_instance_type: AST::Types::t | true | nil,
+          variable_bounds: Hash[Symbol, AST::Types::t?]
+        ) -> void
+
+        def update: (
+          ?resolve_self: AST::Types::t | true | nil,
+          ?resolve_class_type: AST::Types::t | true | nil,
+          ?resolve_instance_type: AST::Types::t | true | nil,
+          ?variable_bounds: Hash[Symbol, AST::Types::t?]
+        ) -> self
+
+        def ==: (untyped) -> bool
+
+        alias eql? ==
+
+        def hash: () -> Integer
+
+        @subst: Substitution
+
+        %a{pure} def subst: () -> Substitution
+      end
+
+      attr_reader factory: AST::Types::Factory
+
+      type cache_key = [
+        AST::Types::t,   # type
+        bool,            # public_only
+        AST::Types::t | true | nil,   # resolve_self
+        AST::Types::t | true | nil,   # resolve_class_type
+        AST::Types::t | true | nil,   # resolve_instance_type
+        Hash[Symbol, AST::Types::t?]? # variable_bounds
+      ]
+      attr_reader cache: Hash[cache_key, Shape?]
+
+      # No type application (if generic), no self-instance-module resolution
+      attr_reader raw_instance_object_shape_cache: Hash[[RBS::TypeName, bool], Shape]
+
+      attr_reader raw_singleton_object_shape_cache: Hash[[RBS::TypeName, bool], Shape]
+
+      attr_reader raw_interface_object_shape_cache: Hash[[RBS::TypeName, bool], Shape]
+
+      def initialize: (AST::Types::Factory) -> void
+
+      # Calculates the shape of given class, based on `public_only` and Config
+      #
+      # Returns `nil` if a type that cannot calculate Shape is given.
+      #
+      # * `public_only`: If false, returns a shape with private methods.
+      #
+      def shape: (AST::Types::t, public_only: bool, config: Config) -> Shape?
+
+      private
+
+      # Fetch and update cache
+      #
+      # Cache if given type is cacheable:
+      #
+      # * `self`, `instance`, `class` is not cacheable
+      # * Type variables are not cacheable
+      #
+      def fetch_cache: (AST::Types::t, bool public_only, Config) { () -> Shape? } -> Shape?
+
+      def include_self?: (AST::Types::t) -> bool
+
+      def definition_builder: () -> RBS::DefinitionBuilder
+
+      def object_shape: (
+        AST::Types::Name::Instance | AST::Types::Name::Singleton | AST::Types::Name::Interface,
+        bool public_only,
+        boolish keep_self,
+        boolish keep_instance,
+        boolish keep_singleton
+      ) -> Shape
+
+      def raw_object_shape: (
+        AST::Types::Name::Instance | AST::Types::Name::Singleton | AST::Types::Name::Interface,
+        bool public_only,
+        Substitution subst
+      ) -> Shape
+
+      def union_shape: (AST::Types::t, Array[Shape], bool public_only) -> Shape
+
+      def intersection_shape: (AST::Types::t, Array[Shape], bool public_only) -> Shape
+
+      def tuple_shape: (AST::Types::Tuple, bool public_only, Config) -> Shape
+
+      def record_shape: (AST::Types::Record, bool public_only, Config) -> Shape?
+
+      def proc_shape: (AST::Types::Proc, bool public_only, Config) -> Shape?
+
+      def replace_primitive_method: (method_name, RBS::Definition::Method::TypeDef, MethodType) -> MethodType
+
+      def method_name_for: (RBS::Definition::Method::TypeDef, Symbol name) -> method_name
+    end
+  end
+end

--- a/sig/steep/interface/function.rbs
+++ b/sig/steep/interface/function.rbs
@@ -10,21 +10,21 @@ module Steep
 
         class PositionalParams
           class Base
-            attr_reader type: untyped
+            attr_reader type: AST::Types::t
 
-            def initialize: (untyped `type`) -> void
+            def initialize: (AST::Types::t `type`) -> void
 
-            def ==: (untyped other) -> untyped
+            def ==: (untyped other) -> bool
 
             alias eql? ==
 
-            def hash: () -> untyped
+            def hash: () -> Integer
 
-            def subst: (untyped s) -> untyped
+            def subst: (Substitution s) -> self
 
-            def var_type: () -> untyped
+            def var_type: () -> AST::Types::t
 
-            def map_type: () { (untyped) -> untyped } -> untyped
+            def map_type: () { (AST::Types::t) -> AST::Types::t } -> self
           end
 
           class Required < Base
@@ -36,61 +36,65 @@ module Steep
           class Rest < Base
           end
 
-          attr_reader head: untyped
+          type param = Required | Optional | Rest
 
-          attr_reader tail: untyped
+          attr_reader head: param
 
-          def initialize: (head: untyped, tail: untyped) -> void
+          attr_reader tail: PositionalParams?
 
-          def self.required: (untyped `type`, ?untyped? tail) -> untyped
+          def initialize: (head: param, tail: PositionalParams?) -> void
 
-          def self.optional: (untyped `type`, ?untyped? tail) -> untyped
+          def self.required: (AST::Types::t `type`, ?PositionalParams? tail) -> PositionalParams
 
-          def self.rest: (untyped `type`, ?untyped? tail) -> untyped
+          def self.optional: (AST::Types::t `type`, ?PositionalParams? tail) -> PositionalParams
 
-          def to_ary: () -> ::Array[untyped]
+          def self.rest: (AST::Types::t `type`, ?PositionalParams? tail) -> PositionalParams
 
-          def map: () { (untyped) -> untyped } -> untyped
+          def to_ary: () -> [param, PositionalParams?]
 
-          def map_type: () { () -> untyped } -> untyped
+          def map: () { (param) -> param } -> PositionalParams
 
-          def subst: (untyped s) -> untyped
+          def map_type: () { (AST::Types::t) -> AST::Types::t } -> PositionalParams
 
-          def ==: (untyped other) -> untyped
+          def subst: (Substitution s) -> PositionalParams
+
+          def ==: (untyped other) -> bool
 
           alias eql? ==
 
-          def hash: () -> untyped
+          def hash: () -> Integer
 
-          def each: () { (untyped) -> untyped } -> untyped
+          def each: () { (param) -> void } -> void
+                  | () -> Enumerator[param, void]
 
-          def each_type: () { (untyped) -> untyped } -> untyped
+          def each_type: () { (AST::Types::t) -> void } -> void
+                       | () -> Enumerator[AST::Types::t, void]
 
-          def size: () -> untyped
+          def size: () -> Integer
 
-          def self.build: (required: untyped, optional: untyped, rest: untyped) -> untyped
+          def self.build: (required: Array[AST::Types::t], optional: Array[AST::Types::t], rest: AST::Types::t?) -> PositionalParams
 
           extend Utils
 
           # Calculates xs + ys.
           # Never fails.
-          def self.merge_for_overload: (untyped xs, untyped ys) -> untyped
+          def self.merge_for_overload: (PositionalParams? xs, PositionalParams? ys) -> PositionalParams
 
           # xs | ys
-          def self.merge_for_union: (untyped xs, untyped ys) -> untyped
+          def self.merge_for_union: (PositionalParams? xs, PositionalParams? ys) -> PositionalParams?
 
           # Calculates xs & ys.
           # Raises when failed.
           #
-          def self.merge_for_intersection: (untyped xs, untyped ys) -> untyped
+          def self.merge_for_intersection: (PositionalParams? xs, PositionalParams? ys) -> PositionalParams?
         end
 
         class KeywordParams
-          attr_reader requireds: untyped
+          attr_reader requireds: Hash[Symbol, AST::Types::t]
 
-          attr_reader optionals: untyped
+          attr_reader optionals: Hash[Symbol, AST::Types::t]
 
-          attr_reader rest: untyped
+          attr_reader rest: AST::Types::t?
 
           def initialize: (?requireds: ::Hash[untyped, untyped], ?optionals: ::Hash[untyped, untyped], ?rest: untyped?) -> void
 
@@ -102,19 +106,21 @@ module Steep
 
           def update: (?requireds: untyped, ?optionals: untyped, ?rest: untyped) -> untyped
 
-          def empty?: () -> untyped
+          def empty?: () -> bool
 
-          def each: () { (untyped, untyped) -> untyped } -> untyped
+          def each: () { ([Symbol?, AST::Types::t]) -> void } -> void
+                  | () -> Enumerator[[Symbol?, AST::Types::t], void]
 
-          def each_type: () { (untyped) -> untyped } -> untyped
+          def each_type: () { (AST::Types::t) -> void } -> void
+                       | () -> Enumerator[AST::Types::t, void]
 
-          def map_type: () { () -> untyped } -> untyped
+          def map_type: () { (AST::Types::t) -> AST::Types::t } -> KeywordParams
 
-          def subst: (untyped s) -> untyped
+          def subst: (Substitution s) -> KeywordParams
 
-          def size: () -> untyped
+          def size: () -> Integer
 
-          def keywords: () -> untyped
+          def keywords: () -> Set[Symbol]
 
           include Utils
 
@@ -134,9 +140,9 @@ module Steep
 
         def rest: () -> AST::Types::t?
 
-        attr_reader positional_params: PositionalParams
+        attr_reader positional_params: PositionalParams?
 
-        attr_reader keyword_params: KeywordParams
+        attr_reader keyword_params: KeywordParams?
 
         def self.build: (?required: untyped, ?optional: untyped, ?rest: untyped?, ?required_keywords: ::Hash[untyped, untyped], ?optional_keywords: ::Hash[untyped, untyped], ?rest_keywords: untyped?) -> untyped
 
@@ -176,13 +182,14 @@ module Steep
 
         def drop_first: () -> untyped
 
-        def each_type: () { () -> untyped } -> untyped
+        def each_type: () { (AST::Types::t) -> void } -> void
+                     | () -> Enumerator[AST::Types::t, void]
 
         def free_variables: () -> untyped
 
         def closed?: () -> untyped
 
-        def subst: (untyped s) -> untyped
+        def subst: (Substitution s) -> Params
 
         def size: () -> untyped
 

--- a/sig/steep/interface/method_type.rbs
+++ b/sig/steep/interface/method_type.rbs
@@ -5,13 +5,13 @@ module Steep
 
       attr_reader type: Function
 
-      attr_reader block: Block
+      attr_reader block: Block?
 
-      attr_reader method_decls: untyped
+      attr_reader method_decls: Set[TypeInference::MethodCall::MethodDecl]
 
-      def initialize: (type_params: untyped, type: untyped, block: untyped, method_decls: untyped) -> void
+      def initialize: (type_params: Array[TypeParam], type: Function, block: Block?, method_decls: Set[TypeInference::MethodCall::MethodDecl]) -> void
 
-      def ==: (untyped other) -> untyped
+      def ==: (untyped other) -> bool
 
       alias eql? ==
 
@@ -21,11 +21,12 @@ module Steep
 
       def subst: (Substitution s) -> MethodType
 
-      def each_type: () { (untyped) -> untyped } -> untyped
+      def each_type: () { (AST::Types::t) -> void } -> void
+                   | () -> Enumerator[AST::Types::t, void]
 
       def instantiate: (Substitution s) -> MethodType
 
-      def with: (?type_params: untyped, ?type: untyped, ?block: untyped, ?method_decls: untyped) -> MethodType
+      def with: (?type_params: Array[TypeParam], ?type: Function, ?block: Block?, ?method_decls: Set[TypeInference::MethodCall::MethodDecl]) -> MethodType
 
       def to_s: () -> ::String
 

--- a/sig/steep/interface/shape.rbs
+++ b/sig/steep/interface/shape.rbs
@@ -1,6 +1,6 @@
 module Steep
   module Interface
-    class Interface
+    class Shape
       class Entry
         attr_reader method_types: untyped
 

--- a/sig/steep/interface/shape.rbs
+++ b/sig/steep/interface/shape.rbs
@@ -2,22 +2,60 @@ module Steep
   module Interface
     class Shape
       class Entry
-        attr_reader method_types: untyped
+        attr_reader method_types: Array[MethodType]
 
-        def initialize: (method_types: untyped) -> void
+        def initialize: (method_types: Array[MethodType]) -> void
 
-        def to_s: () -> ::String
+        def to_s: () -> String
       end
 
-      attr_reader type: untyped
+      class Methods
+        def []=: (Symbol, Entry) -> Entry
 
-      attr_reader methods: untyped
+        def []: (Symbol) -> Entry?
 
-      def initialize: (type: untyped, private: untyped) -> void
+        def key?: (Symbol) -> bool
 
-      def private?: () -> untyped
+        def each: () { ([Symbol, Entry]) -> void } -> void
+                | () -> Enumerator[[Symbol, Entry], void]
 
-      def public?: () -> untyped
+        def each_name: () { (Symbol) -> void } -> void
+                     | () -> Enumerator[Symbol, void]
+
+        include Enumerable[[Symbol, Entry]]
+
+        attr_reader substs: Array[Substitution]
+
+        attr_reader methods: Hash[Symbol, Entry]
+        attr_reader resolved_methods: Hash[Symbol, Entry?]
+
+        def initialize: (substs: Array[Substitution], methods: Hash[Symbol, Entry]) -> void
+
+        @subst: Substitution?
+        def subst: () -> Substitution
+
+        def push_substitution: (Substitution) -> Methods
+
+        def merge!: (Methods other) -> void
+
+        # def +: (Methods other) -> Methods
+      end
+
+      attr_reader type: AST::Types::t
+
+      attr_reader methods: Methods
+
+      @private: bool
+
+      def initialize: (type: AST::Types::t, private: bool, ?methods: Methods?) -> void
+
+      def update: (?type: AST::Types::t, ?methods: Methods) -> self
+
+      def private?: () -> bool
+
+      def public?: () -> bool
+
+      def subst: (Substitution, ?type: AST::Types::t?) -> Shape
     end
   end
 end

--- a/sig/steep/interface/substitution.rbs
+++ b/sig/steep/interface/substitution.rbs
@@ -23,12 +23,6 @@ module Steep
 
       def empty?: () -> untyped
 
-      INSTANCE_TYPE: untyped
-
-      CLASS_TYPE: untyped
-
-      SELF_TYPE: untyped
-
       def domain: () -> untyped
 
       def to_s: () -> ::String

--- a/sig/steep/interface/substitution.rbs
+++ b/sig/steep/interface/substitution.rbs
@@ -9,39 +9,41 @@ module Steep
         def initialize: (vars_size: untyped, types_size: untyped) -> void
       end
 
-      attr_reader dictionary: untyped
+      attr_reader dictionary: Hash[Symbol, AST::Types::t]
 
-      attr_reader instance_type: untyped
+      attr_reader instance_type: AST::Types::t
 
-      attr_reader module_type: untyped
+      attr_reader module_type: AST::Types::t
 
-      attr_reader self_type: untyped
+      attr_reader self_type: AST::Types::t
 
-      def initialize: (dictionary: untyped, instance_type: untyped, module_type: untyped, self_type: untyped) -> void
+      def initialize: (dictionary: Hash[Symbol, AST::Types::t], instance_type: AST::Types::t, module_type: AST::Types::t, self_type: AST::Types::t) -> void
 
-      def self.empty: () -> untyped
+      def self.empty: () -> instance
 
-      def empty?: () -> untyped
+      def empty?: () -> bool
 
-      def domain: () -> untyped
+      def domain: () -> Set[AST::Types::t | Symbol]
 
       def to_s: () -> ::String
 
-      def []: (untyped key) -> untyped
+      def []: (Symbol key) -> AST::Types::t
 
-      def key?: (untyped var) -> untyped
+      def key?: (Symbol var) -> bool
 
-      def self.build: (untyped vars, ?untyped? types, ?instance_type: untyped, ?module_type: untyped, ?self_type: untyped) -> Substitution
+      def self.build: (Array[Symbol] vars, ?Array[AST::Types::t]? types, ?instance_type: AST::Types::t, ?module_type: AST::Types::t, ?self_type: AST::Types::t) -> Substitution
 
-      def except: (untyped vars) -> untyped
+      def except: (Array[Symbol] vars) -> Substitution
 
-      def except!: (untyped vars) -> self
+      def except!: (Array[Symbol] vars) -> self
 
-      def merge!: (untyped s, ?overwrite: bool) -> self
+      def merge!: (Substitution s, ?overwrite: bool) -> self
 
-      def merge: (untyped s) -> untyped
+      def merge: (Substitution s) -> Substitution
 
-      def add!: (untyped v, untyped ty) -> untyped
+      def apply?: (AST::Types::t) -> bool
+
+      def add!: (Symbol v, AST::Types::t ty) -> self
     end
   end
 end

--- a/sig/steep/services/completion_provider.rbs
+++ b/sig/steep/services/completion_provider.rbs
@@ -71,15 +71,15 @@ module Steep
         def inherited?: () -> bool
       end
 
-      attr_reader source_text: untyped
+      attr_reader source_text: String
 
-      attr_reader path: untyped
+      attr_reader path: Pathname
 
-      attr_reader subtyping: untyped
+      attr_reader subtyping: Subtyping::Check
 
-      attr_reader modified_text: untyped
+      attr_reader modified_text: String
 
-      attr_reader source: untyped
+      attr_reader source: Source
 
       attr_reader typing: Typing
 

--- a/sig/steep/subtyping/check.rbs
+++ b/sig/steep/subtyping/check.rbs
@@ -1,27 +1,33 @@
 module Steep
   module Subtyping
     class Check
-      attr_reader factory: AST::Types::Factory
+      attr_reader builder: Interface::Builder
 
       attr_reader cache: untyped
 
       attr_reader assumptions: untyped
 
-      def initialize: (factory: untyped) -> void
+      @bounds: Array[Hash[Symbol, AST::Types::t?]]
+
+      def initialize: (builder: Interface::Builder) -> void
+
+      def factory: () -> AST::Types::Factory
 
       def with_context: (self_type: untyped, instance_type: untyped, class_type: untyped, constraints: untyped) { () -> untyped } -> untyped
 
       def push_assumption: (untyped relation) { () -> untyped } -> untyped
 
-      def push_variable_bounds: (untyped params) { () -> untyped } -> untyped
+      def push_variable_bounds: [A] (Array[Interface::TypeParam] | Hash[Symbol, AST::Types::t?] params) { () -> A } -> A
 
-      def variable_upper_bound: (untyped name) -> (untyped | nil)
+      def variable_upper_bound: (Symbol name) -> AST::Types::t?
 
-      def self_type: () -> untyped
+      def variable_upper_bounds: () -> Hash[Symbol, AST::Types::t?]
 
-      def instance_type: () -> untyped
+      def self_type: () -> AST::Types::t
 
-      def class_type: () -> untyped
+      def instance_type: () -> AST::Types::t
+
+      def class_type: () -> AST::Types::t
 
       def constraints: () -> untyped
 
@@ -57,7 +63,7 @@ module Steep
 
       def same_type?: (untyped relation) -> (true | untyped)
 
-      def check_interface: (untyped relation) -> untyped
+      def check_interface: (Relation[Interface::Shape] relation) -> Result::t
 
       def check_method: (untyped name, untyped relation) -> untyped
 

--- a/sig/steep/subtyping/relation.rbs
+++ b/sig/steep/subtyping/relation.rbs
@@ -1,11 +1,11 @@
 module Steep
   module Subtyping
-    class Relation
-      attr_reader sub_type: untyped
+    class Relation[T]
+      attr_reader sub_type: T
 
-      attr_reader super_type: untyped
+      attr_reader super_type: T
 
-      def initialize: (sub_type: untyped, super_type: untyped) -> void
+      def initialize: (sub_type: T, super_type: T) -> void
 
       def hash: () -> untyped
 
@@ -15,7 +15,7 @@ module Steep
 
       def to_s: () -> ::String
 
-      def to_ary: () -> ::Array[untyped]
+      def to_ary: () -> [T, T]
 
       def type?: () -> untyped
 
@@ -43,9 +43,9 @@ module Steep
 
       def block!: () -> untyped
 
-      def map: () { (untyped) -> untyped } -> untyped
+      def map: [S] () { (T) -> S } -> Relation[S]
 
-      def flip: () -> untyped
+      def flip: () -> Relation[T]
     end
   end
 end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -122,11 +122,13 @@ module Steep
 
     def synthesize_children: (Parser::AST::Node node, ?skips: Array[Parser::AST::Node]) -> TypeConstruction
 
-    def type_send_interface: (Parser::AST::Node node, interface: Interface::Shape, receiver: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, arguments: Array[Parser::AST::Node], block_params: Parser::AST::Node?, block_body: Parser::AST::Node?) -> Pair
+    def type_send_interface: (Parser::AST::Node node, interface: Interface::Shape?, receiver: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, arguments: Array[Parser::AST::Node], block_params: Parser::AST::Node?, block_body: Parser::AST::Node?) -> Pair
 
     def type_send: (untyped node, send_node: untyped, block_params: untyped, block_body: untyped, ?unwrap: bool) -> untyped
 
-    def calculate_interface: (untyped `type`, private: untyped, ?self_type: untyped) -> untyped
+    def builder_config: () -> Interface::Builder::Config
+
+    def calculate_interface: (AST::Types::t `type`, private: bool) -> Interface::Shape?
 
     def expand_self: (untyped `type`) -> untyped
 
@@ -231,12 +233,11 @@ module Steep
 
     def type_any_rec: (Parser::AST::Node node) -> Pair
 
-    def unwrap: (untyped `type`) -> untyped
+    def unwrap: (AST::Types::t `type`) -> AST::Types::t
 
-    def deep_expand_alias: (AST::Types::t `type`) -> AST::Types::t
-                         | [A] (AST::Types::t) { (AST::Types::t) -> A } -> A
+    def deep_expand_alias: (AST::Types::t `type`) -> AST::Types::t?
 
-    def flatten_union: (untyped `type`) -> untyped
+    def flatten_union: (AST::Types::t `type`) -> Array[AST::Types::t]
 
     def select_flatten_types: (untyped `type`) { () -> untyped } -> untyped
 

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -30,17 +30,17 @@ module Steep
 
     attr_reader context: TypeInference::Context
 
-    def module_context: () -> TypeInference::Context::ModuleContext?
+    %a{pure} def module_context: () -> TypeInference::Context::ModuleContext?
 
-    def method_context: () -> TypeInference::Context::MethodContext?
+    %a{pure} def method_context: () -> TypeInference::Context::MethodContext?
 
-    def block_context: () -> TypeInference::Context::BlockContext?
+    %a{pure} def block_context: () -> TypeInference::Context::BlockContext?
 
-    def break_context: () -> TypeInference::Context::BreakContext?
+    %a{pure} def break_context: () -> TypeInference::Context::BreakContext?
 
-    def self_type: () -> untyped
+    %a{pure} def self_type: () -> AST::Types::t
 
-    def variable_context: () -> TypeInference::Context::TypeVariableContext
+    %a{pure} def variable_context: () -> TypeInference::Context::TypeVariableContext
 
     def initialize: (checker: untyped, source: untyped, annotations: untyped, typing: untyped, context: untyped) -> void
 
@@ -122,7 +122,7 @@ module Steep
 
     def synthesize_children: (Parser::AST::Node node, ?skips: Array[Parser::AST::Node]) -> TypeConstruction
 
-    def type_send_interface: (Parser::AST::Node node, interface: Interface::Shape?, receiver: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, arguments: Array[Parser::AST::Node], block_params: Parser::AST::Node?, block_body: Parser::AST::Node?) -> Pair
+    def type_send_interface: (Parser::AST::Node node, interface: Interface::Shape, receiver: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, arguments: Array[Parser::AST::Node], block_params: Parser::AST::Node?, block_body: Parser::AST::Node?) -> Pair
 
     def type_send: (untyped node, send_node: untyped, block_params: untyped, block_body: untyped, ?unwrap: bool) -> untyped
 
@@ -134,6 +134,7 @@ module Steep
     # * Returns Shape::Entry instead of Shape, if `method_name` is given
     #
     def calculate_interface: (AST::Types::t `type`, private: bool) -> Interface::Shape?
+                           | (AST::Types::t `type`, Symbol method_name, private: bool) -> Interface::Shape::Entry?
 
     def expand_self: (untyped `type`) -> untyped
 

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -128,6 +128,11 @@ module Steep
 
     def builder_config: () -> Interface::Builder::Config
 
+    # Calculates the shape (interface) of an type
+    #
+    # * Returns `nil` if the type cannot be translated to a shape
+    # * Returns Shape::Entry instead of Shape, if `method_name` is given
+    #
     def calculate_interface: (AST::Types::t `type`, private: bool) -> Interface::Shape?
 
     def expand_self: (untyped `type`) -> untyped

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -122,7 +122,7 @@ module Steep
 
     def synthesize_children: (Parser::AST::Node node, ?skips: Array[Parser::AST::Node]) -> TypeConstruction
 
-    def type_send_interface: (Parser::AST::Node node, interface: Interface::Interface, receiver: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, arguments: Array[Parser::AST::Node], block_params: Parser::AST::Node?, block_body: Parser::AST::Node?) -> Pair
+    def type_send_interface: (Parser::AST::Node node, interface: Interface::Shape, receiver: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, arguments: Array[Parser::AST::Node], block_params: Parser::AST::Node?, block_body: Parser::AST::Node?) -> Pair
 
     def type_send: (untyped node, send_node: untyped, block_params: untyped, block_body: untyped, ?unwrap: bool) -> untyped
 
@@ -140,7 +140,7 @@ module Steep
       Parser::AST::Node node,
       method_name: Symbol,
       receiver_type: AST::Types::t,
-      method: Interface::Interface::Entry,
+      method: Interface::Shape::Entry,
       arguments: Array[Parser::AST::Node],
       block_params: Parser::AST::Node?,
       block_body: Parser::AST::Node?,

--- a/sig/steep/type_inference/context.rbs
+++ b/sig/steep/type_inference/context.rbs
@@ -62,15 +62,33 @@ module Steep
 
         attr_reader class_name: RBS::TypeName
 
-        attr_reader instance_definition: RBS::Definition
+        attr_reader instance_definition: RBS::Definition?
 
-        attr_reader module_definition: RBS::Definition
+        attr_reader module_definition: RBS::Definition?
 
-        def initialize: (instance_type: untyped, module_type: untyped, implement_name: untyped, class_name: untyped, nesting: untyped, ?instance_definition: untyped?, ?module_definition: untyped?) -> void
+        @class_variables: Hash[Symbol, RBS::Types::t]?
 
-        def class_variables: () -> (untyped | nil)
+        def initialize: (
+          instance_type: AST::Types::t,
+          module_type: AST::Types::t,
+          implement_name: untyped,
+          class_name: RBS::TypeName,
+          nesting: RBS::Resolver::context,
+          ?instance_definition: RBS::Definition?,
+          ?module_definition: RBS::Definition?
+        ) -> void
 
-        def update: (?instance_type: untyped, ?module_type: untyped, ?implement_name: untyped, ?class_name: untyped, ?instance_definition: untyped, ?module_definition: untyped, ?nesting: untyped) -> untyped
+        def class_variables: () -> Hash[Symbol, RBS::Types::t]?
+
+        def update: (
+          ?instance_type: AST::Types::t,
+          ?module_type: AST::Types::t,
+          ?implement_name: untyped,
+          ?class_name: RBS::TypeName,
+          ?instance_definition: RBS::Definition?,
+          ?module_definition: RBS::Definition?,
+          ?nesting: RBS::Resolver::context
+        ) -> ModuleContext
       end
 
       class TypeVariableContext
@@ -99,7 +117,7 @@ module Steep
 
       attr_reader break_context: BreakContext?
 
-      attr_reader module_context: untyped
+      attr_reader module_context: ModuleContext?
 
       attr_reader self_type: AST::Types::t
 
@@ -111,7 +129,7 @@ module Steep
         method_context: untyped,
         block_context: BlockContext?,
         break_context: BreakContext?,
-        module_context: untyped,
+        module_context: ModuleContext?,
         self_type: untyped,
         type_env: TypeEnv,
         call_context: untyped,
@@ -122,7 +140,7 @@ module Steep
         ?method_context: untyped,
         ?block_context: BlockContext?,
         ?break_context: BreakContext?,
-        ?module_context: untyped,
+        ?module_context: ModuleContext?,
         ?self_type: untyped,
         ?type_env: TypeEnv,
         ?call_context: untyped,

--- a/sig/steep/type_inference/logic_type_interpreter.rbs
+++ b/sig/steep/type_inference/logic_type_interpreter.rbs
@@ -7,7 +7,9 @@ module Steep
 
       attr_reader factory (): AST::Types::Factory
 
-      def initialize: (subtyping: Subtyping::Check, typing: Typing) -> void
+      attr_reader config: Interface::Builder::Config
+
+      def initialize: (subtyping: Subtyping::Check, typing: Typing, config: Interface::Builder::Config) -> void
 
       def eval: (env: TypeEnv, node: Parser::AST::Node) -> [TypeEnv, TypeEnv, Set[Symbol | Parser::AST::Node], AST::Types::t, AST::Types::t]
 

--- a/test/annotation_parsing_test.rb
+++ b/test/annotation_parsing_test.rb
@@ -39,7 +39,7 @@ class AnnotationParsingTest < Minitest::Test
 
       assert_instance_of Annotation::MethodType, annot
       assert_equal :foo, annot.name
-      assert_equal factory.method_type(RBS::Parser.parse_method_type("(Bar) -> Baz"), self_type: Steep::AST::Types::Self.new, method_decls: Set[]),
+      assert_equal factory.method_type(RBS::Parser.parse_method_type("(Bar) -> Baz"), method_decls: Set[]),
                    annot.type
     end
   end

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -1,0 +1,294 @@
+require_relative "test_helper"
+
+class InterfaceBuilderTest < Minitest::Test
+  include TestHelper
+  include FactoryHelper
+
+  include Steep
+
+  def config
+    Interface::Builder::Config.new(resolve_self: nil, resolve_class_type: nil, resolve_instance_type: nil, variable_bounds: {})
+  end
+
+  def test_interface_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def hello: () -> void
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::_Foo"), public_only: true, config: config)
+
+      assert_equal parse_type("::_Foo"), shape.type
+      assert_equal [:hello], shape.methods.each_name.to_a
+      assert_equal [parse_method_type("() -> void")], shape.methods[:hello].method_types
+    end
+  end
+
+  def test_class_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::String"), public_only: true, config: config)
+
+      assert_equal parse_type("::String"), shape.type
+      assert_includes shape.methods.each_name.to_a, :gsub!      # Method from String
+      assert_includes shape.methods.each_name.to_a, :__id__     # Method from BasicObject
+      refute_includes shape.methods.each_name.to_a, :initialize # Private method String
+    end
+  end
+
+  def test_interface_shape_unfold_self
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def itself: () -> self
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::_Foo"), public_only: true, config: config.update(resolve_self: parse_type("::String")))
+
+      assert_equal parse_type("::_Foo"), shape.type
+      assert_equal [parse_method_type("() -> ::_Foo")], shape.methods[:itself].method_types
+    end
+  end
+
+  def test_self_shape_no_resolve
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def itself: () -> self
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("self"), public_only: true, config: config)
+
+      assert_nil shape
+    end
+  end
+
+  def test_self_shape_with_resolve
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def itself: () -> self
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("self"), public_only: true, config: config.update(resolve_self: parse_type("::_Foo")))
+
+      assert_equal parse_type("::_Foo"), shape.type
+      assert_equal [parse_method_type("() -> self")], shape.methods[:itself].method_types
+    end
+  end
+
+  def test_self_shape_with_resolve_application
+    with_factory({ "a.rbs" => <<-RBS }) do
+class Foo[A, B, C]
+  def foo: () -> [A, B, C]
+         | () -> [self, class, instance]
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(
+        parse_type("::Foo[self, class, instance]"),
+        public_only: true,
+        config: config.update(
+          resolve_self: parse_type("::String"),
+          resolve_class_type: parse_type("singleton(::String)"),
+          resolve_instance_type: parse_type("::String")
+        )
+      )
+
+      assert_equal parse_type("::Foo[::String, singleton(::String), ::String]"), shape.type
+      assert_equal(
+        [
+          parse_method_type("() -> [::String, singleton(::String), ::String]"),
+          parse_method_type("() -> [::Foo[::String, singleton(::String), ::String], singleton(::Foo), ::Foo[untyped, untyped, untyped]]")
+        ],
+        shape.methods[:foo].method_types
+      )
+    end
+  end
+
+  def test_instance_shape_with_resolve
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def itself: () -> self
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("instance"), public_only: true, config: config.update(resolve_instance_type: parse_type("::Array[bool]")))
+
+      assert_equal parse_type("::Array[bool]"), shape.type
+    end
+  end
+
+  def test_class_shape_with_resolve
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def itself: () -> self
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("class"), public_only: true, config: config.update(resolve_class_type: parse_type("singleton(::Array)")))
+
+      assert_equal parse_type("singleton(::Array)"), shape.type
+    end
+  end
+
+  def test_alias_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def itself: () -> self
+end
+
+type foo = _Foo
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::foo"), public_only: true, config: config)
+
+      assert_equal parse_type("::foo"), shape.type
+    end
+  end
+
+  def test_alias_shape_broken
+    with_factory({ "a.rbs" => <<-RBS }) do
+type k = k | ^() -> k
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::k"), public_only: true, config: config)
+
+      assert_nil shape
+    end
+  end
+
+  def test_union_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def f: (Integer) -> Integer
+
+  def g: (String) -> Integer
+
+  def h: () -> void
+end
+
+interface _Bar
+  def f: (String) -> String
+
+  def g: () -> void
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::_Foo | ::_Bar"), public_only: true, config: config)
+
+      assert_equal parse_type("::_Foo | ::_Bar"), shape.type
+      assert_equal [:f], shape.methods.each_name.to_a
+
+      assert_equal [parse_method_type("(::Integer & ::String) -> (::Integer | ::String)")], shape.methods[:f].method_types
+    end
+  end
+
+  def test_intersection_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+interface _Foo
+  def f: (Integer) -> Integer
+
+  def g: (String) -> Integer
+end
+
+interface _Bar
+  def f: (String) -> String
+end
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("::_Foo & ::_Bar"), public_only: true, config: config)
+
+      assert_equal parse_type("::_Foo & ::_Bar"), shape.type
+      assert_equal [:f, :g], shape.methods.each_name.to_a
+
+      assert_equal [parse_method_type("(::String) -> ::String")], shape.methods[:f].method_types
+      assert_equal [parse_method_type("(::String) -> ::Integer")], shape.methods[:g].method_types
+    end
+  end
+
+  def test_tuple_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("[::Integer, top]"), public_only: true, config: config)
+
+      assert_equal parse_type("[::Integer, top]"), shape.type
+
+      assert_includes(shape.methods[:[]].method_types, parse_method_type("(0) -> ::Integer"))
+      assert_includes(shape.methods[:[]].method_types, parse_method_type("(1) -> top"))
+
+      assert_includes(shape.methods[:[]=].method_types, parse_method_type("(0, ::Integer) -> ::Integer"))
+      assert_includes(shape.methods[:[]=].method_types, parse_method_type("(1, top) -> top"))
+
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("(0) -> ::Integer"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("(1) -> top"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (0, T) -> (::Integer | T)"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (1, T) -> (top | T)"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (0) { (::Integer) -> T } -> (::Integer | T)"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (1) { (::Integer) -> T } -> (top | T)"))
+
+      assert_equal([parse_method_type("() -> ::Integer")], shape.methods[:first].method_types)
+      assert_equal([parse_method_type("() -> top")], shape.methods[:last].method_types)
+    end
+  end
+
+  def test_record_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("{ id: ::Integer, name: ::String }"), public_only: true, config: config)
+
+      assert_equal parse_type("{ id: ::Integer, name: ::String }"), shape.type
+
+      assert_includes(shape.methods[:[]].method_types, parse_method_type("(:id) -> ::Integer"))
+      assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name) -> ::String"))
+
+      assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:id, ::Integer) -> ::Integer"))
+      assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:name, ::String) -> ::String"))
+
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("(:id) -> ::Integer"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("(:name) -> ::String"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id, T) -> (::Integer | T)"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name, T) -> (::String | T)"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id) { (:id | :name) -> T } -> (::Integer | T)"))
+      assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name) { (:id | :name) -> T } -> (::String | T)"))
+    end
+  end
+
+  def test_proc_shape
+    with_factory({ "a.rbs" => <<-RBS }) do
+      RBS
+      builder = Interface::Builder.new(factory)
+
+      shape = builder.shape(parse_type("^(::String) { (::Integer) -> void } -> ::String"), public_only: true, config: config)
+
+      assert_equal parse_type("^(::String) { (::Integer) -> void } -> ::String"), shape.type
+
+      assert_equal(
+        [parse_method_type("(::String) { (::Integer) -> void } -> ::String")],
+        shape.methods[:[]].method_types
+      )
+      assert_equal(
+        [parse_method_type("(::String) { (::Integer) -> void } -> ::String")],
+        shape.methods[:call].method_types
+      )
+    end
+  end
+end

--- a/test/server/lsp_formatter_test.rb
+++ b/test/server/lsp_formatter_test.rb
@@ -9,7 +9,8 @@ class Steep::Server::LSPFormatterTest < Minitest::Test
 
   def type_check(content)
     source = Source.parse(content, path: Pathname("a.rb"), factory: factory)
-    subtyping = Subtyping::Check.new(factory: factory)
+    builder = Interface::Builder.new(factory)
+    subtyping = Subtyping::Check.new(builder: builder)
     Services::TypeCheckService.type_check(source: source, subtyping: subtyping)
   end
 
@@ -187,7 +188,7 @@ EOM
   def test_ruby_hover_constant_class
     with_factory({ "foo.rbs" => <<RBS }) do
 # ClassHover is a class to do something with String.
-#      
+#
 class ClassHover[A < String] < BasicObject
 end
 RBS

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -114,7 +114,8 @@ end
 
     paths["builtin.rbs"] = BUILTIN unless nostdlib
     with_factory(paths, nostdlib: true) do |factory|
-      yield Subtyping::Check.new(factory: factory)
+      builder = Interface::Builder.new(factory)
+      yield Subtyping::Check.new(builder: builder)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -425,7 +425,8 @@ end
     end
 
     with_factory(paths, nostdlib: !with_stdlib) do |factory|
-      @checker = Steep::Subtyping::Check.new(factory: factory)
+      builder = Steep::Interface::Builder.new(factory)
+      @checker = Steep::Subtyping::Check.new(builder: builder)
       yield @checker
     ensure
       @checker = nil
@@ -530,9 +531,9 @@ module FactoryHelper
     Steep::Source.parse(string, path: Pathname("test.rb"), factory: factory)
   end
 
-  def parse_method_type(string, factory: self.factory, variables: [], self_type: Steep::AST::Types::Self.new)
+  def parse_method_type(string, factory: self.factory, variables: [])
     type = RBS::Parser.parse_method_type(string, variables: variables)
-    factory.method_type type, self_type: self_type, method_decls: Set[]
+    factory.method_type(type, method_decls: Set[])
   end
 end
 

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6335,7 +6335,7 @@ x + ""       # <= error! (x: String | Integer | nil)
 
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
-        assert_equal 1, typing.errors.size
+        assert_typing_error typing, size: 1
       end
     end
   end
@@ -9881,6 +9881,22 @@ x, y =
         assert_equal parse_type("[::String?, ::Integer?]"), type
         assert_equal parse_type("::String?"), context.type_env[:x]
         assert_equal parse_type("::Integer?"), context.type_env[:y]
+      end
+    end
+  end
+
+  def test_self_type_call
+    with_checker(<<-RBS) do |checker|
+      RBS
+      source = parse_ruby(<<-RUBY)
+# @type var x: Object
+x = self
+x = x.itself
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+        assert_no_error typing
       end
     end
   end

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -250,21 +250,21 @@ class TypeFactoryTest < Minitest::Test
     with_factory() do |factory|
       self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
 
-      factory.method_type(parse_method_type("[A] (A) { (A, B) -> nil } -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[A] (A) { (A, B) -> nil } -> void"), method_decls: Set[]).yield_self do |type|
         assert_equal "[A] (A) { (A, B) -> nil } -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[A] (A) -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[A] (A) -> void"), method_decls: Set[]).yield_self do |type|
         assert_equal "[A] (A) -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[A] () ?{ () -> A } -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[A] () ?{ () -> A } -> void"), method_decls: Set[]).yield_self do |type|
         assert_equal "[A] () ?{ () -> A } -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[X] (X) -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[X] (X) -> void"), method_decls: Set[]).yield_self do |type|
         assert_method_type(
-          "[X(a)] (X(a)) -> void",
+          "[X] (X) -> void",
           type
         )
       end
@@ -275,20 +275,20 @@ class TypeFactoryTest < Minitest::Test
     with_factory() do |factory|
       self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
 
-      factory.method_type(parse_method_type("[A < Integer] (A) -> void"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[A < Integer] (A) -> void"), method_decls: Set[]).yield_self do |type|
         assert_equal "[A < Integer] (A) -> void", type.to_s
       end
 
-      factory.method_type(parse_method_type("[X < Integer] () -> X"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[X < Integer] () -> X"), method_decls: Set[]).yield_self do |type|
         assert_method_type(
-          "[X(n) < Integer] () -> X(n)",
+          "[X < Integer] () -> X",
           type
         )
       end
 
-      factory.method_type(parse_method_type("[X < Integer, Y < Array[X]] (Y) -> X"), self_type: self_type, method_decls: Set[]).yield_self do |type|
+      factory.method_type(parse_method_type("[X < Integer, Y < Array[X]] (Y) -> X"), method_decls: Set[]).yield_self do |type|
         assert_method_type(
-          "[X(n) < Integer, Y < Array[X(n)]] (Y) -> X(n)",
+          "[X < Integer, Y < Array[X]] (Y) -> X",
           type
         )
       end
@@ -300,325 +300,18 @@ class TypeFactoryTest < Minitest::Test
       self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
 
       parse_method_type("[A] (A) { (A, B) -> nil } -> void").tap do |original|
-        type = factory.method_type_1(factory.method_type(original, self_type: self_type, method_decls: Set[]),
-                                     self_type: self_type)
+        type = factory.method_type_1(factory.method_type(original, method_decls: Set[]))
         assert_equal original, type
       end
 
       parse_method_type("[A] (A) -> void").tap do |original|
-        type = factory.method_type_1(factory.method_type(original, self_type: self_type, method_decls: Set[]),
-                                     self_type: self_type)
+        type = factory.method_type_1(factory.method_type(original, method_decls: Set[]))
         assert_equal original, type
       end
 
       parse_method_type("[A] () ?{ () -> A } -> void").tap do |original|
-        type = factory.method_type_1(factory.method_type(original, self_type: self_type, method_decls: Set[]),
-                                     self_type: self_type)
+        type = factory.method_type_1(factory.method_type(original, method_decls: Set[]))
         assert_equal original, type
-      end
-    end
-  end
-
-  def test_interface_instance
-    with_factory({ "foo.rbs" => <<FOO}) do |factory|
-class Foo[A]
-  def klass: -> class
-  def get: -> A
-  def set: (A) -> self
-  private
-  def hoge: -> instance
-end
-FOO
-      factory.type(parse_type("::Foo[::String]")).yield_self do |type|
-        factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_overload_with interface.methods[:klass], "() -> singleton(::Foo)"
-          assert_overload_with interface.methods[:get], "() -> ::String"
-          assert_overload_with interface.methods[:set], "(::String) -> ::Foo[::String]"
-          assert_overload_with interface.methods[:hoge], "() -> ::Foo[untyped]"
-        end
-
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_overload_with interface.methods[:klass], "() -> singleton(::Foo)"
-          assert_overload_with interface.methods[:get], "() -> ::String"
-          assert_overload_with interface.methods[:set], "(::String) -> ::Foo[::String]"
-          refute_operator interface.methods, :key?, :hoge
-        end
-      end
-    end
-  end
-
-  def test_interface_interface
-    with_factory({ "foo.rbs" => <<FOO }) do |factory|
-interface _Each2[A, B]
-  def each: () { (A) -> void } -> B
-end
-FOO
-      factory.type(parse_type("::_Each2[::String, ::Array[::String]]")).yield_self do |type|
-        factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_equal "{ () { (::String) -> void } -> ::Array[::String] }", interface.methods[:each].to_s
-        end
-      end
-    end
-  end
-
-  def test_interface_class
-    with_factory({ "foo.rbs" => <<FOO }) do |factory|
-class People[X]
-  def self.all: -> Array[People[::String]]
-  def self.instance: -> instance
-  def self.itself: -> self
-end
-FOO
-      factory.type(parse_type("singleton(::People)")).yield_self do |type|
-        factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_overload_with interface.methods[:new], "[X] () -> ::People[X]"
-          assert_overload_with interface.methods[:all], "() -> ::Array[::People[::String]]"
-          assert_overload_with interface.methods[:instance], "() -> ::People[untyped]"
-          assert_overload_with interface.methods[:itself], "() -> singleton(::People)"
-        end
-      end
-    end
-  end
-
-  def test_interface_module
-    with_factory({ "foo.rbs" => <<FOO }) do |factory|
-module Subject[X]
-  def self.foo: () -> void
-  def bar: () -> X
-end
-FOO
-
-      factory.type(parse_type("::Subject[bool]")).yield_self do |type|
-        factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_overload_with interface.methods[:bar], "() -> bool"
-        end
-      end
-
-      factory.type(parse_type("singleton(::Subject)")).yield_self do |type|
-        factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_overload_with interface.methods[:foo], "() -> void"
-          assert_overload_with interface.methods[:attr_reader], "(*(::String | ::Symbol)) -> ::NilClass"
-        end
-      end
-    end
-  end
-
-  def test_literal_type
-    with_factory() do |factory|
-      factory.type(parse_type("3")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          assert_overload_including interface.methods[:+], "(::Integer) -> ::Integer", "(::Float) -> ::Float"
-
-          interface.methods[:yield_self].tap do |method|
-            x = method.method_types[0].type_params[0]
-            assert_includes method.to_s, " [#{x}] () { (3) -> #{x} } -> #{x} "
-          end
-        end
-      end
-    end
-  end
-
-  def test_tuple_type
-    with_factory() do |factory|
-      factory.type(parse_type("[::Integer, ::String]")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          assert_overload_including interface.methods[:[]],
-                                    "(0) -> ::Integer",
-                                    "(1) -> ::String",
-                                    "(::int) -> (::Integer | ::String)"
-
-          assert_overload_including interface.methods[:[]=],
-                                    "(0, ::Integer) -> ::Integer",
-                                    "(1, ::String) -> ::String",
-                                    "(::int, (::Integer | ::String)) -> (::Integer | ::String)"
-
-          assert_overload_including interface.methods[:fetch],
-                                    "(0) -> ::Integer",
-                                    "(1) -> ::String",
-                                    "[T] (0, T default) -> (::Integer | T)",
-                                    "[T] (1, T default) -> (::String | T)",
-                                    "[T] (0) { (::Integer) -> T } -> (::Integer | T)",
-                                    "[T] (1) { (::Integer) -> T } -> (::String | T)"
-        end
-      end
-    end
-  end
-
-  def test_record_type
-    with_factory() do |factory|
-      factory.type(parse_type("{ 1 => ::Integer, :foo => ::String, \"baz\" => bool }")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          assert_overload_including interface.methods[:[]],
-                                    "(1) -> ::Integer",
-                                    "(:foo) -> ::String",
-                                    "(\"baz\") -> bool"
-
-          assert_overload_including interface.methods[:[]=],
-                                    "(1, ::Integer) -> ::Integer",
-                                    "(:foo, ::String) -> ::String",
-                                    "(\"baz\", bool) -> bool"
-
-          assert_overload_including interface.methods[:fetch],
-                                    "(1) -> ::Integer",
-                                    "(:foo) -> ::String",
-                                    "(\"baz\") -> bool",
-                                    "[T] (1, T default) -> (::Integer | T)",
-                                    "[T] (:foo, T default) -> (::String | T)",
-                                    "[T] (\"baz\", T default) -> (bool | T)",
-                                    "[T] (1) { ((1 | :foo | \"baz\")) -> T } -> (::Integer | T)",
-                                    "[T] (:foo) { ((1 | :foo | \"baz\")) -> T } -> (::String | T)",
-                                    "[T] (\"baz\") { ((1 | :foo | \"baz\")) -> T } -> (bool | T)"
-
-        end
-      end
-    end
-  end
-
-  def test_union_type
-    with_factory() do |factory|
-      factory.type(parse_type("::Integer | ::String")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          interface.methods[:to_s].yield_self do |entry|
-            assert_overload_with entry, "() -> ::String"
-          end
-
-          interface.methods[:+].yield_self do |entry|
-            assert_overload_including entry,
-                                      "((::Integer & ::string)) -> (::Integer | ::String)",
-                                      "((::Float & ::string)) -> (::Float | ::String)"
-          end
-
-          assert_nil interface.methods[:floor]
-          assert_nil interface.methods[:end_with?]
-        end
-      end
-    end
-  end
-
-  def test_union_type_methods
-    with_factory({ "foo.rbs" => <<-RBS }) do |factory|
-interface _I1
-  def f: () -> void
-  def g: () -> void
-
-  def foo: (String) -> void
-         | (Symbol) -> String
-end
-
-interface _I2
-  def g: () -> void
-  def h: () -> void
-
-  def foo: () -> void
-         | (Integer) -> Float
-end
-    RBS
-      factory.type(parse_type("::_I1 | ::_I2")).tap do |type|
-        factory.interface(type, private: false).tap do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          assert_equal Set[:g, :foo], Set.new(interface.methods.keys)
-          assert_overload_with interface.methods[:g], "() -> void"
-          assert_overload_with interface.methods[:foo],
-                               "((::String & ::Integer)) -> (::Float | void)",
-                               "((::Symbol & ::Integer)) -> (::Float | ::String)"
-        end
-      end
-    end
-  end
-
-  def test_intersection_type
-    with_factory({ "foo.rbs" => <<-RBS }) do |factory|
-interface _I1
-  def f: () -> void
-  def g: () -> void
-end
-
-interface _I2
-  def g: (String) -> Integer
-  def h: () -> void
-end
-    RBS
-      factory.type(parse_type("::_I1 & ::_I2")).tap do |type|
-        factory.interface(type, private: false).tap do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          assert_equal Set[:f, :g, :h], Set.new(interface.methods.keys)
-          assert_overload_with interface.methods[:f], "() -> void"
-          assert_overload_with interface.methods[:g], "(::String) -> ::Integer"
-          assert_overload_with interface.methods[:h], "() -> void"
-        end
-      end
-    end
-  end
-
-  def test_proc_type
-    with_factory() do |factory|
-      factory.type(parse_type("^(String) -> Integer")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          interface.methods[:call].yield_self do |entry|
-            assert_overload_with entry, "(String) -> Integer"
-          end
-
-          interface.methods[:[]].yield_self do |entry|
-            assert_overload_with entry, "(String) -> Integer"
-          end
-        end
-      end
-
-      factory.type(parse_type("^(String) { (Object) -> Symbol } -> Integer")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          interface.methods[:call].yield_self do |entry|
-            assert_overload_with entry, "(String) { (Object) -> Symbol } -> Integer"
-          end
-
-          refute_operator interface.methods, :key?, :[]
-        end
-      end
-
-      factory.type(parse_type("^(String) ?{ (Object) -> Symbol } -> Integer")).yield_self do |type|
-        factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          interface.methods[:call].yield_self do |entry|
-            assert_overload_with entry, "(String) ?{ (Object) -> Symbol } -> Integer"
-          end
-
-          interface.methods[:[]].yield_self do |entry|
-            assert_overload_with entry, "(String) -> Integer"
-          end
-        end
       end
     end
   end
@@ -698,94 +391,6 @@ end
       factory.type(parse_type("Baz")).tap do |type|
         factory.absolute_type(type, context: [nil, ("::Foo")]) do |absolute_type|
           assert_equal factory.type(parse_type("::Baz")), absolute_type
-        end
-      end
-    end
-  end
-
-  def test_variable_rename
-    with_factory({ "foo.rbs" => <<-EOF }) do |factory|
-class Hello[X]
-  def foo: [Y] (X, Y) -> void
-end
-    EOF
-
-      factory.type(parse_type("::Hello[::Array[Y]]", variables: [:Y])).tap do |type|
-        factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-          assert_equal type, interface.type
-
-          method = interface.methods[:foo]
-          assert_method_type(
-            "{ [Y(a)] (::Array[Y], Y(a)) -> void }",
-            method
-          )
-        end
-      end
-    end
-  end
-
-  def test_expand_specials
-    with_factory({ "foo.rbs" => <<-EOF }) do |factory|
-class WithBuiltinMethods
-end
-
-class WithCustomMethods
-  def is_a?: (Module) -> bool
-
-  alias kind_of? is_a?
-
-  def nil?: () -> bool
-
-  def !: () -> bool
-end
-    EOF
-
-      factory.type(parse_type("::WithBuiltinMethods")).tap do |type|
-        factory.interface(type, private: true).tap do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          interface.methods[:is_a?].tap do |is_a|
-            assert_instance_of Types::Logic::ReceiverIsArg, is_a.method_types[0].type.return_type
-          end
-
-          interface.methods[:kind_of?].tap do |kind_of|
-            assert_instance_of Types::Logic::ReceiverIsArg, kind_of.method_types[0].type.return_type
-          end
-
-          interface.methods[:instance_of?].tap do |instance_of|
-            assert_instance_of Types::Logic::ReceiverIsArg, instance_of.method_types[0].type.return_type
-          end
-
-          interface.methods[:nil?].tap do |nilp|
-            assert_instance_of Types::Logic::ReceiverIsNil, nilp.method_types[0].type.return_type
-          end
-
-          interface.methods[:!].tap do |unot|
-            assert_instance_of Types::Logic::Not, unot.method_types[0].type.return_type
-          end
-        end
-      end
-
-      factory.type(parse_type("::WithCustomMethods")).tap do |type|
-        factory.interface(type, private: true).tap do |interface|
-          assert_instance_of Steep::Interface::Shape, interface
-
-          interface.methods[:is_a?].tap do |is_a|
-            assert_instance_of Types::Boolean, is_a.method_types[0].type.return_type
-          end
-
-          interface.methods[:kind_of?].tap do |kind_of|
-            assert_instance_of Types::Boolean, kind_of.method_types[0].type.return_type
-          end
-
-          interface.methods[:nil?].tap do |nilp|
-            assert_instance_of Types::Boolean, nilp.method_types[0].type.return_type
-          end
-
-          interface.methods[:!].tap do |unot|
-            assert_instance_of Types::Boolean, unot.method_types[0].type.return_type
-          end
         end
       end
     end

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -331,7 +331,7 @@ end
 FOO
       factory.type(parse_type("::Foo[::String]")).yield_self do |type|
         factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_overload_with interface.methods[:klass], "() -> singleton(::Foo)"
@@ -341,7 +341,7 @@ FOO
         end
 
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_overload_with interface.methods[:klass], "() -> singleton(::Foo)"
@@ -361,7 +361,7 @@ end
 FOO
       factory.type(parse_type("::_Each2[::String, ::Array[::String]]")).yield_self do |type|
         factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_equal "{ () { (::String) -> void } -> ::Array[::String] }", interface.methods[:each].to_s
@@ -380,7 +380,7 @@ end
 FOO
       factory.type(parse_type("singleton(::People)")).yield_self do |type|
         factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_overload_with interface.methods[:new], "[X] () -> ::People[X]"
@@ -402,7 +402,7 @@ FOO
 
       factory.type(parse_type("::Subject[bool]")).yield_self do |type|
         factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_overload_with interface.methods[:bar], "() -> bool"
@@ -411,7 +411,7 @@ FOO
 
       factory.type(parse_type("singleton(::Subject)")).yield_self do |type|
         factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_overload_with interface.methods[:foo], "() -> void"
@@ -425,7 +425,7 @@ FOO
     with_factory() do |factory|
       factory.type(parse_type("3")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           assert_overload_including interface.methods[:+], "(::Integer) -> ::Integer", "(::Float) -> ::Float"
@@ -443,7 +443,7 @@ FOO
     with_factory() do |factory|
       factory.type(parse_type("[::Integer, ::String]")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           assert_overload_including interface.methods[:[]],
                                     "(0) -> ::Integer",
@@ -471,7 +471,7 @@ FOO
     with_factory() do |factory|
       factory.type(parse_type("{ 1 => ::Integer, :foo => ::String, \"baz\" => bool }")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           assert_overload_including interface.methods[:[]],
                                     "(1) -> ::Integer",
@@ -503,7 +503,7 @@ FOO
     with_factory() do |factory|
       factory.type(parse_type("::Integer | ::String")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           interface.methods[:to_s].yield_self do |entry|
             assert_overload_with entry, "() -> ::String"
@@ -542,7 +542,7 @@ end
     RBS
       factory.type(parse_type("::_I1 | ::_I2")).tap do |type|
         factory.interface(type, private: false).tap do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           assert_equal Set[:g, :foo], Set.new(interface.methods.keys)
           assert_overload_with interface.methods[:g], "() -> void"
@@ -568,7 +568,7 @@ end
     RBS
       factory.type(parse_type("::_I1 & ::_I2")).tap do |type|
         factory.interface(type, private: false).tap do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           assert_equal Set[:f, :g, :h], Set.new(interface.methods.keys)
           assert_overload_with interface.methods[:f], "() -> void"
@@ -583,7 +583,7 @@ end
     with_factory() do |factory|
       factory.type(parse_type("^(String) -> Integer")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           interface.methods[:call].yield_self do |entry|
             assert_overload_with entry, "(String) -> Integer"
@@ -597,7 +597,7 @@ end
 
       factory.type(parse_type("^(String) { (Object) -> Symbol } -> Integer")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           interface.methods[:call].yield_self do |entry|
             assert_overload_with entry, "(String) { (Object) -> Symbol } -> Integer"
@@ -609,7 +609,7 @@ end
 
       factory.type(parse_type("^(String) ?{ (Object) -> Symbol } -> Integer")).yield_self do |type|
         factory.interface(type, private: false).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           interface.methods[:call].yield_self do |entry|
             assert_overload_with entry, "(String) ?{ (Object) -> Symbol } -> Integer"
@@ -712,7 +712,7 @@ end
 
       factory.type(parse_type("::Hello[::Array[Y]]", variables: [:Y])).tap do |type|
         factory.interface(type, private: true).yield_self do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
           assert_equal type, interface.type
 
           method = interface.methods[:foo]
@@ -743,7 +743,7 @@ end
 
       factory.type(parse_type("::WithBuiltinMethods")).tap do |type|
         factory.interface(type, private: true).tap do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           interface.methods[:is_a?].tap do |is_a|
             assert_instance_of Types::Logic::ReceiverIsArg, is_a.method_types[0].type.return_type
@@ -769,7 +769,7 @@ end
 
       factory.type(parse_type("::WithCustomMethods")).tap do |type|
         factory.interface(type, private: true).tap do |interface|
-          assert_instance_of Steep::Interface::Interface, interface
+          assert_instance_of Steep::Interface::Shape, interface
 
           interface.methods[:is_a?].tap do |is_a|
             assert_instance_of Types::Boolean, is_a.method_types[0].type.return_type


### PR DESCRIPTION
The goal of this pull request is to make type to shape translation more robust and consistent. It contains the following sub-goals.

* Rename `Interface::Interface` to `Interface::Shape` class to avoid class name confusion
* Simplify `Factory` class implementations that just translate the RBS data to Steep data
* Add `Interface::Builder` class that translates a `type` to a shape if possible
* Many performance tricks to make `MethodType#subst` memory conscious