### PR TITLE
Support type checking block/proc self type binding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :stackprof, optional: true do
   gem "stackprof"
 end
 gem 'minitest-slow_test'
-gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"
 
 group :ide, optional: true do
   gem "ruby-debug-ide"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :stackprof, optional: true do
   gem "stackprof"
 end
 gem 'minitest-slow_test'
-gem "rbs", path: "../rbs"
+gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"
 
 group :ide, optional: true do
   gem "ruby-debug-ide"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :stackprof, optional: true do
   gem "stackprof"
 end
 gem 'minitest-slow_test'
-gem "rbs", "~> 2.5.1"
+gem "rbs", path: "../rbs"
 
 group :ide, optional: true do
   gem "ruby-debug-ide"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ruby/rbs.git
-  revision: 05406d7e3a02e76a5dd1af3be6601c96226c65fe
+  revision: ded22b5f58b5d252f60a290a41ee7d3143216d6a
   branch: master
   specs:
     rbs (2.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../rbs
+GIT
+  remote: https://github.com/ruby/rbs.git
+  revision: 05406d7e3a02e76a5dd1af3be6601c96226c65fe
+  branch: master
   specs:
     rbs (2.6.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/ruby/rbs.git
-  revision: ded22b5f58b5d252f60a290a41ee7d3143216d6a
-  branch: master
-  specs:
-    rbs (2.6.0)
-
 PATH
   remote: .
   specs:
@@ -15,7 +8,7 @@ PATH
       parallel (>= 1.0.0)
       parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 2.3.2)
+      rbs (>= 2.7.0.pre)
       terminal-table (>= 2, < 4)
 
 GEM
@@ -51,6 +44,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbs (2.7.0.pre.1)
     ruby-debug-ide (0.7.3)
       rake (>= 0.8.1)
     stackprof (0.2.21)
@@ -69,7 +63,6 @@ DEPENDENCIES
   minitest-hooks
   minitest-slow_test
   rake
-  rbs!
   ruby-debug-ide
   stackprof
   steep!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,9 @@
 PATH
+  remote: ../rbs
+  specs:
+    rbs (2.6.0)
+
+PATH
   remote: .
   specs:
     steep (1.1.0)
@@ -44,7 +49,6 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (2.5.1)
     ruby-debug-ide (0.7.3)
       rake (>= 0.8.1)
     stackprof (0.2.21)
@@ -63,7 +67,7 @@ DEPENDENCIES
   minitest-hooks
   minitest-slow_test
   rake
-  rbs (~> 2.5.1)
+  rbs!
   ruby-debug-ide
   stackprof
   steep!

--- a/Steepfile
+++ b/Steepfile
@@ -3,4 +3,26 @@ target :app do
   signature "sig"
 
   collection_config "rbs_collection.steep.yaml"
+
+  signature "../rbs/sig", "../rbs/stdlib/rdoc/0"
+  library(
+    "set",
+    "pathname",
+    "json",
+    "logger",
+    "monitor",
+    "tsort",
+    "uri",
+    'yaml',
+    'dbm',
+    'pstore',
+    'singleton',
+    'shellwords',
+    'fileutils',
+    'find',
+    'digest',
+    "strscan",
+    "rubygems",
+    "optparse"
+  )
 end

--- a/lib/steep/interface/block.rb
+++ b/lib/steep/interface/block.rb
@@ -3,10 +3,12 @@ module Steep
     class Block
       attr_reader :type
       attr_reader :optional
+      attr_reader :self_type
 
-      def initialize(type:, optional:)
+      def initialize(type:, optional:, self_type:)
         @type = type
         @optional = optional
+        @self_type = self_type
       end
 
       def optional?
@@ -20,18 +22,19 @@ module Steep
       def to_optional
         self.class.new(
           type: type,
+          self_type: self_type,
           optional: true
         )
       end
 
       def ==(other)
-        other.is_a?(self.class) && other.type == type && other.optional == optional
+        other.is_a?(self.class) && other.type == type && other.optional == optional && other.self_type == self_type
       end
 
       alias eql? ==
 
       def hash
-        type.hash ^ optional.hash
+        type.hash ^ optional.hash ^ self_type.hash
       end
 
       def closed?
@@ -40,27 +43,28 @@ module Steep
 
       def subst(s)
         ty = type.subst(s)
-        if ty == type
+        st = self_type.subst(s) if self_type
+
+        if ty == type && st == self_type
           self
         else
-          self.class.new(
-            type: ty,
-            optional: optional
-          )
+          self.class.new(type: ty, self_type: st, optional: optional)
         end
       end
 
       def free_variables()
-        @fvs ||= type.free_variables
+        @fvs ||= type.free_variables + (self_type&.free_variables || Set[])
       end
 
       def to_s
-        "#{optional? ? "?" : ""}{ #{type.params} -> #{type.return_type} }"
+        self_binding = self_type ? "[self: #{self_type}] " : ""
+        "#{optional? ? "?" : ""}{ #{type.params} #{self_binding}-> #{type.return_type} }"
       end
 
       def map_type(&block)
         self.class.new(
           type: type.map_type(&block),
+          self_type: self_type&.map_type(&block),
           optional: optional
         )
       end
@@ -73,9 +77,15 @@ module Steep
           location: nil
         )
 
+        self_types = [self.self_type, other.self_type].compact
+
         self.class.new(
           type: type,
-          optional: optional
+          optional: optional,
+          self_type:
+            unless self_types.empty?
+              AST::Types::Union.build(types: self_types)
+            end
         )
       end
     end

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -423,7 +423,8 @@ module Steep
                       return_type: AST::Types::Var.new(name: :T),
                       location: nil
                     ),
-                    optional: false
+                    optional: false,
+                    self_type: nil
                   ),
                   method_decls: Set[]
                 )
@@ -567,7 +568,8 @@ module Steep
                       return_type: AST::Types::Var.new(name: :T),
                       location: nil
                     ),
-                    optional: false
+                    optional: false,
+                    self_type: nil
                   ),
                   method_decls: Set[]
                 )

--- a/lib/steep/interface/function.rb
+++ b/lib/steep/interface/function.rb
@@ -967,18 +967,16 @@ module Steep
         end
       end
 
-      def each_child(&block)
-        each_type(&block)
-      end
-
       def each_type(&block)
-        if block_given?
+        if block
           params.each_type(&block)
           yield return_type
         else
           enum_for :each_type
         end
       end
+
+      alias each_child each_type
 
       def map_type(&block)
         Function.new(

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -60,6 +60,9 @@ module Steep
         if block_given?
           type.each_type(&block)
           self.block&.tap do
+            if block_self = self.block&.self_type
+              yield(block_self)
+            end
             self.block.type.params.each_type(&block)
             yield(self.block.type.return_type)
           end

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -3,7 +3,6 @@ module Steep
     class Check
       attr_reader :builder
       attr_reader :cache
-      attr_reader :assumptions
 
       def initialize(builder:)
         @builder = builder
@@ -71,6 +70,10 @@ module Steep
         end
       end
 
+      def assumptions
+        @assumptions || raise
+      end
+
       def self_type
         @self_type || raise
       end
@@ -88,7 +91,7 @@ module Steep
       end
 
       def each_ancestor(ancestors, &block)
-        if block_given?
+        if block
           if ancestors.super_class
             yield ancestors.super_class
           end
@@ -107,7 +110,8 @@ module Steep
 
         subst = unless args.empty?
                   args_ = args.map {|type| factory.type_1(type) }
-                  RBS::Substitution.build(ancestors.params, args_)
+                  params = ancestors.params or raise
+                  RBS::Substitution.build(params, args_)
                 end
 
         each_ancestor(ancestors).map do |ancestor|
@@ -400,7 +404,7 @@ module Steep
                   type,
                   public_only: true,
                   config: Interface::Builder::Config.new(resolve_self: true, resolve_instance_type: true, resolve_class_type: true, variable_bounds: variable_upper_bounds)
-                )
+                ) or raise
               }
             )
           end
@@ -408,7 +412,7 @@ module Steep
         when relation.sub_type.is_a?(AST::Types::Name::Base) && relation.super_type.is_a?(AST::Types::Name::Base)
           if relation.sub_type.name == relation.super_type.name && relation.sub_type.class == relation.super_type.class
             if arg_type?(relation.sub_type) && arg_type?(relation.super_type)
-              check_type_arg(relation)
+              check_type_arg(_ = relation)
             else
               Success(relation)
             end
@@ -445,10 +449,15 @@ module Steep
             end
 
             result.add(relation.map {|p| p.block }) do |rel|
-              check_block_given(name, rel) do
+              case ret = expand_block_given(name, rel)
+              when Relation
                 Expand(rel.map {|b| b.type }) do |rel|
                   check_function(name, rel.flip)
                 end
+              when Result::Base
+                ret
+              when true
+                nil
               end
             end
           end
@@ -459,6 +468,7 @@ module Steep
 
             All(relation) do |result|
               pairs.each do |t1, t2|
+                t2 or raise
                 result.add(Relation.new(sub_type: t1, super_type: t2)) do |rel|
                   check_type(rel)
                 end
@@ -506,7 +516,7 @@ module Steep
                     resolve_instance_type: true,
                     variable_bounds: variable_upper_bounds
                   )
-                )
+                ) or raise
               }
             )
           end
@@ -541,15 +551,13 @@ module Steep
       end
 
       def definition_for_type(type)
-        type_name = type.name
-
         case type
         when AST::Types::Name::Instance
-          factory.definition_builder.build_instance(type_name)
+          factory.definition_builder.build_instance(type.name)
         when AST::Types::Name::Singleton
-          factory.definition_builder.build_singleton(type_name)
+          factory.definition_builder.build_singleton(type.name)
         when AST::Types::Name::Interface
-          factory.definition_builder.build_interface(type_name)
+          factory.definition_builder.build_interface(type.name)
         else
           raise
         end
@@ -642,18 +650,6 @@ module Steep
         end
       end
 
-      def check_type_application(result, type_params, type_args)
-        raise unless type_params.size == type_args.size
-
-        rels = type_params.zip(type_args).filter_map do |(param, arg)|
-          if ub = param.upper_bound
-            Relation.new(sub_type: arg, super_type: ub.subst(sub))
-          end
-        end
-
-        result.add(*rels) {|rel| check_type(rel) } and yield
-      end
-
       def check_generic_method_type(name, relation)
         relation.method!
 
@@ -675,7 +671,9 @@ module Steep
 
             relation = Relation.new(sub_type: sub_type_, super_type: super_type)
             All(relation) do |result|
-              sub_args.zip(sub_type.type_params).each do |(arg, param)|
+              sub_args.zip(sub_type.type_params).each do |arg, param|
+                param or raise
+
                 if ub = param.upper_bound
                   result.add(Relation.new(sub_type: arg, super_type: ub)) do |rel|
                     check_type(rel)
@@ -683,23 +681,10 @@ module Steep
                 end
               end
 
-              match_method_type(name, relation) do |pairs|
-                rels =
-                  pairs.each.with_object([]) do |(sub, sup), rels|
-                    rels << Relation.new(sub_type: sub, super_type: sup)
-                    rels << Relation.new(sub_type: sup, super_type: sub)
-                  end
-
-                result.add(*rels) do |rel|
-                  check_type(rel)
-                end
-
-                result.add(Relation.new(sub_type: sub_type_, super_type: super_type)) do |rel|
-                  check_method_type(
-                    name,
-                    Relation.new(sub_type: sub_type_, super_type: super_type)
-                  )
-                end
+              if failure = match_method_type_fails?(name, sub_type_, super_type)
+                result.add_result(failure)
+              else
+                result.add_result(check_method_type(name, Relation(sub_type_, super_type)))
               end
 
               result.add(relation) do |rel|
@@ -714,22 +699,25 @@ module Steep
 
         when sub_type.type_params.empty? && !super_type.type_params.empty?
           # Check if sub_type is an instance of super_type && no constraints on type variables (any).
-          Expand(relation) do
-            match_method_type(name, relation) do
-              sub_args = sub_type.type_params.map {|param| AST::Types::Var.fresh(param.name) }
-              sub_type_ = sub_type.instantiate(Interface::Substitution.build(sub_type.type_params.map(&:name), sub_args))
+          All(relation) do |result|
+            super_args = super_type.type_params.map {|param| AST::Types::Var.fresh(param.name) }
+            super_type_ = super_type.instantiate(Interface::Substitution.build(super_type.type_params.map(&:name), super_args))
 
-              sub_args.each do |arg|
+            if failure = match_method_type_fails?(name, sub_type, super_type_)
+              result.add_result(failure)
+            else
+              super_args.each do |arg|
                 constraints.unknown!(arg.name)
               end
 
-              rel_ = Relation.new(sub_type: sub_type_, super_type: super_type)
-              result = check_method_type(name, rel_)
+              result.add(Relation(sub_type, super_type_)) do |rel_|
+                ret = check_method_type(name, rel_)
 
-              if result.success? && sub_args.map(&:name).none? {|var| constraints.has_constraint?(var) }
-                result
-              else
-                Failure(rel_, Result::Failure::PolyMethodSubtyping.new(name: name))
+                if ret.success? && super_args.map(&:name).none? {|var| constraints.has_constraint?(var) }
+                  ret
+                else
+                  Failure(rel_, Result::Failure::PolyMethodSubtyping.new(name: name))
+                end
               end
             end
           end
@@ -754,9 +742,9 @@ module Steep
               when sub_ub && !sup_ub
                 upper_bounds[arg.name] = sub_ub
               when !sub_ub && sup_ub
-                result.add(
-                  Failure(relation, Result::Failure::PolyMethodSubtyping.new(name: name))
-                )
+                result.add(Relation.new(sub_type: AST::Types::Var.new(name: sub_param.name), super_type: sub_ub)) do |rel|
+                  Failure(rel, Result::Failure::PolyMethodSubtyping.new(name: name))
+                end
               when !sub_ub && !sup_ub
                 # no constraints
               end
@@ -800,33 +788,43 @@ module Steep
 
         sub_type, super_type = relation
 
+        sub_type.type_params.empty? or raise "Expected monomorphic method type: #{sub_type}"
+        super_type.type_params.empty? or raise "Expected monomorphic method type: #{super_type}"
+
         All(relation) do |result|
           result.add(Relation.new(sub_type: sub_type.type, super_type: super_type.type)) do |rel|
             check_function(name, rel)
           end
 
           result.add(Relation.new(sub_type: sub_type.block, super_type: super_type.block)) do |rel|
-            check_block_given(name, rel) do
-              Expand(Relation.new(sub_type: super_type.block.type, super_type: sub_type.block.type)) do |rel|
-                check_function(name, rel)
+            ret = expand_block_given(name, rel)
+
+            case ret
+            when Relation
+              Expand(ret) do
+                check_function(name, Relation(ret.super_type.type, ret.sub_type.type))
               end
+            when Result::Base
+              ret
+            else
+              nil
             end
           end
         end
       end
 
-      def check_block_given(name, relation, &block)
+      def expand_block_given(name, relation, &block)
         relation.block!
 
         sub_block, super_block = relation
 
         case
         when !super_block && !sub_block
-          Success(relation)
+          true
         when super_block && sub_block && super_block.optional? == sub_block.optional?
-          Expand(relation, &block)
+          Relation.new(sub_type: sub_block, super_type: super_block)
         when sub_block&.optional?
-          Success(relation)
+          true
         else
           Failure(relation, Result::Failure::BlockMismatchError.new(name: name))
         end
@@ -854,7 +852,7 @@ module Steep
         when Array
           unless pairs.empty?
             All(relation) do |result|
-              pairs.each do |(sub_type, super_type)|
+              pairs.each do |sub_type, super_type|
                 result.add(Relation.new(sub_type: super_type, super_type: sub_type)) do |rel|
                   check_type(rel)
                 end
@@ -870,38 +868,25 @@ module Steep
         end
       end
 
-      # ```rbs
-      # (Symbol, Relation[MethodType]) -> (Array[[Symbol, Symbol]] | Result::t)
-      # [A] (Symbol, Relation[MethodType]) { (Array[[Symbol, Symbol]]) -> A } -> (A | Result::t)
-      # ````
-      def match_method_type(name, relation)
-        relation.method!
+      def Relation(sub, sup)
+        Relation.new(sub_type: sub, super_type: sup)
+      end
 
-        sub_type, super_type = relation
-
-        pairs = []
-
-        match_params(name, relation.map {|m| m.type.params }).tap do |param_pairs|
+      def match_method_type_fails?(name, type1, type2)
+        match_params(name, Relation(type1.type.params, type2.type.params)).tap do |param_pairs|
           return param_pairs unless param_pairs.is_a?(Array)
-
-          pairs.push(*param_pairs)
-          pairs.push [sub_type.type.return_type, super_type.type.return_type]
         end
 
-        check_block_given(name, relation.map {|m| m.block }) do |rel|
-          match_params(name, rel.map {|m| m.type.params }).tap do |param_pairs|
+        case result = expand_block_given(name, Relation(type1.block, type2.block))
+        when Result::Base
+          return result
+        when Relation
+          match_params(name, result.map {|m| m.type.params }).tap do |param_pairs|
             return param_pairs unless param_pairs.is_a?(Array)
-
-            pairs.push(*param_pairs)
-            pairs.push [sub_type.type.return_type, super_type.type.return_type]
           end
         end
 
-        if block_given?
-          yield pairs
-        else
-          pairs
-        end
+        nil
       end
 
       def match_params(name, relation)

--- a/lib/steep/subtyping/result.rb
+++ b/lib/steep/subtyping/result.rb
@@ -259,6 +259,12 @@ module Steep
           end
         end
 
+        class SelfBindingMismatch
+          def message
+            "Self binding is incompatible"
+          end
+        end
+
         attr_reader :error
 
         def initialize(relation, error)

--- a/lib/steep/subtyping/result.rb
+++ b/lib/steep/subtyping/result.rb
@@ -15,6 +15,7 @@ module Steep
         def then
           if success?
             yield self
+            self
           else
             self
           end
@@ -23,6 +24,7 @@ module Steep
         def else
           if failure?
             yield self
+            self
           else
             self
           end
@@ -83,7 +85,9 @@ module Steep
           relations.each do |relation|
             if success?
               result = yield(relation)
-              branches << result
+              if result
+                branches << result
+              end
             else
               # Already failed.
               branches << Skip.new(relation)
@@ -92,6 +96,10 @@ module Steep
 
           # No need to test more branches if already failed.
           success?
+        end
+
+        def add_result(result)
+          add(result.relation) { result }
         end
 
         def success?
@@ -104,7 +112,7 @@ module Steep
 
         def failure_path(path = [])
           if failure?
-            r = branches.find(&:failure?)
+            r = branches.find(&:failure?) or raise
             path.unshift(self)
             r.failure_path(path)
           end

--- a/lib/steep/subtyping/result.rb
+++ b/lib/steep/subtyping/result.rb
@@ -99,7 +99,11 @@ module Steep
         end
 
         def add_result(result)
-          add(result.relation) { result }
+          if result
+            add(result.relation) { result }
+          else
+            success?
+          end
         end
 
         def success?

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -347,6 +347,8 @@ module Steep
       if implement_module_name
         module_entry = checker.factory.definition_builder.env.class_decls[implement_module_name.name]
 
+        raise unless module_entry.is_a?(RBS::Environment::ModuleEntry)
+
         module_context = module_context.update(
           instance_type: AST::Types::Intersection.build(
             types: [

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1613,7 +1613,8 @@ module Steep
             if block_type = method_context.block_type
               type = AST::Types::Proc.new(
                 type: block_type.type,
-                block: nil
+                block: nil,
+                self_type: block_type.self_type
               )
               args = TypeInference::SendArgs.new(
                 node: node,

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2740,8 +2740,9 @@ module Steep
         block_type_hint: return_hint,
         block_block_hint: block_hint,
         block_annotations: block_annotations,
+        block_self_hint: self_hint,
         node_type_hint: nil
-      ).update_context {|con| con.with(self_type: self_hint) }
+      )
 
       block_constr.typing.add_context_for_body(node, context: block_constr.context)
 
@@ -3429,6 +3430,7 @@ module Steep
                 block_type_hint: method_type.block.type.return_type,
                 block_block_hint: nil,
                 block_annotations: block_annotations,
+                block_self_hint: nil,
                 node_type_hint: method_type.type.return_type
               )
               block_constr = block_constr.with_new_typing(
@@ -3730,6 +3732,7 @@ module Steep
         block_type_hint: nil,
         block_block_hint: nil,
         block_annotations: block_annotations,
+        block_self_hint: nil,
         node_type_hint: nil
       )
 
@@ -3779,7 +3782,7 @@ module Steep
       end
     end
 
-    def for_block(body_node, block_params:, block_param_hint:, block_type_hint:, block_block_hint:, block_annotations:, node_type_hint:)
+    def for_block(body_node, block_params:, block_param_hint:, block_type_hint:, block_block_hint:, block_annotations:, node_type_hint:, block_self_hint:)
       block_param_pairs = block_param_hint && block_params.zip(block_param_hint, block_block_hint)
 
       # @type var param_types_hash: Hash[Symbol, AST::Types::t]
@@ -3860,7 +3863,7 @@ module Steep
         next_type: block_context.body_type || AST::Builtin.any_type
       )
 
-      self_type = self.self_type
+      self_type = block_annotations.self_type || block_self_hint || self.self_type
       module_context = self.module_context
 
       if implements = block_annotations.implement_module_annotation

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -277,17 +277,10 @@ module Steep
 
           if block_param
             if block
-              proc_type =
-                if block.optional?
-                  AST::Types::Union.build(
-                    types: [
-                      AST::Types::Proc.new(type: block.type, block: nil),
-                      AST::Builtin.nil_type
-                    ]
-                  )
-                else
-                  AST::Types::Proc.new(type: block.type, block: nil)
-                end
+              proc_type = AST::Types::Proc.new(type: block.type, block: nil, self_type: block.self_type)
+              if block.optional?
+                proc_type = AST::Types::Union.build(types: [proc_type, AST::Builtin.nil_type])
+              end
 
               zip << [block_param, proc_type]
             else

--- a/lib/steep/type_inference/send_args.rb
+++ b/lib/steep/type_inference/send_args.rb
@@ -473,7 +473,7 @@ module Steep
         def node_type
           raise unless block
 
-          type = AST::Types::Proc.new(type: block.type, block: nil)
+          type = AST::Types::Proc.new(type: block.type, block: nil, self_type: block.self_type)
 
           if block.optional?
             type = AST::Types::Union.build(types: [type, AST::Builtin.nil_type])

--- a/lib/steep/type_inference/type_env_builder.rb
+++ b/lib/steep/type_inference/type_env_builder.rb
@@ -125,7 +125,7 @@ module Steep
       attr_reader :commands
 
       def initialize(*commands)
-        @commands = commands
+        @commands = commands.compact
       end
 
       def build(type_env)

--- a/rbs_collection.steep.lock.yaml
+++ b/rbs_collection.steep.lock.yaml
@@ -10,16 +10,12 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: rbs
-  version: 2.5.1
-  source:
-    type: rubygems
 - name: activesupport
   version: '6.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 933f7176968d8620224c0b22baefadbd7d77ef27
+    revision: e59b7d94d326a1ac66c6bce8cb82cbabf1734726
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -27,7 +23,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 933f7176968d8620224c0b22baefadbd7d77ef27
+    revision: e59b7d94d326a1ac66c6bce8cb82cbabf1734726
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -35,7 +31,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 933f7176968d8620224c0b22baefadbd7d77ef27
+    revision: e59b7d94d326a1ac66c6bce8cb82cbabf1734726
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: listen
@@ -43,7 +39,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 933f7176968d8620224c0b22baefadbd7d77ef27
+    revision: e59b7d94d326a1ac66c6bce8cb82cbabf1734726
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parallel
@@ -51,7 +47,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 933f7176968d8620224c0b22baefadbd7d77ef27
+    revision: e59b7d94d326a1ac66c6bce8cb82cbabf1734726
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -59,33 +55,9 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 933f7176968d8620224c0b22baefadbd7d77ef27
+    revision: e59b7d94d326a1ac66c6bce8cb82cbabf1734726
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: logger
-  version: '0'
-  source:
-    type: stdlib
-- name: pathname
-  version: '0'
-  source:
-    type: stdlib
-- name: json
-  version: '0'
-  source:
-    type: stdlib
-- name: optparse
-  version: '0'
-  source:
-    type: stdlib
-- name: rubygems
-  version: '0'
-  source:
-    type: stdlib
-- name: tsort
-  version: '0'
-  source:
-    type: stdlib
 - name: monitor
   version: '0'
   source:
@@ -98,11 +70,19 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: logger
+  version: '0'
+  source:
+    type: stdlib
 - name: mutex_m
   version: '0'
   source:
     type: stdlib
 - name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: pathname
   version: '0'
   source:
     type: stdlib

--- a/rbs_collection.steep.yaml
+++ b/rbs_collection.steep.yaml
@@ -15,5 +15,6 @@ gems:
     ignore: true
   - name: set
   - name: rbs
+    ignore: true
   - name: with_steep_types
     ignore: true

--- a/sig/steep.rbs
+++ b/sig/steep.rbs
@@ -1,5 +1,5 @@
 module Steep
-  def self.logger: () -> ActiveSupport::TaggedLogging
+  def self.logger: () -> (Logger & _TaggedLogging)
 
   def self.new_logger: (untyped output, untyped prev_level) -> untyped
 
@@ -10,6 +10,10 @@ module Steep
   def self.measure: (untyped message, ?level: ::Symbol) { () -> untyped } -> untyped
 
   def self.log_error: (untyped exn, ?message: ::String) -> untyped
+
+  interface _TaggedLogging
+    def tagged: [A] (*String) { () -> A } -> A
+  end
 
   class Sampler
     def initialize: () -> void
@@ -29,4 +33,3 @@ module Steep
 
   def self.measure2: (untyped message, ?level: ::Symbol) { (untyped) -> untyped } -> untyped
 end
-

--- a/sig/steep/ast/annotation/collection.rbs
+++ b/sig/steep/ast/annotation/collection.rbs
@@ -40,17 +40,17 @@ module Steep
 
         def method_type: (untyped name) -> (untyped | nil)
 
-        def block_type: () -> untyped
+        %a{pure} def block_type: () -> Types::t?
 
-        def return_type: () -> untyped
+        %a{pure} def return_type: () -> Types::t?
 
-        def self_type: () -> untyped
+        %a{pure} def self_type: () -> Types::t?
 
-        def instance_type: () -> untyped
+        %a{pure} def instance_type: () -> Types::t?
 
-        def module_type: () -> untyped
+        %a{pure} def module_type: () -> Types::t?
 
-        def break_type: () -> untyped
+        %a{pure} def break_type: () -> Types::t?
 
         def lvar_types: () -> untyped
 

--- a/sig/steep/ast/types/factory.rbs
+++ b/sig/steep/ast/types/factory.rbs
@@ -2,6 +2,10 @@ module Steep
   module AST
     module Types
       class Factory
+        @env: RBS::Environment
+
+        @type_name_resolver: RBS::Resolver::TypeNameResolver
+
         attr_reader definition_builder: RBS::DefinitionBuilder
 
         attr_reader type_cache: Hash[RBS::Types::t, t]
@@ -16,11 +20,13 @@ module Steep
 
         def type_name_resolver: () -> RBS::Resolver::TypeNameResolver
 
-        def type_opt: (RBS::Types::t? `type`) -> t?
-
         def type: (RBS::Types::t `type`) -> t
 
+        def type_opt: (RBS::Types::t? `type`) -> t?
+
         def type_1: (t `type`) -> RBS::Types::t
+
+        def type_1_opt: (t?) -> RBS::Types::t?
 
         def function_1: (Interface::Function func) -> RBS::Types::Function
 
@@ -31,7 +37,7 @@ module Steep
         def type_param_1: (Interface::TypeParam type_param) -> RBS::AST::TypeParam
 
         @method_type_cache: Hash[RBS::MethodType, Interface::MethodType]
-        
+
         def method_type: (RBS::MethodType method_type, method_decls: Set[TypeInference::MethodCall::MethodDecl]) -> Interface::MethodType
 
         def method_type_1: (Interface::MethodType method_type) -> RBS::MethodType

--- a/sig/steep/ast/types/intersection.rbs
+++ b/sig/steep/ast/types/intersection.rbs
@@ -8,7 +8,7 @@ module Steep
 
         def initialize: (types: untyped, ?location: untyped?) -> void
 
-        def self.build: (types: untyped, ?location: untyped?) -> untyped
+        def self.build: (types: Array[t], ?location: untyped?) -> t
 
         def ==: (untyped other) -> untyped
 

--- a/sig/steep/ast/types/proc.rbs
+++ b/sig/steep/ast/types/proc.rbs
@@ -6,9 +6,11 @@ module Steep
 
         attr_reader type: Interface::Function
 
+        attr_reader self_type: AST::Types::t?
+
         attr_reader block: Interface::Block?
 
-        def initialize: (type: Interface::Function, block: Interface::Block?, ?location: untyped) -> void
+        def initialize: (type: Interface::Function, self_type: AST::Types::t?, block: Interface::Block?, ?location: untyped) -> void
 
         def ==: (untyped other) -> bool
 

--- a/sig/steep/interface/block.rbs
+++ b/sig/steep/interface/block.rbs
@@ -3,9 +3,11 @@ module Steep
     class Block
       attr_reader type: Function
 
+      attr_reader self_type: AST::Types::t?
+
       attr_reader optional: bool
 
-      def initialize: (type: Function, optional: bool) -> void
+      def initialize: (type: Function, self_type: AST::Types::t?, optional: bool) -> void
 
       def optional?: () -> bool
 

--- a/sig/steep/interface/function.rbs
+++ b/sig/steep/interface/function.rbs
@@ -178,7 +178,7 @@ module Steep
 
         def has_keywords?: () -> untyped
 
-        def each_positional_param: () { () -> untyped } -> (untyped | nil | untyped)
+        def each_positional_param: () { (PositionalParams::Base) -> void } -> void
 
         def without_keywords: () -> untyped
 
@@ -197,16 +197,16 @@ module Steep
 
         def to_s: () -> ::String
 
-        def map_type: () { () -> untyped } -> untyped
+        def map_type: () { (AST::Types::t) -> AST::Types::t } -> Params
 
-        def empty?: () -> untyped
+        def empty?: () -> bool
 
         # Returns true if all arguments are non-required.
-        def optional?: () -> untyped
+        def optional?: () -> bool
 
         # self + params returns a new params for overloading.
         #
-        def +: (untyped other) -> untyped
+        def +: (Params other) -> Params
 
         # Returns the intersection between self and other.
         # Returns nil if the intersection cannot be computed.
@@ -216,7 +216,7 @@ module Steep
         #
         # `self & other` accept `arg` if `arg` is acceptable for both of `self` and `other`.
         #
-        def &: (untyped other) -> (nil | untyped)
+        def &: (Params other) -> Params?
 
         # Returns the union between self and other.
         #
@@ -225,34 +225,37 @@ module Steep
         #
         # `self | other` accept `arg` if `self` accepts `arg` or `other` accepts `arg`.
         #
-        def |: (untyped other) -> (nil | untyped)
+        def |: (Params other) -> Params?
       end
 
-      attr_reader params: untyped
+      type location = RBS::Location[untyped, untyped]
+
+      attr_reader params: Params
 
       attr_reader return_type: AST::Types::t
 
-      attr_reader location: untyped
+      attr_reader location: location?
 
-      def initialize: (params: untyped, return_type: untyped, location: untyped) -> void
+      def initialize: (params: Params, return_type: AST::Types::t, location: location?) -> void
 
-      def ==: (untyped other) -> untyped
+      def ==: (untyped other) -> bool
 
       alias eql? ==
 
-      def hash: () -> untyped
+      def hash: () -> Integer
 
       def free_variables: () -> Set[Symbol]
 
       def subst: (Substitution s) -> Function
 
-      def each_child: () { () -> untyped } -> untyped
+      alias each_child each_type
 
-      def each_type: () { (untyped) -> untyped } -> untyped
+      def each_type: () { (AST::Types::t) -> void } -> void
+                   | () -> Enumerator[AST::Types::t, void]
 
-      def map_type: () { (untyped) -> untyped } -> untyped
+      def map_type: () { (AST::Types::t) -> AST::Types::t } -> Function
 
-      def with: (?params: untyped, ?return_type: untyped) -> untyped
+      def with: (?params: Params, ?return_type: AST::Types::t) -> Function
 
       def to_s: () -> ::String
 

--- a/sig/steep/subtyping/check.rbs
+++ b/sig/steep/subtyping/check.rbs
@@ -3,25 +3,25 @@ module Steep
     class Check
       attr_reader builder: Interface::Builder
 
-      attr_reader cache: untyped
+      attr_reader cache: Cache
 
-      attr_reader assumptions: untyped
+      @assumptions: Set[Relation[untyped]]?
 
       @bounds: Array[Hash[Symbol, AST::Types::t?]]
+
+      @self_type: AST::Types::t?
+
+      @instance_type: AST::Types::t?
+
+      @class_type: AST::Types::t?
+
+      @constraints: Constraints?
 
       def initialize: (builder: Interface::Builder) -> void
 
       def factory: () -> AST::Types::Factory
 
-      def with_context: (self_type: untyped, instance_type: untyped, class_type: untyped, constraints: untyped) { () -> untyped } -> untyped
-
-      def push_assumption: (untyped relation) { () -> untyped } -> untyped
-
-      def push_variable_bounds: [A] (Array[Interface::TypeParam] | Hash[Symbol, AST::Types::t?] params) { () -> A } -> A
-
-      def variable_upper_bound: (Symbol name) -> AST::Types::t?
-
-      def variable_upper_bounds: () -> Hash[Symbol, AST::Types::t?]
+      def with_context: [A] (self_type: AST::Types::t, instance_type: AST::Types::t, class_type: AST::Types::t, constraints: Constraints) { () -> A } -> A
 
       def self_type: () -> AST::Types::t
 
@@ -29,71 +29,94 @@ module Steep
 
       def class_type: () -> AST::Types::t
 
-      def constraints: () -> untyped
+      def constraints: () -> Constraints
 
-      def each_ancestor: (untyped ancestors) { (untyped) -> untyped } -> untyped
+      def push_variable_bounds: [A] (Array[Interface::TypeParam] | Hash[Symbol, AST::Types::t?] params) { () -> A } -> A
 
-      def instance_super_types: (untyped type_name, args: untyped) -> untyped
+      def variable_upper_bound: (Symbol name) -> AST::Types::t?
 
-      def singleton_super_types: (untyped type_name) -> untyped
+      def variable_upper_bounds: () -> Hash[Symbol, AST::Types::t?]
 
-      def check: (untyped relation, constraints: untyped, self_type: untyped, instance_type: untyped, class_type: untyped) -> untyped
+      def push_assumption: [A] (Relation[untyped] relation) { () -> A } -> A
 
-      def check_type: (untyped relation) -> untyped
+      def assumptions: () -> Set[Relation[untyped]]
 
-      def cache_bounds: (untyped relation) -> untyped
+      def each_ancestor: (RBS::DefinitionBuilder::AncestorBuilder::OneAncestors ancestors) { (RBS::Definition::Ancestor::t) -> void } -> void
+                       | (RBS::DefinitionBuilder::AncestorBuilder::OneAncestors ancestors) -> Enumerator[RBS::Definition::Ancestor::t, void]
 
-      def alias?: (untyped `type`) -> untyped
+      type super_type = AST::Types::Name::Instance | AST::Types::Name::Interface | AST::Types::Name::Singleton
 
-      def cacheable?: (untyped relation) -> untyped
+      def instance_super_types: (RBS::TypeName type_name, args: Array[AST::Types::t]) -> Array[super_type]
 
-      def true_type?: (untyped `type`) -> untyped
+      def singleton_super_types: (RBS::TypeName type_name) -> Array[super_type]
 
-      def false_type?: (untyped `type`) -> untyped
+      def check: (Relation[AST::Types::t] relation, constraints: Constraints, self_type: AST::Types::t, instance_type: AST::Types::t, class_type: AST::Types::t) -> Result::t
+
+      def check_type: (Relation[AST::Types::t] relation) -> Result::t
+
+      def cache_bounds: (Relation[AST::Types::t] relation) -> Hash[Symbol, AST::Types::t?]
+
+      def alias?: (AST::Types::t `type`) -> bool
+
+      def cacheable?: (Relation[AST::Types::t] relation) -> bool
+
+      def true_type?: (AST::Types::t `type`) -> bool
+
+      def false_type?: (AST::Types::t `type`) -> bool
 
       include Result::Helper
 
-      def check_type0: (untyped relation) -> untyped
+      def check_type0: (Relation[AST::Types::t] relation) -> Result::t
 
-      def definition_for_type: (untyped `type`) -> untyped
+      def definition_for_type: (AST::Types::t `type`) -> RBS::Definition
 
-      def arg_type?: (untyped `type`) -> untyped
+      # Returns true if given `type` is with one or more type arguments.
+      #
+      def arg_type?: (AST::Types::t `type`) -> bool
 
-      def check_type_arg: (untyped relation) -> untyped
+      type application_type = AST::Types::Name::Instance | AST::Types::Name::Interface | AST::Types::Name::Alias
 
-      def same_type?: (untyped relation) -> (true | untyped)
+      def check_type_arg: (Relation[application_type] relation) -> untyped
+
+      def same_type?: (Relation[AST::Types::t] relation) -> bool
 
       def check_interface: (Relation[Interface::Shape] relation) -> Result::t
 
-      def check_method: (untyped name, untyped relation) -> untyped
+      def check_method: (Symbol name, Relation[Interface::Shape::Entry] relation) -> Result::t
 
-      def check_type_application: (untyped result, untyped type_params, untyped type_args) { () -> untyped } -> untyped
+      def check_generic_method_type: (Symbol name, Relation[Interface::MethodType] relation) -> Result::t
 
-      def check_generic_method_type: (untyped name, untyped relation) -> untyped
+      def check_constraints: (Relation[untyped] relation, variables: Enumerable[Symbol], variance: VariableVariance) -> Result::t
 
-      def check_constraints: (untyped relation, variables: untyped, variance: untyped) -> untyped
+      def check_method_type: (Symbol name, Relation[Interface::MethodType] relation) -> Result::t
 
-      def check_method_type: (untyped name, untyped relation) -> untyped
+      # Receives subtyping relation of blocks `b <: b'` where `b` and `b'` are expanded from
+      # subtyping relation of two method types `(...) _b_ -> T <: (...) _b'_ -> S`.
+      #
+      # Returns `true` is the relation is satisfied immediately.
+      # Returns a Relation when the given relation can be expanded to relation between Interface::Block.
+      # Returns a failure otherwise.
+      #
+      def expand_block_given: (Symbol name, Relation[Interface::Block?] relation) -> (Relation[Interface::Block] | true | Result::t)
 
-      def check_block_given: (untyped name, untyped relation) { () -> untyped } -> untyped
+      def check_function: (Symbol name, Relation[Interface::Function] relation) -> Result::t
 
-      def check_function: (untyped name, untyped relation) -> untyped
+      def check_method_params: (Symbol name, Relation[Interface::Function::Params] relation) -> Result::t
 
-      def check_method_params: (untyped name, untyped relation) -> untyped
+      # Returns `nil` when given two method_types are structually comparable.
+      # Returns a failure otherwise.
+      #
+      def match_method_type_fails?: (Symbol name, Interface::MethodType method_type1, Interface::MethodType method_type2) -> (nil | Result::t)
 
-      # ```rbs
-      # (Symbol, Relation[MethodType]) -> (Array[[Symbol, Symbol]] | Result::t)
-      # [A] (Symbol, Relation[MethodType]) { (Array[[Symbol, Symbol]]) -> A } -> (A | Result::t)
-      # ````
-      def match_method_type: (untyped name, untyped relation) { (untyped) -> untyped } -> untyped
+      def match_params: (Symbol name, Relation[Interface::Function::Params] relation) -> (Array[[AST::Types::t, AST::Types::t]] | Result::t)
 
-      def match_params: (untyped name, untyped relation) -> untyped
-
-      def expand_alias: (untyped `type`) { () -> untyped } -> untyped
+      def expand_alias: (AST::Types::t `type`) -> AST::Types::t
 
       # Returns the shortest type paths for one of the _unknown_ type variables.
       # Returns nil if there is no path.
-      def hole_path: (untyped `type`, ?untyped path) -> untyped
+      def hole_path: (AST::Types::t `type`, ?Array[AST::Types::t] path) -> Array[AST::Types::t]?
+
+      def Relation: [T < Object] (T sub, T sup) -> Relation[T]
     end
   end
 end

--- a/sig/steep/subtyping/check.rbs
+++ b/sig/steep/subtyping/check.rbs
@@ -99,6 +99,13 @@ module Steep
       #
       def expand_block_given: (Symbol name, Relation[Interface::Block?] relation) -> (Relation[Interface::Block] | true | Result::t)
 
+      # Receives a subtyping relation between self bindings `S <: S'` that is included in procs or blocks as:
+      #
+      # *             `^() [self: S] -> T <: ^() [self: S'] -> T`           (proc)
+      # * `() { () [self: S'] -> T } -> T <: () { () [self: S] -> T } -> T` (block in method type)
+      #
+      def check_self_type_binding: (Relation[untyped], AST::Types::t? sub_self, AST::Types::t? super_self) -> Result::t?
+
       def check_function: (Symbol name, Relation[Interface::Function] relation) -> Result::t
 
       def check_method_params: (Symbol name, Relation[Interface::Function::Params] relation) -> Result::t

--- a/sig/steep/subtyping/relation.rbs
+++ b/sig/steep/subtyping/relation.rbs
@@ -1,51 +1,53 @@
 module Steep
   module Subtyping
-    class Relation[T]
-      attr_reader sub_type: T
+    class Relation[out Subject < Object]
+      attr_reader sub_type: Subject
 
-      attr_reader super_type: T
+      attr_reader super_type: Subject
 
-      def initialize: (sub_type: T, super_type: T) -> void
+      def initialize: (sub_type: Subject, super_type: Subject) -> void
 
-      def hash: () -> untyped
+      def hash: () -> Integer
 
-      def ==: (untyped other) -> untyped
+      def ==: (untyped other) -> bool
 
       alias eql? ==
 
       def to_s: () -> ::String
 
-      def to_ary: () -> [T, T]
+      def to_ary: () -> [Subject, Subject]
 
-      def type?: () -> untyped
+      def type?: () -> bool
 
-      def interface?: () -> untyped
+      def interface?: () -> bool
 
-      def method?: () -> untyped
+      def method?: () -> bool
 
-      def function?: () -> untyped
+      def function?: () -> bool
 
-      def params?: () -> untyped
+      def params?: () -> bool
 
-      def block?: () -> untyped
+      def block?: () -> bool
 
-      def assert_type: (untyped `type`) -> (untyped | nil)
+      type relation_type = :type | :interface | :method | :function | :params | :block
 
-      def type!: () -> untyped
+      def assert_type: (relation_type `type`) -> void
 
-      def interface!: () -> untyped
+      def type!: () -> void
 
-      def method!: () -> untyped
+      def interface!: () -> void
 
-      def function!: () -> untyped
+      def method!: () -> void
 
-      def params!: () -> untyped
+      def function!: () -> void
 
-      def block!: () -> untyped
+      def params!: () -> void
 
-      def map: [S] () { (T) -> S } -> Relation[S]
+      def block!: () -> void
 
-      def flip: () -> Relation[T]
+      def map: [T < Object] () { (Subject) -> T } -> Relation[T]
+
+      def flip: () -> Relation[Subject]
     end
   end
 end

--- a/sig/steep/subtyping/result.rbs
+++ b/sig/steep/subtyping/result.rbs
@@ -4,19 +4,19 @@ module Steep
       type t = Skip | Expand | All | Any | Success | Failure
 
       class Base
-        attr_reader relation: Relation
+        attr_reader relation: Relation[untyped]
 
-        def initialize: (Relation relation) -> void
+        def initialize: (Relation[untyped] relation) -> void
 
         def failure?: () -> bool
 
         def success?: () -> bool
 
-        def then: [A] () { (self) -> A } -> A
+        def then: () { (self) -> void } -> self
 
-        def else: [A] () { (self) -> A } -> A
+        def else: () { (self) -> void } -> self
 
-        def failure_path: (?untyped path) -> untyped
+        def failure_path: (?Array[t] path) -> Array[t]?
       end
 
       class Skip < Base
@@ -28,50 +28,60 @@ module Steep
       end
 
       class Expand < Base
-        attr_reader child: untyped
+        attr_reader child: t
 
-        def initialize: (untyped relation) { (untyped) -> untyped } -> void
+        def initialize: (Relation[untyped] relation) { (Relation[untyped]) -> t } -> void
 
-        def success?: () -> untyped
+        def success?: () -> bool
 
-        def failure_path: (?untyped path) -> (untyped | nil)
+        def failure_path: (?Array[t] path) -> Array[t]?
       end
 
       class All < Base
-        attr_reader branches: untyped
+        attr_reader branches: Array[t]
 
-        def initialize: (untyped relation) -> void
+        def initialize: (Relation[untyped] relation) -> void
+
+        @failure: bool
 
         # Returns `false` if no future `#add` changes the result.
-        def add: (*untyped relations) { (untyped) -> untyped } -> untyped
+        def add: [T < Object] (*Relation[T] relations) { (Relation[T]) -> t? } -> bool
 
-        def success?: () -> untyped
+        # Returns `false` if no future `#add` changes the result.
+        def add_result: (t) -> bool
 
-        def failure?: () -> untyped
+        def success?: () -> bool
 
-        def failure_path: (?untyped path) -> (untyped | nil)
+        def failure?: () -> bool
+
+        def failure_path: (?Array[t] path) -> Array[t]?
       end
 
       class Any < Base
-        attr_reader branches: untyped
+        attr_reader branches: Array[t]
 
-        def initialize: (untyped relation) -> void
+        def initialize: (Relation[untyped] relation) -> void
+
+        @success: bool
 
         # Returns `false` if no future `#add` changes the result.
-        def add: (*untyped relations) { (untyped) -> untyped } -> untyped
+        def add: [T < Object] (*Relation[T] relations) { (Relation[T]) -> t } -> bool
 
-        def success?: () -> untyped
+        def success?: () -> bool
 
-        def failure_path: (?untyped path) -> (untyped | nil)
+        def failure_path: (?Array[t] path) -> Array[t]?
       end
 
       class Success < Base
         def success?: () -> true
 
-        def failure_path: (?untyped path) -> nil
+        def failure_path: (?Array[t] path) -> Array[t]?
       end
 
       class Failure < Base
+        type error = MethodMissingError | BlockMismatchError | ParameterMismatchError
+                   | UnknownPairError | PolyMethodSubtyping | UnsatisfiedConstraints
+
         class MethodMissingError
           attr_reader name: untyped
 
@@ -128,29 +138,30 @@ module Steep
           def message: () -> ::String
         end
 
-        attr_reader error: untyped
+        attr_reader error: error
 
-        def initialize: (untyped relation, untyped error) -> void
+        def initialize: (Relation[untyped] relation, error error) -> void
 
         def success?: () -> false
 
-        def failure_path: (?untyped path) -> untyped
+        def failure_path: (?Array[t] path) -> Array[t]?
       end
 
       module Helper
-        def Skip: (untyped relation) -> untyped
+        def Skip: (Relation[untyped] relation) -> Skip
 
-        def Expand: (untyped relation) { () -> untyped } -> untyped
+        def Expand: [T < Object] (Relation[T] relation) { (Relation[T]) -> t } -> Expand
 
-        def All: (untyped relation) { () -> untyped } -> untyped
+        def All: (Relation[untyped] relation) { (All) -> void } -> All
 
-        def Any: (untyped relation) { () -> untyped } -> untyped
+        def Any: (Relation[untyped] relation) { (Any) -> void } -> Any
 
-        def Success: (untyped relation) -> untyped
+        def Success: (Relation[untyped] relation) -> Success
 
         alias success Success
 
-        def Failure: (untyped relation, ?untyped? error) { () -> untyped } -> untyped
+        def Failure: (Relation[untyped] relation, Failure::error) -> Failure
+                   | (Relation[untyped]) { () -> Failure::error } -> Failure
       end
     end
   end

--- a/sig/steep/subtyping/result.rbs
+++ b/sig/steep/subtyping/result.rbs
@@ -81,6 +81,7 @@ module Steep
       class Failure < Base
         type error = MethodMissingError | BlockMismatchError | ParameterMismatchError
                    | UnknownPairError | PolyMethodSubtyping | UnsatisfiedConstraints
+                   | SelfBindingMismatch
 
         class MethodMissingError
           attr_reader name: untyped
@@ -136,6 +137,12 @@ module Steep
           def result: () -> untyped
 
           def message: () -> ::String
+        end
+
+        class SelfBindingMismatch
+          def initialize: () -> void
+
+          def message: () -> String
         end
 
         attr_reader error: error

--- a/sig/steep/subtyping/result.rbs
+++ b/sig/steep/subtyping/result.rbs
@@ -48,7 +48,7 @@ module Steep
         def add: [T < Object] (*Relation[T] relations) { (Relation[T]) -> t? } -> bool
 
         # Returns `false` if no future `#add` changes the result.
-        def add_result: (t) -> bool
+        def add_result: (t?) -> bool
 
         def success?: () -> bool
 

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -235,7 +235,8 @@ module Steep
         block_type_hint: AST::Types::t?,
         block_block_hint: Interface::Block?,
         block_annotations: AST::Annotation::Collection,
-        node_type_hint: AST::Types::t?
+        node_type_hint: AST::Types::t?,
+        block_self_hint: AST::Types::t?
       ) -> TypeConstruction
 
     # Synthesize the block body and returns the type of the body

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -399,5 +399,11 @@ module Steep
     # This is typically used for transforming assginment node for case condition.
     #
     def extract_outermost_call: (Parser::AST::Node node, Symbol) -> [Parser::AST::Node, Parser::AST::Node?]
+
+    def type_name: (AST::Types::t) -> RBS::TypeName?
+
+    def singleton_type: (AST::Types::t) -> AST::Types::t?
+
+    def instance_type: (AST::Types::t) -> AST::Types::t?
   end
 end

--- a/sig/steep/type_inference/block_params.rbs
+++ b/sig/steep/type_inference/block_params.rbs
@@ -70,7 +70,7 @@ module Steep
       #
       class MultipleParam
         attr_reader node: Parser::AST::Node
-
+        
         attr_reader params: Array[Param | MultipleParam]
 
         def initialize: (node: Parser::AST::Node, params: Array[Param | MultipleParam]) -> void

--- a/sig/steep/type_inference/block_params.rbs
+++ b/sig/steep/type_inference/block_params.rbs
@@ -111,7 +111,7 @@ module Steep
 
       def params: () -> Array[Param | MultipleParam]
 
-      def self.from_node: (Parser::AST::Node node, annotations: AST::Annotation::Collection) -> BlockParams?
+      def self.from_node: (Parser::AST::Node node, annotations: AST::Annotation::Collection) -> BlockParams
 
       def self.from_multiple: (Parser::AST::Node node, AST::Annotation::Collection) -> MultipleParam
 

--- a/sig/steep/type_inference/method_params.rbs
+++ b/sig/steep/type_inference/method_params.rbs
@@ -45,7 +45,7 @@ module Steep
         alias eql? ==
 
         def hash: () -> Integer
-        
+
         def var_type: () -> AST::Types::t
       end
 
@@ -58,23 +58,27 @@ module Steep
       end
 
       class BlockParameter
-        attr_reader name: untyped
+        attr_reader name: Symbol
 
-        attr_reader type: untyped
+        attr_reader type: Interface::Function?
 
-        attr_reader node: untyped
+        attr_reader node: Parser::AST::Node
 
-        def initialize: (name: untyped, type: untyped, node: untyped, optional: untyped) -> void
+        attr_reader self_type: AST::Types::t?
 
-        def optional?: () -> (true | false)
+        def initialize: (name: Symbol, type: Interface::Function?, node: Parser::AST::Node, optional: boolish, self_type: AST::Types::t?) -> void
+
+        @optional: boolish
+
+        def optional?: () -> bool
 
         def var_type: () -> AST::Types::t
 
-        def ==: (untyped other) -> untyped
+        def ==: (untyped other) -> bool
 
         alias eql? ==
 
-        def hash: () -> untyped
+        def hash: () -> Integer
       end
 
       attr_reader args: untyped
@@ -94,7 +98,7 @@ module Steep
       def each_param: () { (BaseParameter | BaseRestParameter | BlockParameter) -> void } -> void
                     | () -> Enumerator[BaseParameter | BaseRestParameter | BlockParameter, void]
 
-      def each: () { (Symbol, BaseRestParameter | BaseRestParameter | BlockParameter) -> void } -> void
+      def each: () { (Symbol, AST::Types::t) -> void } -> void
 
       def self.empty: (node: Parser::AST::Node) -> MethodParams
 

--- a/sig/steep/type_inference/type_env_builder.rbs
+++ b/sig/steep/type_inference/type_env_builder.rbs
@@ -69,7 +69,7 @@ module Steep
 
       attr_reader commands: Array[Command::_Base]
 
-      def initialize: (*Command::_Base) -> void
+      def initialize: (*Command::_Base?) -> void
 
       def build: (TypeEnv) -> TypeEnv
     end

--- a/smoke/block/e.rb
+++ b/smoke/block/e.rb
@@ -1,0 +1,12 @@
+123.instance_eval do
+  self - 1
+end
+
+b = BlockWithSelf.new.instance_exec do
+  @name = ""
+  @id = 123
+end
+
+[1, ""][0].instance_eval do
+  foo()
+end

--- a/smoke/block/e.rbs
+++ b/smoke/block/e.rbs
@@ -1,0 +1,4 @@
+class BlockWithSelf
+  @name: String
+  @id: Integer
+end

--- a/smoke/block/test_expectations.yml
+++ b/smoke/block/test_expectations.yml
@@ -123,3 +123,15 @@
         def map: [U] () { (::Integer) -> U } -> ::Array[U]
                | () -> ::Enumerator[::Integer, ::Array[untyped]]
     code: Ruby::UnresolvedOverloading
+- file: e.rb
+  diagnostics:
+  - range:
+      start:
+        line: 11
+        character: 2
+      end:
+        line: 11
+        character: 5
+    severity: ERROR
+    message: Type `(::Integer | ::String)` does not have method `foo`
+    code: Ruby::NoMethod

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0", "< 3.17"
-  spec.add_runtime_dependency "rbs", ">= 2.3.2"
+  spec.add_runtime_dependency "rbs", ">= 2.7.0.pre"
   spec.add_runtime_dependency "parallel", ">= 1.0.0"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
 end

--- a/test/block_params_test.rb
+++ b/test/block_params_test.rb
@@ -400,7 +400,8 @@ proc {|a, b=1, *c|
           Params.empty,
           Steep::Interface::Block.new(
             type: parse_type("^() -> void").type,
-            optional: false
+            optional: false,
+            self_type: nil
           )
         ).tap do |zip|
           assert_equal 1, zip.size
@@ -411,7 +412,8 @@ proc {|a, b=1, *c|
           Params.empty,
           Steep::Interface::Block.new(
             type: parse_type("^() -> void").type,
-            optional: true
+            optional: true,
+            self_type: nil
           )
         ).tap do |zip|
           assert_equal 1, zip.size

--- a/test/method_params_test.rb
+++ b/test/method_params_test.rb
@@ -451,12 +451,32 @@ class MethodParamsTest < Minitest::Test
             name: :block,
             type: parse_type("^() -> void").type,
             node: params.args[0],
-            optional: false
+            optional: false,
+            self_type: nil
           ),
           params[:block]
         )
 
         assert_equal parse_type("^() -> void"), params[:block].var_type
+
+        assert_empty params.errors
+      end
+
+      MethodParams.build(node: node, method_type: parse_method_type("() { () [self: self] -> void } -> void")).tap do |params|
+        assert_equal 1, params.size
+
+        assert_equal(
+          MethodParams::BlockParameter.new(
+            name: :block,
+            type: parse_type("^() -> void").type,
+            node: params.args[0],
+            optional: false,
+            self_type: parse_type("self")
+          ),
+          params[:block]
+        )
+
+        assert_equal parse_type("^() [self: self] -> void"), params[:block].var_type
 
         assert_empty params.errors
       end
@@ -469,7 +489,8 @@ class MethodParamsTest < Minitest::Test
             name: :block,
             type: parse_type("^() -> void").type,
             node: params.args[0],
-            optional: true
+            optional: true,
+            self_type: nil
           ),
           params[:block]
         )
@@ -487,7 +508,8 @@ class MethodParamsTest < Minitest::Test
             name: :block,
             type: nil,
             node: params.args[0],
-            optional: false
+            optional: false,
+            self_type: nil
           ),
           params[:block]
         )

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -361,6 +361,27 @@ end
     end
   end
 
+  def test_interface_block_self
+    with_checker <<-EOS do |checker|
+interface _A[X]
+  def foo: () { () [self: X] -> void } -> void
+end
+
+interface _B
+  def foo: () { () -> void } -> void
+end
+    EOS
+
+      assert_success_check checker, "::_A[::Integer]", "::_A[::Object]"
+      assert_fail_check checker, "::_A[::Object]", "::_A[::Integer]"
+
+      assert_fail_check checker, "::_B", "::_A[::Object]"
+      assert_fail_check checker, "::_A[::Object]", "::_B"
+
+      assert_success_check checker, "::_B", "::_A[top]"
+    end
+  end
+
   def test_literal
     with_checker do |checker|
       assert_success_check checker, "123", "::Integer"
@@ -930,6 +951,8 @@ type c = a | b
     with_checker do |checker|
       assert_success_check checker, "^() [self: ::String] -> void", "^() [self: ::String] -> void"
       assert_success_check checker, "^() [self: ::Object] -> void", "^() [self: ::String] -> void"
+
+      assert_success_check checker, "^() { () [self: ::String] -> void } -> void", "^() { () [self: ::Object] -> void } -> void"
 
       assert_fail_check checker, "^() [self: ::String] -> void", "^() -> void"
       assert_fail_check checker, "^() -> void", "^() [self: ::String] -> void"

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -926,6 +926,19 @@ type c = a | b
     end
   end
 
+  def test_proc_type_with_self_binding
+    with_checker do |checker|
+      assert_success_check checker, "^() [self: ::String] -> void", "^() [self: ::String] -> void"
+      assert_success_check checker, "^() [self: ::Object] -> void", "^() [self: ::String] -> void"
+
+      assert_fail_check checker, "^() [self: ::String] -> void", "^() -> void"
+      assert_fail_check checker, "^() -> void", "^() [self: ::String] -> void"
+      assert_fail_check checker, "^() [self: ::String] -> void", "^() [self: ::Object] -> void"
+
+      assert_success_check checker, "^() [self: top] -> void", "^() -> void"
+    end
+  end
+
   def test_self_type
     with_checker do |checker|
       assert_success_check checker, "self", "::Integer", self_type: "::Integer"

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9925,4 +9925,20 @@ end
       end
     end
   end
+
+  def test_proc_with_self_type_binding
+    with_checker() do |checker|
+      source = parse_ruby(<<RUBY)
+# @type var callback: ^() [self: String] -> String
+callback = -> { self + "" }
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_equal parse_type("^() [self: ::String] -> ::String"), type
+        assert_no_error typing
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9986,10 +9986,15 @@ RUBY
     with_checker(<<-RBS) do |checker|
 class TestSelfBinding
   def self.foo: [A] { () [self: instance] -> A } -> A
+
+  @name: String
 end
       RBS
       source = parse_ruby(<<RUBY)
-TestSelfBinding.foo { self }
+TestSelfBinding.foo {
+  @name = "123"
+  self
+}
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -9926,11 +9926,29 @@ end
     end
   end
 
-  def test_proc_with_self_type_binding
+  def test_self_type_binding_proc_with_type_declaration
     with_checker() do |checker|
       source = parse_ruby(<<RUBY)
 # @type var callback: ^() [self: String] -> String
 callback = -> { self + "" }
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_equal parse_type("^() [self: ::String] -> ::String"), type
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_self_type_binding_proc_with_annotation
+    with_checker() do |checker|
+      source = parse_ruby(<<RUBY)
+callback = -> do
+  # @type self: String
+  self + ""
+end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|


### PR DESCRIPTION
See https://github.com/ruby/rbs/pull/1078.

**New subtyping rules:**

* `^(...) [self: T] -> S <: ^(...) [self: T'] -> S` ⇐ `T' <: T` (`self` is essentially a parameter.)
* `^(...) [self: top] -> S <: ^(...) -> S` (Having `top` can be used as _no self binding_.)