### PR TITLE
Unfold type alias before splatting on block parameters

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3420,7 +3420,7 @@ module Steep
 
           if method_type.block
             # Method accepts block
-            pairs = block_params_&.zip(method_type.block.type.params, nil)
+            pairs = block_params_&.zip(method_type.block.type.params, nil, factory: checker.factory)
 
             if block_params_ && pairs
               # Block parameters are compatible with the block type
@@ -3797,7 +3797,7 @@ module Steep
     end
 
     def for_block(body_node, block_params:, block_param_hint:, block_type_hint:, block_block_hint:, block_annotations:, node_type_hint:, block_self_hint:)
-      block_param_pairs = block_param_hint && block_params.zip(block_param_hint, block_block_hint)
+      block_param_pairs = block_param_hint && block_params.zip(block_param_hint, block_block_hint, factory: checker.factory)
 
       # @type var param_types_hash: Hash[Symbol, AST::Types::t]
       param_types_hash = {}

--- a/sig/steep/type_inference/block_params.rbs
+++ b/sig/steep/type_inference/block_params.rbs
@@ -70,7 +70,7 @@ module Steep
       #
       class MultipleParam
         attr_reader node: Parser::AST::Node
-        
+
         attr_reader params: Array[Param | MultipleParam]
 
         def initialize: (node: Parser::AST::Node, params: Array[Param | MultipleParam]) -> void
@@ -120,16 +120,21 @@ module Steep
       def params_type0: (hint: nil) -> Interface::Function::Params
                       | (hint: Interface::Function::Params?) -> Interface::Function::Params?
 
-      def zip: (Interface::Function::Params params_type, Interface::Block? block) -> Array[[Param | MultipleParam, AST::Types::t]]
+      def zip: (
+        Interface::Function::Params params_type,
+        Interface::Block? block,
+        factory: AST::Types::Factory
+      ) -> Array[[Param | MultipleParam, AST::Types::t]]
 
       # Returns true if given possible block yields are subject to auto expand/splat
       #
       # ```rbs
-      # { (Array[String]) -> void }      # true
-      # { ([Integer, String]) -> void }  # true
+      # { (Array[String]) -> void }      # Array[String]
+      # { ([Integer, String]) -> void }  # [Integer, String]
+      # { (String) -> void }             # nil
       # ```
       #
-      def expandable_params?: (Interface::Function::Params params_type) -> bool
+      def expandable_params?: (Interface::Function::Params params_type, AST::Types::Factory) -> AST::Types::t?
 
       # Returns true if the block is defined to expand/splat automatically
       #

--- a/smoke/regression/block_param_split.rb
+++ b/smoke/regression/block_param_split.rb
@@ -1,0 +1,7 @@
+# @type var a: Array[BlockParamSplit::pair[Integer, String]]
+a = [[1, "a"]]
+
+a.each do |x, y|
+  x + 1
+  y + "2"
+end

--- a/smoke/regression/block_param_split.rbs
+++ b/smoke/regression/block_param_split.rbs
@@ -1,0 +1,3 @@
+module BlockParamSplit
+  type pair[T, S] = [T, S]
+end

--- a/test/block_params_test.rb
+++ b/test/block_params_test.rb
@@ -102,7 +102,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|a, b=1, *c| }") do |params, args|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
         assert_equal [params.params[0], parse_type("Integer")], zip[0]
         assert_equal [params.params[1], parse_type("nil")], zip[1]
         assert_equal [params.params[2], parse_type("::Array[untyped]")], zip[2]
@@ -122,7 +122,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|a, b, *c| }") do |params, args|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Integer")], zip[0]
         assert_equal [params.params[1], parse_type("::String")], zip[1]
@@ -143,7 +143,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|x, *y| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Integer")], zip[0]
         assert_equal [params.params[1], parse_type("::Array[::Object | ::String]")], zip[1]
@@ -163,7 +163,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|x| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal 1, zip.size
         assert_equal [params.params[0], parse_type("::Integer")], zip[0]
@@ -183,7 +183,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc { }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_empty zip
       end
@@ -202,7 +202,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|x, y| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal 2, zip.size
         assert_equal [params.params[0], parse_type("::Object")], zip[0]
@@ -223,7 +223,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|x,y,*z| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Integer | nil")], zip[0]
         assert_equal [params.params[1], parse_type("::Integer | nil")], zip[1]
@@ -231,7 +231,7 @@ proc {|a, b=1, *c, d, &e|
       end
 
       block_params("proc {|x,| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Integer | nil")], zip[0]
       end
@@ -250,7 +250,7 @@ proc {|a, b=1, *c, d, &e|
       )
 
       block_params("proc {|x,y,*z| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Symbol")], zip[0]
         assert_equal [params.params[1], parse_type("::Integer")], zip[1]
@@ -258,13 +258,13 @@ proc {|a, b=1, *c, d, &e|
       end
 
       block_params("proc {|x,| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Symbol")], zip[0]
       end
 
       block_params("proc {|x, *y| }") do |params|
-        zip = params.zip(type, nil)
+        zip = params.zip(type, nil, factory: factory)
 
         assert_equal [params.params[0], parse_type("::Symbol")], zip[0]
         assert_equal [params.params[1], parse_type("::Array[::Integer]")], zip[1]
@@ -402,7 +402,8 @@ proc {|a, b=1, *c|
             type: parse_type("^() -> void").type,
             optional: false,
             self_type: nil
-          )
+          ),
+          factory: factory
         ).tap do |zip|
           assert_equal 1, zip.size
           assert_equal [params.block_param, parse_type("^() -> void")], zip[0]
@@ -414,7 +415,8 @@ proc {|a, b=1, *c|
             type: parse_type("^() -> void").type,
             optional: true,
             self_type: nil
-          )
+          ),
+          factory: factory
         ).tap do |zip|
           assert_equal 1, zip.size
           assert_equal [params.block_param, parse_type("^() -> void | nil")], zip[0]
@@ -422,7 +424,8 @@ proc {|a, b=1, *c|
 
         params.zip(
           Params.empty,
-          nil
+          nil,
+          factory: factory
         ).tap do |zip|
           assert_equal 1, zip.size
           assert_equal [params.block_param, parse_type("nil")], zip[0]
@@ -476,7 +479,8 @@ end
             optional_keywords: {},
             rest_keywords: nil
           ),
-          nil
+          nil,
+          factory: factory
         ).tap do |zip|
           assert_equal 1, zip.size
           zip[0].tap do |pair|

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10058,4 +10058,26 @@ RUBY
       end
     end
   end
+
+  def test_block_splat_alias
+    with_checker(<<-RBS) do |checker|
+type foo = [Integer, String]
+      RBS
+      source = parse_ruby(<<-RUBY)
+# @type var array: Array[foo]
+array = []
+
+array.each do |x, y|
+  x + 1
+  y + ""
+end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
Steep supports block parameter auto-splat on tuples and arrays.

```rb
# @type var array: Array[[Integer, String]]
array = ...

array.each do |x, y|
  x + 1      # x is Integer
  y + ""     # y is String
end
```

This PR is to let the array element a type alias -- like `Array[pair]` where `type pair = [Integer, String]`.

Note that this doesn't support `#to_ary` conversion, or the case the argument is a subclass of `Array`.