### PR TITLE
Fork to start worker processes

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -10,7 +10,6 @@ target :app do
     hash[D::Ruby::MethodDefinitionMissing] = :hint
   end
 
-  signature "../rbs/sig", "../rbs/stdlib/rdoc/0"
   library(
     "set",
     "pathname",

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -36,7 +36,7 @@ module Steep
         server_reader = LanguageServer::Protocol::Transport::Io::Reader.new(server_read)
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(
           steepfile: project.steepfile_path,
           args: command_line_patterns,
           delay_shutdown: true,

--- a/lib/steep/drivers/checkfile.rb
+++ b/lib/steep/drivers/checkfile.rb
@@ -101,7 +101,7 @@ module Steep
 
         Steep.logger.info { "Starting #{count} workers for #{files.size} files..." }
 
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(
           steepfile: project.steepfile_path,
           args: [],
           delay_shutdown: true,

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -35,8 +35,8 @@ module Steep
       def run
         @project = load_config()
 
-        interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: project.steepfile_path, steep_command: jobs_option.steep_command_value)
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: jobs_option.steep_command_value, count: jobs_option.jobs_count_value)
+        interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: project.steepfile_path, steep_command: jobs_option.steep_command_value)
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: jobs_option.steep_command_value, count: jobs_option.jobs_count_value)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/stats.rb
+++ b/lib/steep/drivers/stats.rb
@@ -126,7 +126,7 @@ module Steep
         server_reader = LanguageServer::Protocol::Transport::Io::Reader.new(server_read)
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(
           steepfile: project.steepfile_path,
           delay_shutdown: true,
           args: command_line_patterns,

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -42,7 +42,7 @@ module Steep
         server_reader = LanguageServer::Protocol::Transport::Io::Reader.new(server_read)
         server_writer = LanguageServer::Protocol::Transport::Io::Writer.new(server_write)
 
-        typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: project.steepfile_path, args: dirs.map(&:to_s), steep_command: jobs_option.steep_command_value, count: jobs_option.jobs_count_value)
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: project.steepfile_path, args: dirs.map(&:to_s), steep_command: jobs_option.steep_command_value, count: jobs_option.jobs_count_value)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -3,7 +3,6 @@ module Steep
     class Worker
       attr_reader :stdout, :stderr, :stdin
 
-      attr_accessor :steepfile_path
       attr_accessor :worker_type
       attr_accessor :worker_name
       attr_accessor :delay_shutdown

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -796,7 +796,10 @@ module Steep
 
           Steep.logger.info "Sending $/typecheck/start notifications"
           typecheck_workers.each do |worker|
-            assignment = Services::PathAssignment.new(max_index: typecheck_workers.size, index: worker.index)
+            assignment = Services::PathAssignment.new(
+              max_index: typecheck_workers.size,
+              index: worker.index || raise
+            )
 
             job_queue << SendMessageJob.to_worker(
               worker,

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -38,9 +38,9 @@ module Steep
         end
 
         stdin, stdout, thread = if Gem.win_platform?
-                                  Open3.popen2(*command, new_pgroup: true)
+                                  __skip__ = Open3.popen2(*command, new_pgroup: true)
                                 else
-                                  Open3.popen2(*command, pgroup: true)
+                                  __skip__ = Open3.popen2(*command, pgroup: true)
                                 end
         stderr = nil
 

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -18,7 +18,7 @@ module Steep
         @index = index
       end
 
-      def self.spawn_worker(type, name:, steepfile:, steep_command: "steep", options: [], delay_shutdown: false, index: nil)
+      def self.start_worker(type, name:, steepfile:, steep_command: "steep", options: [], delay_shutdown: false, index: nil)
         args = ["--name=#{name}", "--steepfile=#{steepfile}"]
         args << (%w(debug info warn error fatal unknown)[Steep.logger.level].yield_self {|log_level| "--log-level=#{log_level}" })
         if Steep.log_output.is_a?(String)
@@ -50,9 +50,9 @@ module Steep
         new(reader: reader, writer: writer, stderr: stderr, wait_thread: thread, name: name, index: index)
       end
 
-      def self.spawn_typecheck_workers(steepfile:, args:, steep_command: "steep", count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
+      def self.start_typecheck_workers(steepfile:, args:, steep_command: "steep", count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
         count.times.map do |i|
-          spawn_worker(
+          start_worker(
             :typecheck,
             name: "typecheck@#{i}",
             steepfile: steepfile,

--- a/rbs_collection.steep.lock.yaml
+++ b/rbs_collection.steep.lock.yaml
@@ -10,6 +10,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: rbs
+  version: 2.7.0
+  source:
+    type: rubygems
 - name: dbm
   version: '0'
   source:
@@ -98,6 +102,22 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: pathname
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
+  version: '0'
+  source:
+    type: stdlib
+- name: tsort
+  version: '0'
+  source:
+    type: stdlib
+- name: rdoc
+  version: '0'
+  source:
+    type: stdlib
 - name: monitor
   version: '0'
   source:
@@ -115,10 +135,6 @@ gems:
   source:
     type: stdlib
 - name: time
-  version: '0'
-  source:
-    type: stdlib
-- name: pathname
   version: '0'
   source:
     type: stdlib

--- a/rbs_collection.steep.yaml
+++ b/rbs_collection.steep.yaml
@@ -15,7 +15,6 @@ gems:
     ignore: true
   - name: set
   - name: rbs
-    ignore: true
   - name: with_steep_types
     ignore: true
   - name: dbm

--- a/sig/steep/drivers/worker.rbs
+++ b/sig/steep/drivers/worker.rbs
@@ -1,31 +1,31 @@
 module Steep
   module Drivers
     class Worker
-      attr_reader stdout: untyped
+      attr_reader stdout: IO
 
-      attr_reader stderr: untyped
+      attr_reader stderr: IO
 
-      attr_reader stdin: untyped
+      attr_reader stdin: IO
 
-      attr_accessor steepfile_path: untyped
+      attr_accessor steepfile_path: Pathname
 
-      attr_accessor worker_type: untyped
+      attr_accessor worker_type: Symbol
 
-      attr_accessor worker_name: untyped
+      attr_accessor worker_name: String
 
-      attr_accessor delay_shutdown: untyped
+      attr_accessor delay_shutdown: bool
 
-      attr_accessor max_index: untyped
+      attr_accessor max_index: Integer
 
-      attr_accessor index: untyped
+      attr_accessor index: Integer
 
-      attr_accessor commandline_args: untyped
+      attr_accessor commandline_args: Array[String]
 
       include Utils::DriverHelper
 
-      def initialize: (stdout: untyped, stderr: untyped, stdin: untyped) -> void
+      def initialize: (stdout: IO, stderr: IO, stdin: IO) -> void
 
-      def run: () -> 0
+      def run: () -> Integer
     end
   end
 end

--- a/sig/steep/drivers/worker.rbs
+++ b/sig/steep/drivers/worker.rbs
@@ -7,8 +7,6 @@ module Steep
 
       attr_reader stdin: IO
 
-      attr_accessor steepfile_path: Pathname
-
       attr_accessor worker_type: Symbol
 
       attr_accessor worker_name: String

--- a/sig/steep/server/worker_process.rbs
+++ b/sig/steep/server/worker_process.rbs
@@ -49,9 +49,28 @@ module Steep
         name: String,
         steepfile: Pathname,
         ?steep_command: ::String,
-        ?options: Array[String],
+        ?patterns: Array[String],
         ?delay_shutdown: bool,
-        ?index: Integer?
+        ?index: [Integer, Integer]?
+      ) -> WorkerProcess
+
+      def self.fork_worker: (
+        worker_type `type`,
+        name: String,
+        steepfile: Pathname,
+        patterns: Array[String],
+        delay_shutdown: bool,
+        index: [Integer, Integer]?
+      ) -> WorkerProcess
+
+      def self.spawn_worker: (
+        worker_type `type`,
+        name: String,
+        steepfile: Pathname,
+        steep_command: ::String,
+        patterns: Array[String],
+        delay_shutdown: bool,
+        index: [Integer, Integer]?
       ) -> WorkerProcess
 
       def self.start_typecheck_workers: (

--- a/sig/steep/server/worker_process.rbs
+++ b/sig/steep/server/worker_process.rbs
@@ -1,5 +1,21 @@
 module Steep
   module Server
+    # WorkerProcess class represents a worker process
+    #
+    # Available operations are:
+    #
+    # 1. Sending a LSP message to the process
+    # 2. Receiving a LSP message from the process
+    # 3. Killing the process
+    #
+    # The process may be invoked by
+    #
+    # 1. `#fork` if available, or
+    # 2. `#spawn` otherwise
+    #
+    # `#fork` version is faster because it skips loading libraries.
+    #
+    #
     class WorkerProcess
       interface _ProcessWaitThread
         def pid: () -> Integer
@@ -28,7 +44,7 @@ module Steep
 
       type worker_type = :interaction | :typecheck
 
-      def self.spawn_worker: (
+      def self.start_worker: (
         worker_type `type`,
         name: String,
         steepfile: Pathname,
@@ -38,7 +54,7 @@ module Steep
         ?index: Integer?
       ) -> WorkerProcess
 
-      def self.spawn_typecheck_workers: (
+      def self.start_typecheck_workers: (
         steepfile: Pathname,
         args: Array[String],
         ?steep_command: ::String,

--- a/sig/steep/server/worker_process.rbs
+++ b/sig/steep/server/worker_process.rbs
@@ -1,29 +1,56 @@
 module Steep
   module Server
     class WorkerProcess
-      attr_reader reader: untyped
+      interface _ProcessWaitThread
+        def pid: () -> Integer
+      end
 
-      attr_reader writer: untyped
+      attr_reader reader: LanguageServer::Protocol::Transport::Io::Reader
 
-      attr_reader stderr: untyped
+      attr_reader writer: LanguageServer::Protocol::Transport::Io::Writer
 
-      attr_reader name: untyped
+      attr_reader stderr: IO?
 
-      attr_reader wait_thread: untyped
+      attr_reader name: String
 
-      attr_reader index: untyped
+      attr_reader wait_thread: Thread & _ProcessWaitThread
 
-      def initialize: (reader: untyped, writer: untyped, stderr: untyped, wait_thread: untyped, name: untyped, ?index: untyped?) -> void
+      attr_reader index: Integer?
 
-      def self.spawn_worker: (untyped `type`, name: untyped, steepfile: untyped, ?steep_command: ::String, ?options: untyped, ?delay_shutdown: bool, ?index: untyped?) -> untyped
+      def initialize: (
+        reader: LanguageServer::Protocol::Transport::Io::Reader,
+        writer: LanguageServer::Protocol::Transport::Io::Writer,
+        stderr: IO?,
+        wait_thread: Thread & _ProcessWaitThread,
+        name: String,
+        ?index: Integer?
+      ) -> void
 
-      def self.spawn_typecheck_workers: (steepfile: untyped, args: untyped, ?steep_command: ::String, ?count: untyped, ?delay_shutdown: bool) -> untyped
+      type worker_type = :interaction | :typecheck
 
-      def <<: (untyped message) -> untyped
+      def self.spawn_worker: (
+        worker_type `type`,
+        name: String,
+        steepfile: Pathname,
+        ?steep_command: ::String,
+        ?options: Array[String],
+        ?delay_shutdown: bool,
+        ?index: Integer?
+      ) -> WorkerProcess
 
-      def read: () ?{ () -> untyped } -> untyped
+      def self.spawn_typecheck_workers: (
+        steepfile: Pathname,
+        args: Array[String],
+        ?steep_command: ::String,
+        ?count: Integer,
+        ?delay_shutdown: bool
+      ) -> Array[WorkerProcess]
 
-      def kill: () -> untyped
+      def <<: (untyped message) -> void
+
+      def read: () { (untyped) -> void } -> void
+
+      def kill: () -> void
     end
   end
 end

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -526,8 +526,8 @@ end
       project = Project.new(steepfile_path: steepfile)
       Project::DSL.parse(project, steepfile.read)
 
-      interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 1, args: [])
+      interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: steepfile)
+      typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: steepfile, count: 1, args: [])
 
       master = Server::Master.new(
         project: project,
@@ -607,8 +607,8 @@ end
       project = Project.new(steepfile_path: steepfile)
       Project::DSL.parse(project, steepfile.read)
 
-      interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 1, args: [])
+      interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: steepfile)
+      typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: steepfile, count: 1, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,
@@ -681,8 +681,8 @@ end
       project = Project.new(steepfile_path: steepfile)
       Project::DSL.parse(project, steepfile.read)
 
-      interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 2, args: [])
+      interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: steepfile)
+      typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: steepfile, count: 2, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,
@@ -731,8 +731,8 @@ end
       project = Project.new(steepfile_path: steepfile)
       Project::DSL.parse(project, steepfile.read)
 
-      interaction_worker = Server::WorkerProcess.spawn_worker(:interaction, name: "interaction", steepfile: steepfile)
-      typecheck_workers = Server::WorkerProcess.spawn_typecheck_workers(steepfile: steepfile, count: 2, args: [])
+      interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: steepfile)
+      typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: steepfile, count: 2, args: [])
 
       master = Server::Master.new(project: project,
                                   reader: worker_reader,


### PR DESCRIPTION
Use `#fork` to start worker processes if available. This makes starting new processes faster than using `#spawn`, and let `steep check` finish much faster when the computer has more cores (>~10).