### PR TITLE
Fixes for some RBS errors within steep gem

### DIFF
--- a/sig/steep/ast/types/factory.rbs
+++ b/sig/steep/ast/types/factory.rbs
@@ -4,8 +4,6 @@ module Steep
       class Factory
         @env: RBS::Environment
 
-        @type_name_resolver: RBS::Resolver::TypeNameResolver
-
         attr_reader definition_builder: RBS::DefinitionBuilder
 
         attr_reader type_cache: Hash[RBS::Types::t, t]

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -384,11 +384,11 @@ module Steep
       class IncompatibleAnnotation < Base
         attr_reader result: Subtyping::Result::Base
 
-        attr_reader relation: Subtyping::Relation
+        attr_reader relation: Subtyping::Relation[untyped]
 
         attr_reader var_name: Symbol
 
-        def initialize: (node: Parser::AST::Node, var_name: Symbol, result: Subtyping::Result::Base, relation: Subtyping::Relation) -> void
+        def initialize: (node: Parser::AST::Node, var_name: Symbol, result: Subtyping::Result::Base, relation: Subtyping::Relation[untyped]) -> void
 
         include ResultPrinter
 


### PR DESCRIPTION
While running `steep check` on my app, I got some errors raised from inside Steep gem. I soon learned from the documentation that I could mute these errors by adding `ignore` entry in my rbs_collection.yaml, but anyway it'd be better for steep not to raise when being type checked, so here are my quick fixes for two of them.

I'm sorry though, I couldn't fix all the errors. I'm still seeing the following error, but I'll leave it untouched because I'm not sure what is the proper fix.

```
.../steep/sig/steep/subtyping/check.rbs:100:44: [error] Type application of `::Steep::Subtyping::Relation` doesn't satisfy the constraints: (::Steep::Interface::Block | nil) <: ::Object
│ Diagnostic ID: RBS::UnsatisfiableTypeApplication
│
└       def expand_block_given: (Symbol name, Relation[Interface::Block?] relation) -> (Relation[Interface::Block] | true | Result::t)
```
