### PR TITLE
Add missing `#level` method

### DIFF
--- a/lib/steep/ast/types/helper.rb
+++ b/lib/steep/ast/types/helper.rb
@@ -4,12 +4,13 @@ module Steep
       module Helper
         module ChildrenLevel
           def level_of_children(children)
-            children.map(&:level).sort {|a, b| b.size <=> a.size }.inject() do |a, b|
-              a.zip(b).map do |(x, y)|
+            levels = children.map(&:level)
+            children.map(&:level).sort {|a, b| (b.size <=> a.size) || 0 }.inject() do |a, b|
+              a.zip(b).map do |x, y|
                 if x && y
                   x + y
                 else
-                  x || y
+                  x || y || raise
                 end
               end
             end || []

--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -28,6 +28,10 @@ module Steep
           def to_s
             "<% #{self.class} %>"
           end
+
+          def level
+            [0]
+          end
         end
 
         class Not < Base

--- a/sig/steep/ast/types/any.rbs
+++ b/sig/steep/ast/types/any.rbs
@@ -20,7 +20,7 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[1]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
       end

--- a/sig/steep/ast/types/boolean.rbs
+++ b/sig/steep/ast/types/boolean.rbs
@@ -20,7 +20,7 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
 

--- a/sig/steep/ast/types/bot.rbs
+++ b/sig/steep/ast/types/bot.rbs
@@ -20,7 +20,7 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[2]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
       end

--- a/sig/steep/ast/types/class.rbs
+++ b/sig/steep/ast/types/class.rbs
@@ -20,7 +20,7 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
 

--- a/sig/steep/ast/types/helper.rbs
+++ b/sig/steep/ast/types/helper.rbs
@@ -3,15 +3,18 @@ module Steep
     module Types
       module Helper
         module ChildrenLevel
-          def level_of_children: (untyped children) -> untyped
+          def level_of_children: (Array[t] children) -> Array[Integer]
         end
 
         module NoFreeVariables
-          def free_variables: () -> untyped
+          @fvs: Set[Symbol]
+
+          def free_variables: () -> Set[Symbol]
         end
 
         module NoChild
-          def each_child: () ?{ () -> untyped } -> (untyped | nil)
+          def each_child: () { (t) -> void } -> void
+                        | () -> Enumerator[t, void]
         end
       end
     end

--- a/sig/steep/ast/types/instance.rbs
+++ b/sig/steep/ast/types/instance.rbs
@@ -20,7 +20,7 @@ module Steep
 
         def to_s: () -> "instance"
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
 

--- a/sig/steep/ast/types/intersection.rbs
+++ b/sig/steep/ast/types/intersection.rbs
@@ -26,7 +26,7 @@ module Steep
 
         def each_child: () ?{ () -> untyped } -> untyped
 
-        def level: () -> untyped
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
       end

--- a/sig/steep/ast/types/logic.rbs
+++ b/sig/steep/ast/types/logic.rbs
@@ -20,6 +20,8 @@ module Steep
           alias eql? ==
 
           def to_s: () -> ::String
+
+          def level: () -> Array[Integer]
         end
 
         # A type for `!` (not) operator results.

--- a/sig/steep/ast/types/name.rbs
+++ b/sig/steep/ast/types/name.rbs
@@ -13,7 +13,7 @@ module Steep
 
           def subst: (Steep::Interface::Substitution s) -> self
 
-          def level: () -> ::Array[0]
+          def level: () -> Array[Integer]
         end
 
         class Applying < Base
@@ -40,7 +40,7 @@ module Steep
 
           include Helper::ChildrenLevel
 
-          def level: () -> untyped
+          def level: () -> Array[Integer]
         end
 
         class Singleton < Base

--- a/sig/steep/ast/types/nil.rbs
+++ b/sig/steep/ast/types/nil.rbs
@@ -20,7 +20,7 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
 

--- a/sig/steep/ast/types/record.rbs
+++ b/sig/steep/ast/types/record.rbs
@@ -29,7 +29,7 @@ module Steep
         def each_child: () { (t) -> void } -> void
                       | () -> Enumerator[t, void]
 
-        def level: () -> Integer
+        def level: () -> Array[Integer]
 
         def with_location: (loc new_location) -> self
       end

--- a/sig/steep/ast/types/self.rbs
+++ b/sig/steep/ast/types/self.rbs
@@ -20,7 +20,7 @@ module Steep
 
         def free_variables: () -> untyped
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
 

--- a/sig/steep/ast/types/top.rbs
+++ b/sig/steep/ast/types/top.rbs
@@ -20,8 +20,8 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[2]
-
+        def level: () -> Array[Integer]
+        
         def with_location: (untyped new_location) -> untyped
       end
     end

--- a/sig/steep/ast/types/tuple.rbs
+++ b/sig/steep/ast/types/tuple.rbs
@@ -25,7 +25,7 @@ module Steep
         def each_child: () { (t) -> void } -> void
                       | () -> Enumerator[t, void]
 
-        def level: () -> untyped
+        def level: () -> Array[Integer]
 
         def with_location: (RBS::Location[untyped, untyped] new_location) -> Tuple
       end

--- a/sig/steep/ast/types/union.rbs
+++ b/sig/steep/ast/types/union.rbs
@@ -29,7 +29,7 @@ module Steep
 
         include Helper::ChildrenLevel
 
-        def level: () -> Integer
+        def level: () -> Array[Integer]
 
         def with_location: (loc new_location) -> Union
       end

--- a/sig/steep/ast/types/var.rbs
+++ b/sig/steep/ast/types/var.rbs
@@ -26,8 +26,8 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[0]
-
+        def level: () -> Array[Integer]
+                 
         def update: (?name: untyped, ?location: untyped) -> untyped
 
         def with_location: (untyped new_location) -> untyped

--- a/sig/steep/ast/types/void.rbs
+++ b/sig/steep/ast/types/void.rbs
@@ -20,7 +20,7 @@ module Steep
 
         include Helper::NoChild
 
-        def level: () -> ::Array[0]
+        def level: () -> Array[Integer]
 
         def with_location: (untyped new_location) -> untyped
       end


### PR DESCRIPTION
```
Unexpected error: #<NoMethodError: undefined method `level' for #<Steep::AST::Types::Logic::Not:0x00000002801976c0>>
```