### PR TITLE
Fix errors caused by non-ascii variable names

### DIFF
--- a/lib/steep/type_inference/type_env.rb
+++ b/lib/steep/type_inference/type_env.rb
@@ -308,7 +308,13 @@ module Steep
       end
 
       def local_variable_name?(name)
-        name.start_with?(/[a-z_]/) && name != :_ && name != :__skip__ && name != :__any__
+        # Ruby constants start with Uppercase_Letter or Titlecase_Letter in the unicode property.
+        # If name start with `@`, it is instance variable or class instance variable.
+        # If name start with `$`, it is global variable.
+        return false if name.start_with?(/[\p{Uppercase_Letter}\p{Titlecase_Letter}@$]/)
+        return false if TypeConstruction::SPECIAL_LVAR_NAMES.include?(name)
+
+        true
       end
 
       def local_variable_name!(name)

--- a/test/type_env_test.rb
+++ b/test/type_env_test.rb
@@ -23,10 +23,34 @@ class TypeEnvTest < Minitest::Test
     with_factory do
       env = TypeEnv.new(constant_env)
 
-      env = env.assign_local_variables({ :x => parse_type("::String") })
+      env = env.assign_local_variables({
+        :x => parse_type("::String"),
+        :ä => parse_type("::Integer")
+      })
+      assert_raises(RuntimeError) do
+        env.assign_local_variables({ :ǲ => parse_type("::Integer") })
+      end
 
       assert_equal parse_type("::String"), env[:x]
+      assert_equal parse_type("::Integer"), env[:ä]
       assert_nil env.enforced_type(:x)
+      assert_nil env.enforced_type(:ä)
+    end
+  end
+
+  def test_local_variable_name_p
+    with_factory do
+      env = TypeEnv.new(constant_env)
+      assert_equal true, env.local_variable_name?(:abc)
+      assert_equal true, env.local_variable_name?(:_abc)
+      assert_equal false, env.local_variable_name?(:@abc)
+      assert_equal false, env.local_variable_name?(:$abc)
+      assert_equal false, env.local_variable_name?(:_)
+      assert_equal false, env.local_variable_name?(:__skip__)
+      assert_equal false, env.local_variable_name?(:__any__)
+      assert_equal true, env.local_variable_name?(:ǳ) # Lowercase_Letter
+      assert_equal false, env.local_variable_name?(:Ǳ) # Uppercase_Letter
+      assert_equal false, env.local_variable_name?(:ǲ) # Titlecase_Letter
     end
   end
 


### PR DESCRIPTION
In Ruby, even non-ascii characters can be used as local variables.

```
変数 = 1
```

However, when this code is checked with steep, it results in an `UnexpectedError`.

```
sample.rb:1:0: [error] UnexpectedError: 変数 is not a local variable
│ Diagnostic ID: Ruby::UnexpectedError
│
└ 変数 = 1
  ~~~~~~
```

This patch fixes it so that a variable with non-ascii characters does not result in an UnexpectedError.