### PR TITLE
Fix constant declaration type checking

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2697,8 +2697,10 @@ module Steep
           synthesize_constant(node, parent_node, constant_name, &block)
         else
           if nesting
-            if constant = context.type_env.constant_env.resolver.table.children(module_context!.class_name)&.fetch(constant_name, nil)
-              return [checker.factory.type(constant.type), self, constant.name]
+            if parent_nesting = nesting[1]
+              if constant = context.type_env.constant_env.resolver.table.children(parent_nesting)&.fetch(constant_name, nil)
+                return [checker.factory.type(constant.type), self, constant.name]
+              end
             end
 
             if block_given?
@@ -2721,6 +2723,7 @@ module Steep
               nil
             ]
           else
+            # No neesting
             synthesize_constant(node, nil, constant_name, &block)
           end
         end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1394,7 +1394,7 @@ module Steep
             constr = self
 
             name_node, super_node, _ = node.children
-            _, constr, class_name = synthesize_constant(name_node, name_node.children[0], name_node.children[1]) do
+            _, constr, class_name = synthesize_constant_decl(name_node, name_node.children[0], name_node.children[1]) do
               typing.add_error(
                 Diagnostic::Ruby::UnknownConstant.new(node: name_node, name: name_node.children[1]).class!
               )
@@ -1444,7 +1444,7 @@ module Steep
             constr = self
 
             name_node, _ = node.children
-            _, constr, module_name = synthesize_constant(name_node, name_node.children[0], name_node.children[1]) do
+            _, constr, module_name = synthesize_constant_decl(name_node, name_node.children[0], name_node.children[1]) do
               typing.add_error Diagnostic::Ruby::UnknownConstant.new(node: name_node, name: name_node.children[1]).module!
             end
 
@@ -1521,7 +1521,7 @@ module Steep
 
         when :casgn
           yield_self do
-            constant_type, constr, constant_name = synthesize_constant(nil, node.children[0], node.children[1]) do
+            constant_type, constr, constant_name = synthesize_constant_decl(nil, node.children[0], node.children[1]) do
               typing.add_error(
                 Diagnostic::Ruby::UnknownConstant.new(
                   node: node,
@@ -2678,6 +2678,53 @@ module Steep
       end
 
       constr.add_typing(node, type: truthy_rhs_type)
+    end
+
+    def synthesize_constant_decl(node, parent_node, constant_name, &block)
+      const_name = module_name_from_node(parent_node, constant_name)
+
+      if const_name && type = context.type_env.annotated_constant(const_name)
+        # const-type annotation wins
+        if node
+          constr = synthesize_children(node)
+          type, constr = constr.add_typing(node, type: type)
+          [type, constr, nil]
+        else
+          [type, self, nil]
+        end
+      else
+        if parent_node
+          synthesize_constant(node, parent_node, constant_name, &block)
+        else
+          if nesting
+            if constant = context.type_env.constant_env.resolver.table.children(module_context!.class_name)&.fetch(constant_name, nil)
+              return [checker.factory.type(constant.type), self, constant.name]
+            end
+
+            if block_given?
+              yield
+            else
+              if node
+                constr.typing.add_error(
+                  Diagnostic::Ruby::UnknownConstant.new(node: node, name: constant_name)
+                )
+              end
+            end
+
+            if node
+              _, constr = add_typing(node, type: AST::Builtin.any_type)
+            end
+
+            [
+              AST::Builtin.any_type,
+              self,
+              nil
+            ]
+          else
+            synthesize_constant(node, nil, constant_name, &block)
+          end
+        end
+      end
     end
 
     def synthesize_constant(node, parent_node, constant_name)

--- a/sample/lib/conference.rb
+++ b/sample/lib/conference.rb
@@ -20,3 +20,9 @@ Konference.new()
 # @type var foo: Konference
 
 foo = Conference.new
+
+class Conference12
+  class Integer
+
+  end
+end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -126,7 +126,37 @@ module Steep
 
     def constant_typename: (Parser::AST::Node parent, Symbol name) -> RBS::TypeName?
 
-    def synthesize_constant: (Parser::AST::Node node, Parser::AST::Node? parent_node, Symbol constant_name) { () -> void } -> [AST::Types::t, TypeConstruction, RBS::TypeName?]
+    # Synthesize a constant declaration -- :cdecl, :class, or :module
+    #
+    # * `node` is the node that references a constant
+    # * `parent_node` is the parent (namespace) of a constant reference
+    # * `constant_name` is the name of constant
+    #
+    # Yields a block that is expected to add an error, or it reports Diagnostic::Ruby::UnknownConstant if not given.
+    #
+    # Returns a tuple of
+    #
+    # * The type of the constant
+    # * TypeConstruction instance after the evaluation
+    # * The full name of the constant
+    #
+    def synthesize_constant_decl: (Parser::AST::Node? node, Parser::AST::Node? parent_node, Symbol constant_name) ?{ () -> void } -> [AST::Types::t, TypeConstruction, RBS::TypeName?]
+
+    # Synthesize a constant reference
+    #
+    # * `node` is the node that references a constant
+    # * `parent_node` is the parent (namespace) of a constant reference
+    # * `constant_name` is the name of constant
+    #
+    # Yields a block that is expected to add an error, or it reports Diagnostic::Ruby::UnknownConstant if not given.
+    #
+    # Returns a tuple of
+    #
+    # * The type of the constant
+    # * TypeConstruction instance after the evaluation
+    # * The full name of the constant
+    #
+    def synthesize_constant: (Parser::AST::Node? node, Parser::AST::Node? parent_node, Symbol constant_name) ?{ () -> void } -> [AST::Types::t, TypeConstruction, RBS::TypeName?]
 
     def optional_proc?: (untyped `type`) -> (untyped | nil | nil | nil | nil)
 

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -333,7 +333,7 @@ module Steep
     #
     def synthesize_block: (node: Parser::AST::Node, block_type_hint: AST::Types::t?, block_body: Parser::AST::Node?) -> AST::Types::t
 
-    def nesting: () -> RBS::Resolver::context
+    %a{pure} def nesting: () -> RBS::Resolver::context
 
     def absolute_name: (untyped name) -> untyped
 

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10241,6 +10241,11 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
           module Kernel
           end
         end
+
+        class UnknownOuterModule
+          class String
+          end
+        end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
@@ -10262,6 +10267,12 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
           assert_instance_of Diagnostic::Ruby::UnknownConstant, error
           assert_equal :Kernel, error.name
           assert_equal :module, error.kind
+        end
+
+        assert_any!(typing.errors) do |error|
+          assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+          assert_equal :String, error.name
+          assert_equal :class, error.kind
         end
       end
     end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10222,4 +10222,48 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       end
     end
   end
+
+  def test_class_name_resolution
+    with_checker(<<~RBS) do |checker|
+        module TestClassConstant
+        end
+
+        module Kernel
+        end
+      RBS
+      source = parse_ruby(<<~RUBY)
+        module TestClassConstant
+          class Integer
+          end
+
+          String = true
+
+          module Kernel
+          end
+        end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_any!(typing.errors) do |error|
+          assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+          assert_equal :Integer, error.name
+          assert_equal :class, error.kind
+        end
+
+        assert_any!(typing.errors) do |error|
+          assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+          assert_equal :String, error.name
+          assert_equal :constant, error.kind
+        end
+
+        assert_any!(typing.errors) do |error|
+          assert_instance_of Diagnostic::Ruby::UnknownConstant, error
+          assert_equal :Kernel, error.name
+          assert_equal :module, error.kind
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Constant resolution in assignment has a special rule:

* It tries to look up a constant in current module nesting context
* No outer module nesting context lookup
* No ancestor constants lookup