### PR TITLE
Support gvasgn in assignment variants

### DIFF
--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -122,6 +122,8 @@ module Steep
 
     def ivasgn: (Parser::AST::Node node, AST::Types::t rhs_type) -> Pair
 
+    def gvasgn: (Parser::AST::Node node, AST::Types::t rhs_type) -> Pair
+
     def type_masgn: (Parser::AST::Node node) -> Pair
 
     def type_masgn_type: (Parser::AST::Node mlhs_node, AST::Types::t? rhs_type, masgn: TypeInference::MultipleAssignment, optional: bool) -> TypeConstruction?

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10396,4 +10396,57 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       end
     end
   end
+
+  def test_masgn__global
+    with_checker(<<~RBS) do |checker|
+        $FOO: String
+
+        $BAR: Integer
+      RBS
+      source = parse_ruby(<<~RUBY)
+        $FOO, $BAR = "1", 2
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error(typing)
+      end
+    end
+  end
+
+  def test_opasgn__global
+    with_checker(<<~RBS) do |checker|
+        $FOO: String
+      RBS
+      source = parse_ruby(<<~RUBY)
+        $FOO += "hoge"
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error(typing)
+        assert_equal parse_type("::String"), type
+      end
+    end
+  end
+
+  def test_orasgn_andasgn__global
+    with_checker(<<~RBS) do |checker|
+        $FOO: String
+      RBS
+      source = parse_ruby(<<~RUBY)
+        $FOO ||= "hoge"
+        $FOO &&= "huga"
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_no_error(typing)
+        assert_equal parse_type("::String"), type
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements the following assignment variants for global variables.

```ruby
$a, $b = array

$a ||= 123

$b += "hello"
```

Closes #695 
