### PR TITLE
Return immediately if blocks are incompatible

### DIFF
--- a/sig/steep/subtyping/check.rbs
+++ b/sig/steep/subtyping/check.rbs
@@ -97,7 +97,7 @@ module Steep
       # Returns a Relation when the given relation can be expanded to relation between Interface::Block.
       # Returns a failure otherwise.
       #
-      def expand_block_given: (Symbol name, Relation[Interface::Block?] relation) -> (Relation[Interface::Block] | true | Result::t)
+      def expand_block_given: (Symbol name, Relation[Interface::Block?] relation) -> (Relation[Interface::Block] | true | Result::Failure)
 
       # Receives a subtyping relation between self bindings `S <: S'` that is included in procs or blocks as:
       #

--- a/smoke/regression/Steepfile
+++ b/smoke/regression/Steepfile
@@ -1,7 +1,6 @@
 target :test do
   check "*.rb"
   signature "*.rbs"
-  library "set"
 
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/regression/enumerator_product.rb
+++ b/smoke/regression/enumerator_product.rb
@@ -1,0 +1,1 @@
+Enumerator::Product.new([1,2,3], ["a", "b", "c"])


### PR DESCRIPTION
Closes #741

The loop was because of `Array[Integer] <: _EachEntry[A]` and `#each_entry` method type check.