### PR TITLE
Refresh completion list if RBS file has a syntax error

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -144,7 +144,6 @@ module Steep
 
               case sig_service.status
               when Services::SignatureService::SyntaxErrorStatus, Services::SignatureService::AncestorErrorStatus
-
                 if buffer = sig_service.latest_env.buffers.find {|buf| Pathname(buf.name) == Pathname(relative_path) }
                   dirs = sig_service.latest_env.signatures[buffer][0]
                 else
@@ -208,7 +207,7 @@ module Steep
               end
 
               LSP::Interface::CompletionList.new(
-                is_incomplete: false,
+                is_incomplete: !sig_service.status.is_a?(Services::SignatureService::LoadedStatus),
                 items: completion_items
               )
             end


### PR DESCRIPTION
This helps generating better result in the following scenario.

```rbs
class Foo
  attr_reader name: 👈 Start completion here
end
```

The RBS file has a syntax error and it starts completion with `nil` nesting context, while the user expects `::Foo`.

Setting `is_incomplete: true` in this case forces generating a new list after user typing some character, that would make the syntax correct.