### PR TITLE
Should escape underscore for method name

### DIFF
--- a/lib/steep/server/lsp_formatter.rb
+++ b/lib/steep/server/lsp_formatter.rb
@@ -296,7 +296,7 @@ module Steep
 
         io = StringIO.new
         if header
-          io.puts "### 📚 #{header}"
+          io.puts "### 📚 #{header.gsub("_", "\\_")}"
           io.puts
         end
         io.puts comment.string.rstrip.gsub(/^[ \t]*<!--(?~-->)-->\n/, "").gsub(/\A([ \t]*\n)+/, "")


### PR DESCRIPTION
Fixed a display error when a method name is sandwiched between `_` when hovering over a method.

### before

<img width="189" src="https://user-images.githubusercontent.com/935310/235338024-db4040a0-4b69-44fa-a92b-561de25a64ec.png">

### after

<img width="234" src="https://user-images.githubusercontent.com/935310/235338033-fb2517c9-5054-4134-a119-e4b4431930b7.png">