### PR TITLE
Update RBS to 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       logger (>= 1.3.0)
       parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 2.8.0)
+      rbs (>= 3.0.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", ">= 2.8.0"
+  spec.add_runtime_dependency "rbs", ">= 3.0.0"
   spec.add_runtime_dependency "concurrent-ruby", ">= 1.2.2"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
   spec.add_runtime_dependency "securerandom", ">= 0.1"


### PR DESCRIPTION
Steep-1.4.0 contains signatures using "use" directive.  For that reason, steep can't work with rbs-2.x now.  So the dependency for RBS should be updated.