### PR TITLE
Handling splat nodes in `super`

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -877,10 +877,6 @@ module Steep
           yield_self do
             if self_type && method_context!.method
               if super_def = method_context!.super_method
-                each_child_node(node) do |child|
-                  synthesize(child)
-                end
-
                 super_method = Interface::Shape::Entry.new(
                   method_types: super_def.defs.map {|type_def|
                     decl = TypeInference::MethodCall::MethodDecl.new(
@@ -927,12 +923,12 @@ module Steep
                   fallback_to_any(node) { error }
                 end
               else
-                fallback_to_any node do
+                synthesize_children(node).fallback_to_any(node) do
                   Diagnostic::Ruby::UnexpectedSuper.new(node: node, method: method_context!.name)
                 end
               end
             else
-              fallback_to_any node
+              synthesize_children(node).fallback_to_any(node)
             end
           end
 

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -301,6 +301,12 @@ module Steep
       Array[Diagnostic::Ruby::Base]
     ) -> TypeConstruction
 
+    # Type check arguments without known method type
+    #
+    # This handles `:splat` nodes and `:kwargs` node that appears as an argument.
+    #
+    def type_check_untyped_args: (Array[Parser::AST::Node] arguments) -> TypeConstruction
+
     def type_check_argument: (Parser::AST::Node node, type: AST::Types::t, constraints: Subtyping::Constraints, errors: Array[Diagnostic::Ruby::Base], ?report_node: Parser::AST::Node) -> Pair
 
     def type_block_without_hint: (node: Parser::AST::Node & Parser::AST::_BlockNode, block_annotations: AST::Annotation::Collection, block_params: TypeInference::BlockParams?, block_body: Parser::AST::Node?) ?{ (Diagnostic::Ruby::Base) -> void } -> void
@@ -485,7 +491,7 @@ module Steep
     # * When hint is union type, it tries recursively with the union cases.
     # * Otherwise, it tries to be a hash instance.
     #
-    def type_hash: (Parser::AST::Node hash_node, hint: AST::Types::t?) -> untyped
+    def type_hash: (Parser::AST::Node hash_node, hint: AST::Types::t?) -> Pair
 
     # Returns the first one from elements of `types` that returns a type `t` where `t <: hint`.
     #

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10570,4 +10570,33 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       end
     end
   end
+
+  def test_super__splat_arg_untyped
+    with_checker(<<~RBS) do |checker|
+        class SuperSplatBase
+        end
+
+        class SuperSplat < SuperSplatBase
+          def foo: (*Integer) -> void
+        end
+      RBS
+      source = parse_ruby(<<~RUBY)
+        class SuperSplat
+          def foo(*is)
+            super(*is)
+          end
+        end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 1) do |errors|
+          assert_any!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::UnexpectedSuper, error
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10545,4 +10545,29 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       end
     end
   end
+
+  def test_super__splat_arg
+    with_checker(<<~RBS) do |checker|
+        class SuperSplatBase
+          def foo: (String, *Integer) -> void
+        end
+
+        class SuperSplat < SuperSplatBase
+          def foo: (*Integer) -> void
+        end
+      RBS
+      source = parse_ruby(<<~RUBY)
+        class SuperSplat
+          def foo(*is)
+            super("foo", *is)
+          end
+        end
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _, context = construction.synthesize(source.node)
+        assert_no_error(typing)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #743.

It's possible to implement better type checking of splat nodes for the case it has tuple type, but it's not in this PR.