### PR TITLE
Suppress UnsupportedSyntax warnings by default

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -931,7 +931,8 @@ module Steep
             FalseAssertion => :information,
             UnexpectedTypeArgument => :information,
             InsufficientTypeArgument => :information,
-            UnexpectedTypeArgument => :information
+            UnexpectedTypeArgument => :information,
+            UnsupportedSyntax => nil
           }
         ).freeze
       end
@@ -944,7 +945,8 @@ module Steep
             FallbackAny => nil,
             ElseOnExhaustiveCase => nil,
             UnknownConstant => nil,
-            MethodDefinitionMissing => nil
+            MethodDefinitionMissing => nil,
+            UnsupportedSyntax => nil
           }
         ).freeze
       end
@@ -959,7 +961,8 @@ module Steep
             UnknownConstant => nil,
             MethodDefinitionMissing => nil,
             UnexpectedJump => nil,
-            FalseAssertion => :hint
+            FalseAssertion => :hint,
+            UnsupportedSyntax => nil
           }
         ).freeze
       end


### PR DESCRIPTION
UnsupportedSyntax warnings are meaningless message for users.  So they should be suppressed by default.

refs: #787 