### PR TITLE
Better hint type handling given to lambda

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -908,6 +908,19 @@ module Steep
         end
       end
 
+      class ProcHintIgnored < Base
+        attr_reader :hint_type, :block_node
+
+        def initialize(hint_type:, node:)
+          @hint_type = hint_type
+          super(node: node)
+        end
+
+        def header_line
+          "The type hint given to the block is ignored: `#{hint_type}`"
+        end
+      end
+
       ALL = ObjectSpace.each_object(Class).with_object([]) do |klass, array|
         if klass < Base
           array << klass
@@ -932,7 +945,8 @@ module Steep
             UnexpectedTypeArgument => :information,
             InsufficientTypeArgument => :information,
             UnexpectedTypeArgument => :information,
-            UnsupportedSyntax => nil
+            UnsupportedSyntax => nil,
+            ProcHintIgnored => :information
           }
         ).freeze
       end
@@ -946,7 +960,8 @@ module Steep
             ElseOnExhaustiveCase => nil,
             UnknownConstant => nil,
             MethodDefinitionMissing => nil,
-            UnsupportedSyntax => nil
+            UnsupportedSyntax => nil,
+            ProcHintIgnored => :warning
           }
         ).freeze
       end
@@ -962,7 +977,8 @@ module Steep
             MethodDefinitionMissing => nil,
             UnexpectedJump => nil,
             FalseAssertion => :hint,
-            UnsupportedSyntax => nil
+            UnsupportedSyntax => nil,
+            ProcHintIgnored => :hint
           }
         ).freeze
       end

--- a/lib/steep/subtyping/variable_variance.rb
+++ b/lib/steep/subtyping/variable_variance.rb
@@ -63,6 +63,17 @@ module Steep
             covariants << type.name
             contravariants << type.name
           end
+        when AST::Types::Proc
+          type.type.params.each_type do |type|
+            add_type(type, variance: variance, covariants: contravariants, contravariants: covariants)
+          end
+          add_type(type.type.return_type, variance: variance, covariants: covariants, contravariants: contravariants)
+          if type.block
+            type.block.type.params.each_type do |type|
+              add_type(type, variance: variance, covariants: covariants, contravariants: contravariants)
+            end
+            add_type(type.type.return_type, variance: variance, covariants: contravariants, contravariants: covariants)
+          end
         when AST::Types::Union, AST::Types::Intersection, AST::Types::Tuple
           type.types.each do |ty|
             add_type(ty, variance: variance, covariants: covariants, contravariants: contravariants)

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -530,6 +530,17 @@ module Steep
         def header_line: () -> String
       end
 
+      # Type hint is given to a proc/lambda but it was ignored
+      #
+      # 1. Because the hint is incompatible to `::Proc` type
+      # 2. More than one *proc type* is included in the hint
+      #
+      class ProcHintIgnored < Base
+        attr_reader hint_type: AST::Types::t
+
+        def initialize: (hint_type: AST::Types::t, node: Parser::AST::Node) -> void
+      end
+
       # Argument forwarding `...` cannot be done safely, because of
       #
       # 1. The arguments are incompatible, or

--- a/sig/steep/subtyping/variable_variance.rbs
+++ b/sig/steep/subtyping/variable_variance.rbs
@@ -1,25 +1,25 @@
 module Steep
   module Subtyping
     class VariableVariance
-      attr_reader covariants: untyped
+      attr_reader covariants: Set[Symbol]
 
-      attr_reader contravariants: untyped
+      attr_reader contravariants: Set[Symbol]
 
-      def initialize: (covariants: untyped, contravariants: untyped) -> void
+      def initialize: (covariants: Set[Symbol], contravariants: Set[Symbol]) -> void
 
-      def covariant?: (untyped var) -> untyped
+      def covariant?: (Symbol var) -> bool
 
-      def contravariant?: (untyped var) -> untyped
+      def contravariant?: (Symbol var) -> bool
 
-      def invariant?: (untyped var) -> untyped
+      def invariant?: (Symbol var) -> bool
 
       def self.from_type: (AST::Types::t) -> VariableVariance
 
-      def self.from_method_type: (untyped method_type) -> untyped
+      def self.from_method_type: (Interface::MethodType method_type) -> VariableVariance
 
-      def self.add_params: (untyped params, block: untyped, covariants: untyped, contravariants: untyped) -> untyped
+      def self.add_params: (Interface::Function::Params params, block: bool, covariants: Set[Symbol], contravariants: Set[Symbol]) -> void
 
-      def self.add_type: (untyped `type`, variance: untyped, covariants: untyped, contravariants: untyped) -> untyped
+      def self.add_type: (AST::Types::t `type`, variance: :covariant | :contravariant | :invariant, covariants: Set[Symbol], contravariants: Set[Symbol]) -> void
     end
   end
 end


### PR DESCRIPTION
Closes #666

1. It extracts the proc types from the hint for the case that is reported in #666
2. It confirms if only one proc type is included in the hint so that it can determine which proc type to use as its hint
3. Otherwise, it reports a diagnostic that the hint which is given to lambda is just ignored `ProcHintIgnored`