### PR TITLE
Add new diagnostic for setter methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /lib/steep/parser.rb
 /log
 /.gem_rbs_collection
+/.vscode/*
+!/.vscode/steep-shared.code-snippets

--- a/.vscode/steep-shared.code-snippets
+++ b/.vscode/steep-shared.code-snippets
@@ -1,0 +1,41 @@
+{
+	// Place your steep workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+
+	"Add type_check_test case": {
+		"scope": "ruby",
+		"body": [
+			"def test_${1:name}",
+			"  run_type_check_test(",
+			"    signatures: {",
+			"      \"a.rbs\" => <<~RBS",
+			"        ${2:rbs}",
+			"      RBS",
+			"    },",
+			"    code: {",
+			"      \"a.rb\" => <<~RUBY",
+      "        ${3:ruby code}",
+			"      RUBY",
+			"    },",
+			"    expectations: <<~YAML",
+			"    YAML",
+			"  )",
+			"end",
+		],
+		"description": "Insert a new test case"
+	}
+}

--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -982,7 +982,9 @@ module Steep
             InsufficientTypeArgument => :information,
             UnexpectedTypeArgument => :information,
             UnsupportedSyntax => nil,
-            ProcHintIgnored => :information
+            ProcHintIgnored => :information,
+            SetterBodyTypeMismatch => nil,
+            SetterReturnTypeMismatch => nil
           }
         ).freeze
       end
@@ -997,7 +999,9 @@ module Steep
             UnknownConstant => nil,
             MethodDefinitionMissing => nil,
             UnsupportedSyntax => nil,
-            ProcHintIgnored => :warning
+            ProcHintIgnored => :warning,
+            SetterBodyTypeMismatch => :error,
+            SetterReturnTypeMismatch => :error
           }
         ).freeze
       end
@@ -1014,7 +1018,9 @@ module Steep
             UnexpectedJump => nil,
             FalseAssertion => :hint,
             UnsupportedSyntax => nil,
-            ProcHintIgnored => :hint
+            ProcHintIgnored => :hint,
+            SetterBodyTypeMismatch => nil,
+            SetterReturnTypeMismatch => nil
           }
         ).freeze
       end

--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -322,6 +322,24 @@ module Steep
         end
       end
 
+      class SetterReturnTypeMismatch < Base
+        attr_reader :expected, :actual, :result, :method_name
+
+        include ResultPrinter
+
+        def initialize(node:, method_name:, expected:, actual:, result:)
+          super(node: node)
+          @method_name = method_name
+          @expected = expected
+          @actual = actual
+          @result = result
+        end
+
+        def header_line
+          "The setter method `#{method_name}` cannot return a value of type `#{actual}` because declared as type `#{expected}`"
+        end
+      end
+
       class UnexpectedBlockGiven < Base
         attr_reader :method_type
 
@@ -536,6 +554,24 @@ module Steep
 
         def header_line
           "Cannot allow method body have type `#{actual}` because declared as type `#{expected}`"
+        end
+      end
+
+      class SetterBodyTypeMismatch < Base
+        attr_reader :expected, :actual, :result, :method_name
+
+        include ResultPrinter
+
+        def initialize(node:, expected:, actual:, result:, method_name:)
+          super(node: node, location: node.loc.name)
+          @expected = expected
+          @actual = actual
+          @result = result
+          @method_name = method_name
+        end
+
+        def header_line
+          "Setter method `#{method_name}` cannot have type `#{actual}` because declared as type `#{expected}`"
         end
       end
 

--- a/lib/steep/type_inference/context.rb
+++ b/lib/steep/type_inference/context.rb
@@ -21,6 +21,10 @@ module Steep
         def block_type
           method_type&.block
         end
+
+        def attribute_setter?
+          name.to_s.end_with?('=')
+        end
       end
 
       class BlockContext

--- a/sig/shims/language-server_protocol.rbs
+++ b/sig/shims/language-server_protocol.rbs
@@ -18,16 +18,6 @@ module LanguageServer
     end
 
     module Constant
-      module DiagnosticSeverity
-        ERROR: String
-
-        WARNING: String
-
-        INFORMATION: String
-
-        HINT: String
-      end
-
       module CompletionItemKind
         type t = Integer
 
@@ -87,6 +77,26 @@ module LanguageServer
 
         MARKDOWN: "markdown"
       end
+
+      module DiagnosticSeverity
+        type t = 1 | 2 | 3 | 4
+
+        ERROR: 1
+
+        WARNING: 2
+
+        INFORMATION: 3
+
+        HINT: 4
+      end
+
+      module DiagnosticTag
+        type t = 1 | 2
+
+        UNNECESSARY: 1
+
+        DEPRECATED: 2
+      end
     end
 
     module Interface
@@ -120,6 +130,16 @@ module LanguageServer
 
         def initialize: (start: Position, end: Position) -> void
                       | (Hash[Symbol, untyped]) -> void
+      end
+
+      class Location
+        include _Base
+
+        attr_reader uri: String
+
+        attr_reader range: Range
+
+        def initialize: (uri: String, range: Range) -> void
       end
 
       class MarkupContent
@@ -291,6 +311,68 @@ module LanguageServer
         attr_reader active_parameter: Integer?
 
         def initialize: (signatures: Array[SignatureInformation], ?active_signature: Integer?, ?active_parameter: Integer?) -> void
+      end
+
+      class PublishDiagnosticsParams
+        include _Base
+
+        attr_reader uri: String
+
+        attr_reader version: Integer?
+
+        attr_reader diagnostics: Array[Diagnostic]
+
+        def initialize: (uri: String, ?version: Integer?, diagnostics: Array[Diagnostic]) -> void
+      end
+
+      class Diagnostic
+        attr_reader range: Range
+
+        attr_reader severity: Constant::DiagnosticSeverity::t?
+
+        attr_reader code: Integer | String | nil
+
+        attr_reader code_description: CodeDescription?
+
+        attr_reader source: String?
+
+        attr_reader message: String
+
+        attr_reader tags: Array[Constant::DiagnosticTag::t]?
+
+        attr_reader related_information: RelatedInformation?
+
+        attr_reader data: untyped?
+
+        def initialize: (
+          range: Range,
+          ?severity: Constant::DiagnosticSeverity::t?,
+          ?code: Integer | String | nil,
+          ?code_description: CodeDescription?,
+          ?source: String?,
+          message: String,
+          ?tags: Array[Constant::DiagnosticTag::t]?,
+          ?related_information: RelatedInformation?,
+          ?data: untyped
+        ) -> void
+      end
+
+      class RelatedInformation
+        include _Base
+
+        attr_reader location: Location
+
+        attr_reader message: String
+
+        def initialize: (location: Location, message: String) -> void
+      end
+
+      class CodeDescription
+        include _Base
+
+        attr_reader href: String
+
+        def initialize: (href: String) -> void
       end
     end
   end

--- a/sig/shims/parser/nodes.rbs
+++ b/sig/shims/parser/nodes.rbs
@@ -19,6 +19,8 @@ module Parser
     end
 
     interface _DefLocation
+      def name: () -> Source::Range
+
       %a{pure} def end: () -> Source::Range?
     end
 

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -153,6 +153,36 @@ module Steep
         def header_line: () -> ::String
       end
 
+      # Setter method, which has a name ending with `=`, returns different type from the method type
+      #
+      # ```ruby
+      # class Foo
+      #   # Assume `name=` has method type of `(String) -> String`
+      #   def name=(value)
+      #     return if value.empty?
+      #     @value = value
+      #   end
+      # end
+      # ```
+      #
+      # This is a special diagnostic for setter methods because the return value is not used with ordinal call syntax.
+      #
+      class SetterReturnTypeMismatch < Base
+        attr_reader expected: AST::Types::t
+
+        attr_reader actual: AST::Types::t
+
+        attr_reader result: Subtyping::Result::Base
+
+        attr_reader method_name: Symbol
+
+        include ResultPrinter
+
+        def initialize: (node: Parser::AST::Node, method_name: Symbol, expected: AST::Types::t, actual: AST::Types::t, result: Subtyping::Result::Base) -> void
+
+        def header_line: () -> String
+      end
+
       class UnexpectedBlockGiven < Base
         attr_reader method_type: untyped
 
@@ -297,6 +327,36 @@ module Steep
         def initialize: (node: untyped, expected: untyped, actual: untyped, result: untyped) -> void
 
         def header_line: () -> ::String
+      end
+
+      # Setter method, which has a name ending with `=`, has different type from the method type
+      #
+      # ```ruby
+      # class Foo
+      #   # Assume `name=` has method type of `(String) -> String`
+      #   def name=(value)
+      #     @value = value
+      #     value.strip!
+      #   end
+      # end
+      # ```
+      #
+      # This is a special diagnostic for setter methods because the return value is not used with ordinal call syntax.
+      #
+      class SetterBodyTypeMismatch < Base
+        attr_reader expected: AST::Types::t
+
+        attr_reader actual: AST::Types::t
+
+        attr_reader result: Subtyping::Result::Base
+
+        attr_reader method_name: Symbol
+
+        include ResultPrinter
+
+        def initialize: (node: Parser::AST::Node & Parser::AST::_DefNode, expected: AST::Types::t, actual: AST::Types::t, result: Subtyping::Result::Base, method_name: Symbol) -> void
+
+        def header_line: () -> String
       end
 
       class UnexpectedYield < Base

--- a/sig/steep/drivers/check.rbs
+++ b/sig/steep/drivers/check.rbs
@@ -3,31 +3,31 @@ module Steep
     class Check
       module LSP = LanguageServer::Protocol
 
-      attr_reader stdout: untyped
+      attr_reader stdout: IO
 
-      attr_reader stderr: untyped
+      attr_reader stderr: IO
 
-      attr_reader command_line_patterns: untyped
+      attr_reader command_line_patterns: Array[String]
 
-      attr_accessor with_expectations_path: untyped
+      attr_accessor with_expectations_path: Pathname?
 
-      attr_accessor save_expectations_path: untyped
+      attr_accessor save_expectations_path: Pathname?
 
-      attr_accessor severity_level: untyped
+      attr_accessor severity_level: Diagnostic::LSPFormatter::severity
 
       attr_reader jobs_option: Utils::JobsOption
 
       include Utils::DriverHelper
 
-      def initialize: (stdout: untyped, stderr: untyped) -> void
+      def initialize: (stdout: IO, stderr: IO) -> void
 
       def run: () -> Integer
 
-      def print_expectations: (project: untyped, all_files: untyped, expectations_path: untyped, notifications: untyped) -> untyped
+      def print_expectations: (project: Project, all_files: Array[Pathname], expectations_path: Pathname, notifications: Array[untyped]) -> Integer
 
-      def save_expectations: (project: untyped, all_files: untyped, expectations_path: untyped, notifications: untyped) -> 0
+      def save_expectations: (project: Project, all_files: Array[Pathname], expectations_path: Pathname, notifications: Array[untyped]) -> Integer
 
-      def print_result: (project: untyped, notifications: untyped) -> (0 | 1)
+      def print_result: (project: Project, notifications: Array[untyped]) -> Integer
     end
   end
 end

--- a/sig/steep/drivers/diagnostic_printer.rbs
+++ b/sig/steep/drivers/diagnostic_printer.rbs
@@ -17,7 +17,7 @@ module Steep
 
       def location: (untyped diagnostic) -> String
 
-      def print: (untyped diagnostic, ?prefix: ::String, ?source: bool) -> void
+      def print: (Hash[Symbol, untyped] diagnostic, ?prefix: ::String, ?source: bool) -> void
 
       def print_source_line: (untyped diagnostic, ?prefix: ::String) -> void
     end

--- a/sig/steep/expectations.rbs
+++ b/sig/steep/expectations.rbs
@@ -1,0 +1,72 @@
+module Steep
+  class Expectations
+    type status = :expected | :missing | :unexpected
+
+    class Diagnostic
+      module DiagnosticSeverity = LanguageServer::Protocol::Constant::DiagnosticSeverity
+
+      type position = { line: Integer, character: Integer }
+
+      attr_reader start_position: position
+
+      attr_reader end_position: position
+
+      attr_reader severity: Steep::Diagnostic::LSPFormatter::severity
+
+      attr_reader message: String
+
+      attr_reader code: String
+
+      def initialize: (start_position: position, end_position: position, severity: Steep::Diagnostic::LSPFormatter::severity, message: String, code: String) -> void
+
+      def self.from_hash: (untyped) -> instance
+
+      def self.from_lsp: (untyped) -> Diagnostic
+
+      def to_hash: () -> Hash[String, untyped]
+
+      def to_lsp: () -> Hash[Symbol, untyped]
+
+      def lsp_severity: () -> Integer
+
+      def sort_key: () -> Array[untyped]
+    end
+
+    class TestResult
+      attr_reader path: Pathname
+
+      attr_reader expectation: Array[Diagnostic]
+
+      attr_reader actual: Array[Diagnostic]
+
+      def initialize: (path: Pathname, expectation: Array[Diagnostic], actual: Array[Diagnostic]) -> void
+
+      def empty?: () -> bool
+
+      def satisfied?: () -> bool
+
+      def each_diagnostics: () { ([status, Diagnostic]) -> void } -> void
+                          | () -> Enumerator[[status, Diagnostic], void]
+
+      def expected_diagnostics: () -> Array[Diagnostic]
+
+      def unexpected_diagnostics: () -> Array[Diagnostic]
+
+      def missing_diagnostics: () -> Array[Diagnostic]
+    end
+
+    module LSP = LanguageServer::Protocol
+
+    attr_reader diagnostics: Hash[Pathname, Array[Diagnostic]]
+
+    def initialize: () -> void
+
+    def test: (path: Pathname, diagnostics: Array[Diagnostic]) -> TestResult
+
+    def self.empty: () -> instance
+
+    def to_yaml: () -> String
+
+    def self.load: (path: Pathname, content: String) -> instance
+  end
+end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -36,6 +36,8 @@ module Steep
 
     %a{pure} def module_context: () -> TypeInference::Context::ModuleContext
 
+    # `method_context` is `nil` outside of any `def` syntax
+    #
     %a{pure} def method_context: () -> TypeInference::Context::MethodContext?
 
     def method_context!: () -> TypeInference::Context::MethodContext
@@ -165,7 +167,7 @@ module Steep
     def synthesize_constant: (Parser::AST::Node? node, Parser::AST::Node? parent_node, Symbol constant_name) ?{ () -> void } -> [AST::Types::t, TypeConstruction, RBS::TypeName?]
 
     # Returns a proc type if given type is a two clause union with the proc type and `nil`
-    # 
+    #
     def optional_proc?: (AST::Types::t) -> AST::Types::Proc?
 
     def type_lambda: (Parser::AST::Node & Parser::AST::_BlockNode node, params_node: Parser::AST::Node, body_node: Parser::AST::Node, type_hint: AST::Types::t?) -> Pair

--- a/sig/steep/type_inference/context.rbs
+++ b/sig/steep/type_inference/context.rbs
@@ -36,6 +36,10 @@ module Steep
 
         # Type of the block of the current method type
         def block_type: () -> Interface::Block?
+
+        # Returns `true` if the method is a setter -- ends with `=`
+        #
+        def attribute_setter?: () -> bool
       end
 
       # Information about the block which the body is being type checked

--- a/test/expectations_test.rb
+++ b/test/expectations_test.rb
@@ -5,6 +5,8 @@ class ExpectationsTest < Minitest::Test
   include ShellHelper
   include Steep
 
+  Diagnostic = Expectations::Diagnostic
+
   LSP = LanguageServer::Protocol
 
   def test_load
@@ -25,12 +27,10 @@ YAML
 
     assert_equal(
       [
-        {
-          range: {
-            start: { line: 3, character: 0 },
-            end: { line: 3, character: 7 }
-          },
-          severity: LSP::Constant::DiagnosticSeverity::ERROR,
+        Diagnostic.new(
+          start_position: { line: 3, character: 0 },
+          end_position: { line: 3, character: 7 },
+          severity: :error,
           code: "Ruby::UnresolvedOverloading",
           message: <<~MSG
             Cannot assign a value of type `::String` to a variable of type `::Symbol`
@@ -38,7 +38,7 @@ YAML
                 ::Object <: ::Symbol
                   ::BasicObject <: ::Symbol
           MSG
-        }
+        )
       ],
       es.diagnostics[Pathname("a.rb")]
     )
@@ -46,33 +46,27 @@ YAML
 
   def test_testresult
     ds = [
-      {
-        range: {
-          start: { line: 3, character: 0 },
-          end: { line: 3, character: 7 }
-        },
-        severity: LSP::Constant::DiagnosticSeverity::ERROR,
+      Diagnostic.new(
+        start_position: { line: 3, character: 0 },
+        end_position: { line: 3, character: 7 },
+        severity: :error,
         code: "Ruby::UnresolvedOverloading",
         message: "Diagnostic 1"
-      },
-      {
-        range: {
-          start: { line: 3, character: 3 },
-          end: { line: 3, character: 7 }
-        },
-        severity: LSP::Constant::DiagnosticSeverity::ERROR,
+      ),
+      Diagnostic.new(
+        start_position: { line: 3, character: 3 },
+        end_position: { line: 3, character: 7 },
+        severity: :error,
         code: "Ruby::UnresolvedOverloading",
         message: "Diagnostic 2"
-      },
-      {
-        range: {
-          start: { line: 4, character: 0 },
-          end: { line: 5, character: 0 }
-        },
-        severity: LSP::Constant::DiagnosticSeverity::ERROR,
+      ),
+      Diagnostic.new(
+        start_position: { line: 4, character: 0 },
+        end_position: { line: 5, character: 0 },
+        severity: :error,
         code: "Ruby::UnresolvedOverloading",
         message: "Diagnostic 3"
-      }
+      )
     ]
 
     result = Expectations::TestResult.new(

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1,6 +1,13 @@
 require_relative "test_helper"
 
-class TypeConstructionTest < Minitest::Test
+# (Almost) end-to-end type checking test
+#
+# Specify the type definition, Ruby code, and expected diagnostics.
+# Running test here allows using debuggers.
+#
+# You can use `Add type_check_test case` VSCode snippet to add new test case.
+#
+class TypeCheckTest < Minitest::Test
   include TestHelper
   include TypeErrorAssertions
   include FactoryHelper

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1,0 +1,106 @@
+require_relative "test_helper"
+
+class TypeConstructionTest < Minitest::Test
+  include TestHelper
+  include TypeErrorAssertions
+  include FactoryHelper
+  include SubtypingHelper
+  include TypeConstructionHelper
+
+  include Steep
+
+  def run_type_check_test(signatures: {}, code: {}, expectations: nil)
+    typings = {}
+
+    with_factory(signatures, nostdlib: false) do |factory|
+      builder = Interface::Builder.new(factory)
+      subtyping = Subtyping::Check.new(builder: builder)
+
+      code.each do |path, content|
+        source = Source.parse(content, path: path, factory: factory)
+        with_standard_construction(subtyping, source) do |construction, typing|
+          construction.synthesize(source.node)
+
+          typings[path] = typing
+        end
+      end
+    end
+
+    formatter = Diagnostic::LSPFormatter.new()
+
+    diagnostics = typings.transform_values do |typing|
+      typing.errors.map do |error|
+        Expectations::Diagnostic.from_lsp(formatter.format(error))
+      end
+    end
+
+    if expectations
+      exps = Expectations.empty
+      diagnostics.each do |path, ds|
+        exps.diagnostics[path] = ds
+      end
+      exps.to_yaml
+
+      assert_equal expectations, exps.to_yaml
+    end
+
+    yield typings if block_given?
+  end
+
+  def test_setter_type
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class SetterReturnType
+            def foo=: (String) -> String
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class SetterReturnType
+            def foo=(value)
+              if value
+                return
+              else
+                123
+              end
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 2
+                character: 6
+              end:
+                line: 2
+                character: 10
+            severity: ERROR
+            message: |-
+              Setter method `foo=` cannot have type `::Integer` because declared as type `::String`
+                ::Integer <: ::String
+                  ::Numeric <: ::String
+                    ::Object <: ::String
+                      ::BasicObject <: ::String
+            code: Ruby::SetterBodyTypeMismatch
+          - range:
+              start:
+                line: 4
+                character: 6
+              end:
+                line: 4
+                character: 12
+            severity: ERROR
+            message: |-
+              The setter method `foo=` cannot return a value of type `nil` because declared as type `::String`
+                nil <: ::String
+            code: Ruby::SetterReturnTypeMismatch
+      YAML
+    )
+  end
+end


### PR DESCRIPTION
Fixes #729 

This PR adds two new Ruby diagnostics -- `SetterBodyTypeMismatch` and `SetterReturnTypeMismatch`. The users can configure the diagnostics to make type checking consistent with RuboCop offense.