### PR TITLE
Completion in annotations

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -1,7 +1,7 @@
 require "steep/version"
 
 require "pathname"
-require "parser/ruby31"
+require "parser/ruby32"
 require "active_support"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"

--- a/lib/steep/node_helper.rb
+++ b/lib/steep/node_helper.rb
@@ -45,5 +45,175 @@ module Steep
         false
       end
     end
+
+    def deconstruct_if_node(node)
+      if node.type == :if
+        [
+          node.children[0],
+          node.children[1],
+          node.children[2],
+          _ = node.location
+        ]
+      end
+    end
+
+    def deconstruct_if_node!(node)
+      deconstruct_if_node(node) or raise
+    end
+
+    def test_if_node(node)
+      if (a, b, c, d = deconstruct_if_node(node))
+        yield(a, b, c, d)
+      else
+        false
+      end
+    end
+
+    def deconstruct_whileish_node(node)
+      case node.type
+      when :while, :until, :while_post, :until_post
+        [
+          node.children[0],
+          node.children[1],
+          _ = node.location
+        ]
+      end
+    end
+
+    def deconstruct_whileish_node!(node)
+      deconstruct_whileish_node(node) or raise
+    end
+
+    def test_whileish_node(node)
+      if (a, b, c = deconstruct_whileish_node(node))
+        yield(a, b, c)
+      else
+        false
+      end
+    end
+
+    def deconstruct_case_node(node)
+      case node.type
+      when :case
+        cond, *whens, else_ = node.children
+        [
+          cond,
+          whens,
+          else_,
+          _ = node.loc
+        ]
+      end
+    end
+
+    def deconstruct_case_node!(node)
+      deconstruct_case_node(node) or raise
+    end
+
+    def test_case_node(node)
+      if (a, b, c, d = deconstruct_case_node(node))
+        yield a, b, c, d
+      else
+        false
+      end
+    end
+
+    def deconstruct_when_node(node)
+      case node.type
+      when :when
+        *conds, body = node.children
+        [
+          conds,
+          body,
+          _ = node.loc
+        ]
+      end
+    end
+
+    def deconstruct_when_node!(node)
+      deconstruct_when_node(node) or raise
+    end
+
+    def test_when_node(node)
+      if (a, b, c = deconstruct_when_node(node))
+        yield a, b, c
+      else
+        false
+      end
+    end
+
+    def deconstruct_rescue_node(node)
+      case node.type
+      when :rescue
+        body, *resbodies, else_ = node.children
+
+        [
+          body,
+          resbodies,
+          else_,
+          _ = node.loc
+        ]
+      end
+    end
+
+    def deconstruct_rescue_node!(node)
+      deconstruct_rescue_node(node) or raise
+    end
+
+    def test_rescue_node(node)
+      if (a, b, c, d = deconstruct_rescue_node(node))
+        yield a, b, c, d
+      else
+        false
+      end
+    end
+
+    def deconstruct_resbody_node(node)
+      case node.type
+      when :resbody
+        [
+          node.children[0],
+          node.children[1],
+          node.children[2],
+          _  = node.loc
+        ]
+      end
+    end
+
+    def deconstruct_resbody_node!(node)
+      deconstruct_resbody_node(node) or raise
+    end
+
+    def test_resbody_node(node)
+      if (a, b, c, d = deconstruct_resbody_node(node))
+        yield a, b, c, d
+      else
+        false
+      end
+    end
+
+    def deconstruct_send_node(node)
+      case node.type
+      when :send, :csend
+        receiver, selector, *args = node.children
+        [
+          receiver,
+          selector,
+          args,
+          _  = node.loc
+        ]
+      end
+    end
+
+    def deconstruct_send_node!(node)
+      deconstruct_send_node(node) or raise
+    end
+
+    def test_send_node(node)
+      if (a, b, c, d = deconstruct_send_node(node))
+        yield a, b, c, d
+      else
+        false
+      end
+    end
   end
 end

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -361,6 +361,26 @@ module Steep
               new_text: item.identifier.to_s
             )
           )
+        when Services::CompletionProvider::TypeNameItem
+          kind =
+            case
+            when item.absolute_type_name.class?
+              LSP::Constant::CompletionItemKind::CLASS
+            when item.absolute_type_name.interface?
+              LSP::Constant::CompletionItemKind::INTERFACE
+            when item.absolute_type_name.alias?
+              LSP::Constant::CompletionItemKind::FIELD
+            end
+          LSP::Interface::CompletionItem.new(
+            label: item.relative_type_name.to_s,
+            kind: kind,
+            label_details: nil,
+            documentation: LSPFormatter.markup_content { LSPFormatter.format_completion_docs(item) },
+            text_edit: LSP::Interface::TextEdit.new(
+              range: range,
+              new_text: item.relative_type_name.to_s
+            )
+          )
         end
       end
 

--- a/lib/steep/server/lsp_formatter.rb
+++ b/lib/steep/server/lsp_formatter.rb
@@ -231,6 +231,25 @@ module Steep
           format_method_item_doc(item.method_types, method_names, comments)
         when Services::CompletionProvider::GeneratedMethodNameItem
           format_method_item_doc(item.method_types, [], {}, "🤖 Generated method for receiver type")
+        when Services::CompletionProvider::TypeNameItem
+          io = StringIO.new
+
+          io.puts <<~MD
+            ```rbs
+            #{declaration_summary(item.decl)}
+            ```
+          MD
+
+          unless item.comments.empty?
+            io.puts "----"
+            io.puts format_comments(
+              item.comments.map {|comment|
+                [item.absolute_type_name.relative!.to_s, comment] #: [String, RBS::AST::Comment?]
+              }
+            )
+          end
+
+          io.string
         end
       end
 

--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -98,6 +98,62 @@ module Steep
         # @implements GeneratedMethodNameItem
       end
 
+      class TypeNameItem < Struct.new(:env, :absolute_type_name, :relative_type_name, :range, keyword_init: true)
+        def decl
+          case
+          when absolute_type_name.interface?
+            env.interface_decls[absolute_type_name].decl
+          when absolute_type_name.alias?
+            env.type_alias_decls[absolute_type_name].decl
+          when absolute_type_name.class?
+            case entry = env.module_class_entry(absolute_type_name)
+            when RBS::Environment::ClassEntry, RBS::Environment::ModuleEntry
+              entry.primary.decl
+            when RBS::Environment::ClassAliasEntry, RBS::Environment::ModuleAliasEntry
+              entry.decl
+            else
+              raise
+            end
+          else
+            raise
+          end
+        end
+
+        def comments
+          comments = [] #: Array[RBS::AST::Comment]
+
+          case
+          when absolute_type_name.interface?
+            if comment = env.interface_decls[absolute_type_name].decl.comment
+              comments << comment
+            end
+          when absolute_type_name.alias?
+            if comment = env.type_alias_decls[absolute_type_name].decl.comment
+              comments << comment
+            end
+          when absolute_type_name.class?
+            case entry = env.module_class_entry(absolute_type_name)
+            when RBS::Environment::ClassEntry, RBS::Environment::ModuleEntry
+              entry.decls.each do |decl|
+                if comment = decl.decl.comment
+                  comments << comment
+                end
+              end
+            when RBS::Environment::ClassAliasEntry, RBS::Environment::ModuleAliasEntry
+              if comment = entry.decl.comment
+                comments << comment
+              end
+            else
+              raise
+            end
+          else
+            raise
+          end
+
+          comments
+        end
+      end
+
       attr_reader :source_text
       attr_reader :path
       attr_reader :subtyping
@@ -146,9 +202,19 @@ module Steep
             end
           end
 
-          # Skip if the cursor is in a comment.
-          # 
-          at_comment?(position) and return []
+          if at_comment?(position)
+            annotation = source.each_annotation.flat_map {|_, annots| annots }.find do |a|
+              if a.location
+                a.location.start_pos < index && index <= a.location.end_pos
+              end
+            end
+
+            if annotation
+              return items_for_rbs(position: position, annotation: annotation)
+            else
+              return []
+            end
+          end
 
           Steep.measure "completion item collection" do
             items_for_trigger(position: position)
@@ -359,6 +425,26 @@ module Steep
         context = typing.context_at(line: position.line, column: position.column)
         items = [] #: Array[item]
         instance_variable_items_for_context(context, prefix: "@", position: position, items: items)
+        items
+      end
+
+      def items_for_rbs(position:, annotation:)
+        items = [] #: Array[item]
+
+        annotation.location or raise
+
+        context = typing.context_at(line: position.line, column: position.column)
+        completion = TypeNameCompletion.new(env: context.env, context: context.module_context.nesting, dirs: [])
+        prefix = TypeNameCompletion::Prefix.parse(annotation.location.buffer, line: position.line, column: position.column)
+
+        size = prefix&.size || 0
+        range = Range.new(start: position - size, end: position)
+
+        completion.find_type_names(prefix).each do |name|
+          absolute, relative = completion.resolve_name_in_context(name)
+          items << TypeNameItem.new(relative_type_name: relative, absolute_type_name: absolute, env: context.env, range: range)
+        end
+
         items
       end
 

--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -146,6 +146,10 @@ module Steep
             end
           end
 
+          # Skip if the cursor is in a comment.
+          # 
+          at_comment?(position) and return []
+
           Steep.measure "completion item collection" do
             items_for_trigger(position: position)
           end
@@ -186,6 +190,14 @@ module Steep
       def at_end?(pos, of:)
         if of
           of.last_line == pos.line && of.last_column == pos.column
+        end
+      end
+
+      def at_comment?(position)
+        if source.find_comment(line: position.line, column: position.column)
+          true
+        else
+          false
         end
       end
 

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -24,7 +24,7 @@ module Steep
     end
 
     def self.new_parser
-      ::Parser::Ruby31.new(Builder.new).tap do |parser|
+      ::Parser::Ruby32.new(Builder.new).tap do |parser|
         parser.diagnostics.all_errors_are_fatal = true
         parser.diagnostics.ignore_warnings = true
       end

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -489,7 +489,11 @@ module Steep
                 nil,
                 [
                   map_child_node(send) {|child| insert_type_node(child, child_assertions) },
-                  *children.map {|child| insert_type_node(child, child_assertions) }
+                  *children.map do |child|
+                    if child
+                      insert_type_node(child, child_assertions)
+                    end
+                  end
                 ]
               )
             when :numblock

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3711,7 +3711,7 @@ module Steep
     def try_method_type(node, receiver_type:, method_name:, method_type:, arguments:, block_params:, block_body:, tapp:, hint:)
       constr = self
 
-      if tapp && type_args = tapp.types?(module_context.nesting, checker.factory, [])
+      if tapp && type_args = tapp.types?(module_context.nesting, checker, [])
         type_arity = method_type.type_params.size
         type_param_names = method_type.type_params.map(&:name)
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2494,7 +2494,7 @@ module Steep
             # @type var as_type: AST::Node::TypeAssertion
             asserted_node, as_type = node.children
 
-            if type = as_type.type?(module_context.nesting, checker.factory, [])
+            if type = as_type.type?(module_context.nesting, checker, [])
               actual_type, constr = synthesize(asserted_node, hint: type)
 
               if no_subtyping?(sub_type: type, super_type: actual_type) && no_subtyping?(sub_type: actual_type, super_type: type)

--- a/lib/steep/type_inference/context_array.rb
+++ b/lib/steep/type_inference/context_array.rb
@@ -23,14 +23,15 @@ module Steep
         root.range
       end
 
-      def self.from_source(source:, range: nil, context: nil)
+      def self.from_source(source:, range: nil, context:)
         content = if source.node
                     source.node.location.expression.source_buffer.source
                   else
                     ""
                   end
         buffer = RBS::Buffer.new(name: source.path, content: content)
-        new(buffer: buffer, context: context, range: range || 0..buffer.content.size)
+        range ||= 0..buffer.content.size
+        new(buffer: buffer, context: context, range: range)
       end
 
       def insert_context(range, context:, entry: self.root)
@@ -62,12 +63,11 @@ module Steep
         end
       end
 
-      def each_entry
-        if block_given?
+      def each_entry(&block)
+        if block
           es = [root]
 
-          until es.empty?
-            e = es.pop
+          while e = es.pop
             es.push(*e.sub_entries.to_a)
 
             yield e

--- a/lib/steep/typing.rb
+++ b/lib/steep/typing.rb
@@ -32,10 +32,10 @@ module Steep
       @should_update = false
 
       @errors = []
-      @typing = {}.compare_by_identity
+      (@typing = {}).compare_by_identity
       @root_context = root_context
-      @contexts = contexts || TypeInference::ContextArray.from_source(source: source)
-      @method_calls = {}.compare_by_identity
+      @contexts = contexts || TypeInference::ContextArray.from_source(source: source, context: root_context)
+      (@method_calls = {}).compare_by_identity
 
       @source_index = source_index || Index::SourceIndex.new(source: source)
     end
@@ -222,10 +222,11 @@ module Steep
     end
 
     def new_child(range)
+      context = contexts[range.begin] || contexts.root.context
       child = self.class.new(source: source,
                              parent: self,
                              root_context: root_context,
-                             contexts: TypeInference::ContextArray.new(buffer: contexts.buffer, range: range, context: nil),
+                             contexts: TypeInference::ContextArray.new(buffer: contexts.buffer, range: range, context: context),
                              source_index: source_index.new_child)
       @should_update = true
 

--- a/sig/shims/parser.rbs
+++ b/sig/shims/parser.rbs
@@ -25,6 +25,16 @@ module Parser
     attr_reader diagnostics: untyped
   end
 
+  class Ruby32
+    def initialize: (untyped builder) -> void
+
+    def parse: (Source::Buffer) -> AST
+
+    def parse_with_comments: (Source::Buffer) -> [AST::Node, Array[Source::Comment]]
+
+    attr_reader diagnostics: untyped
+  end
+
   module Source
     class Buffer
       def initialize: (String file, Integer lineno, source: String) -> void

--- a/sig/shims/parser/nodes.rbs
+++ b/sig/shims/parser/nodes.rbs
@@ -43,5 +43,205 @@ module Parser
     interface _SelectorLocation
       %a{pure} def selector: () -> Source::Range
     end
+
+    # ```ruby
+    # if foo then bar else baz end
+    # #^                              => keyword
+    # #      ^^^^                     => begin
+    # #               ^^^^            => else
+    # #                        ^^^    => end
+    # ```
+    #
+    interface _Condition
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def else: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    interface _Ternary
+      %a{pure} def question: () -> Source::Range
+
+      %a{pure} def colon: () -> Source::Range
+    end
+
+    interface _Variable
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    # foo.bar(baz)
+    # #  ^             => dot
+    # #   ^^^          => selector
+    # #      ^         => begin
+    # #          ^     => end
+    #
+    # foo.bar += 1
+    # #  ^             => dot
+    # #   ^^^          => selector
+    # #       ^^       => operator
+    # ```
+    #
+    interface _Send
+      %a{pure} def dot: () -> Source::Range?
+
+      %a{pure} def selector: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    # ```ruby
+    # rescue Foo => x then
+    # #^^^^^                => keyword
+    # #          ^^         => assoc
+    # #               ^^^^  => begin
+    # ```
+    interface _RescueBody
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def assoc: () -> Source::Range?
+
+      %a{pure} def begin: () -> Source::Range?
+    end
+
+    # ```ruby
+    # +1
+    # ^         => operator
+    # ```
+    interface _Operator
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    # def self.foo(); end
+    # #^^                        => keyword
+    # #       ^                  => operator
+    # #        ^^^               => name
+    # #               ^^^        => end
+    #
+    # def foo = bar
+    # #^^                        => keyword
+    # #   ^^^                    => name
+    # #       ^                  => assignment
+    # ```
+    interface _MethodDefinition
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def end: () -> Source::Range?
+
+      %a{pure} def assignment: () -> Source::Range?
+    end
+
+    # ```ruby
+    # when foo then
+    # #^^^             => keyword
+    # #        ^^^^    => begin
+    # ```
+    interface _Keyword
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
+
+    # ```ruby
+    # foo[1] += 1
+    # #  ^             => begin
+    # #    ^           => end
+    # #      ^^        => operator
+    # ```
+    interface _Index
+      %a{pure} def begin: () -> Source::Range
+
+      %a{pure} def end: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    # <<FOO                   <= expression
+    #   foo                   <= heredoc_body
+    # FOO                     <= heredoc_end
+    # ```
+    #
+    interface _Heredoc
+      %a{pure} def heredoc_body: () -> Source::Range
+
+      %a{pure} def heredoc_end: () -> Source::Range
+    end
+
+    # ```ruby
+    # for x in [] then ... end
+    # #^^                       => keyword
+    # #     ^^                  => in
+    # #           ^^^^          => begin
+    # #                    ^^^  => end
+    # ```
+    interface _For
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def in: () -> Source::Range
+
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range
+    end
+
+    # ```ruby
+    # class Foo::Bar < Baz; end
+    # #^^^^                       => keyword
+    # #     ^^^^^^^^              => name
+    # #              ^            => operator
+    # #                     ^^^   => end
+    # ```
+    interface _Definition
+      %a{pure} def keyword: () -> Source::Range
+
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range
+    end
+
+    # ```ruby
+    # Foo::Bar += 1
+    # #  ^^                 => double_colon
+    # #    ^^^              => name
+    # #        ^^           => operator
+    # ```
+    #
+    interface _Constant
+      %a{pure} def double_colon: () -> Source::Range?
+
+      %a{pure} def name: () -> Source::Range
+
+      %a{pure} def operator: () -> Source::Range?
+    end
+
+    # ```ruby
+    #   (1)
+    # # ^           => begin
+    # #   ^         => end
+    # ```
+    interface _Collection
+      %a{pure} def begin: () -> Source::Range?
+
+      %a{pure} def end: () -> Source::Range?
+    end
   end
 end

--- a/sig/steep/ast/node/type_application.rbs
+++ b/sig/steep/ast/node/type_application.rbs
@@ -12,9 +12,9 @@ module Steep
 
         def initialize: (RBS::Location[untyped, untyped]) -> void
 
-        def types: (RBS::Resolver::context, Types::Factory, Array[Symbol] type_vars) -> (Array[Types::t] | RBS::ParsingError)
+        def types: (RBS::Resolver::context, Subtyping::Check, Array[Symbol] type_vars) -> (Array[Types::t] | RBS::ParsingError | nil)
 
-        def types?: (RBS::Resolver::context, Types::Factory, Array[Symbol] type_vars) -> Array[Types::t]?
+        def types?: (RBS::Resolver::context, Subtyping::Check, Array[Symbol] type_vars) -> Array[Types::t]?
 
         @type_str: String?
         def type_str: () -> String

--- a/sig/steep/ast/node/type_assertion.rbs
+++ b/sig/steep/ast/node/type_assertion.rbs
@@ -10,9 +10,9 @@ module Steep
 
         def initialize: (RBS::Location[untyped, untyped]) -> void
 
-        def type: (RBS::Resolver::context, Types::Factory, Array[Symbol] type_vars) -> (Types::t | RBS::ParsingError | nil)
+        def type: (RBS::Resolver::context, Subtyping::Check, Array[Symbol] type_vars) -> (Types::t | RBS::ParsingError | nil)
 
-        def type?: (RBS::Resolver::context, Types::Factory, Array[Symbol] type_vars) -> Types::t?
+        def type?: (RBS::Resolver::context, Subtyping::Check, Array[Symbol] type_vars) -> Types::t?
 
         @type_str: String?
         def type_str: () -> String
@@ -22,7 +22,7 @@ module Steep
         # Returns true if given comment body has a valid type syntax
         #
         # This method is used to reject RDoc directives beforehand.
-        # 
+        #
         def type_syntax?: () -> bool
 
         def self.parse: (RBS::Location[untyped, untyped]) -> TypeAssertion?

--- a/sig/steep/node_helper.rbs
+++ b/sig/steep/node_helper.rbs
@@ -1,3 +1,7 @@
+use Parser::AST::Node
+use Parser::AST::_Condition, Parser::AST::_Ternary, Parser::AST::_Keyword, Parser::AST::_RescueBody, Parser::AST::_Send
+use Parser::Source::Map
+
 module Steep
   module NodeHelper
     def each_child_node: (Parser::AST::Node) -> Enumerator[Parser::AST::Node, void]
@@ -9,5 +13,57 @@ module Steep
     # Returns true if given node is a syntactic-value node
     #
     def value_node?: (Parser::AST::Node) -> bool
+
+    type condition_loc = Map & _Condition
+
+    type ternary_loc = Map & _Ternary
+
+    def deconstruct_if_node: (Node) -> [Node, Node?, Node?, condition_loc | ternary_loc]?
+
+    def deconstruct_if_node!: (Node) -> [Node, Node?, Node?, condition_loc | ternary_loc]
+
+    def test_if_node: (Node) { (Node, Node?, Node?, condition_loc | ternary_loc) -> bool } -> bool
+
+    type keyword_loc = Map & Parser::AST::_Keyword
+
+    def deconstruct_whileish_node: (Node) -> [Node, Node?, keyword_loc]?
+
+    def deconstruct_whileish_node!: (Node) -> [Node, Node?, keyword_loc]
+
+    def test_whileish_node: (Node) { (Node, Node?, keyword_loc) -> bool } -> bool
+
+    def deconstruct_case_node: (Node) -> [Node?, Array[Node], Node?, condition_loc]?
+
+    def deconstruct_case_node!: (Node) -> [Node?, Array[Node], Node?, condition_loc]
+
+    def test_case_node: (Node) { (Node?, Array[Node], Node?, condition_loc) -> bool } -> bool
+
+    def deconstruct_when_node: (Node) -> [Array[Node], Node?, keyword_loc]?
+
+    def deconstruct_when_node!: (Node) -> [Array[Node], Node?, keyword_loc]
+
+    def test_when_node: (Node) { (Array[Node], Node?, keyword_loc) -> bool } -> bool
+
+    def deconstruct_rescue_node: (Node) -> [Node?, Array[Node], Node?, condition_loc]?
+
+    def deconstruct_rescue_node!: (Node) -> [Node?, Array[Node], Node?, condition_loc]
+
+    def test_rescue_node: (Node) { (Node?, Array[Node], Node?, condition_loc) -> bool } -> bool
+
+    type rescue_body_loc = Map & _RescueBody
+
+    def deconstruct_resbody_node: (Node) -> [Node?, Node?, Node?, rescue_body_loc]?
+
+    def deconstruct_resbody_node!: (Node) -> [Node?, Node?, Node?, rescue_body_loc]
+
+    def test_resbody_node: (Node) { (Node?, Node?, Node?, rescue_body_loc) -> bool } -> bool
+
+    type send_loc = Map & _Send
+
+    def deconstruct_send_node: (Node) -> [Node?, Symbol, Array[Node], send_loc]?
+
+    def deconstruct_send_node!: (Node) -> [Node?, Symbol, Array[Node], send_loc]
+
+    def test_send_node: (Node) { (Node?, Symbol, Array[Node], send_loc) -> bool } -> bool
   end
 end

--- a/sig/steep/services/completion_provider.rbs
+++ b/sig/steep/services/completion_provider.rbs
@@ -176,6 +176,8 @@ module Steep
 
       def range_from_loc: (Parser::Source::Range loc) -> Range
 
+      def at_comment?: (Position pos) -> bool
+
       def at_end?: (Position pos, of: Parser::Source::Map | Parser::Source::Range | nil) -> boolish
 
       def range_for: (Position position, ?prefix: ::String) -> Range

--- a/sig/steep/services/completion_provider.rbs
+++ b/sig/steep/services/completion_provider.rbs
@@ -152,7 +152,29 @@ module Steep
         ) -> void
       end
 
-      type item = InstanceVariableItem | LocalVariableItem | ConstantItem | SimpleMethodNameItem | ComplexMethodNameItem | GeneratedMethodNameItem
+      class TypeNameItem
+        attr_reader env: Environment
+
+        attr_reader absolute_type_name: TypeName
+
+        attr_reader relative_type_name: TypeName
+
+        attr_reader range: Range
+
+        def initialize: (absolute_type_name: TypeName, relative_type_name: TypeName, env: Environment, range: Range) -> void
+
+        def decl: () -> Server::LSPFormatter::summarizable_decl
+
+        def comments: () -> Array[RBS::AST::Comment]
+      end
+
+      type item = InstanceVariableItem
+                | LocalVariableItem
+                | ConstantItem
+                | SimpleMethodNameItem
+                | ComplexMethodNameItem
+                | GeneratedMethodNameItem
+                | TypeNameItem
 
       attr_reader source_text: String
 
@@ -190,6 +212,8 @@ module Steep
 
       def items_for_atmark: (position: Position) -> Array[item]
 
+      def items_for_rbs: (position: Position, annotation: AST::Annotation::t) -> Array[item]
+
       def method_items_for_receiver_type: (AST::Types::t, include_private: bool, prefix: String, position: Position, items: Array[item]) -> void
 
       def word_name?: (String name) -> bool
@@ -203,7 +227,6 @@ module Steep
       def index_for: (String, line: Integer, column: Integer) -> Integer
 
       def disallowed_method?: (Symbol name) -> bool
-
     end
   end
 end

--- a/sig/steep/services/completion_provider.rbs
+++ b/sig/steep/services/completion_provider.rbs
@@ -212,7 +212,7 @@ module Steep
 
       def items_for_atmark: (position: Position) -> Array[item]
 
-      def items_for_rbs: (position: Position, annotation: AST::Annotation::t) -> Array[item]
+      def items_for_rbs: (position: Position, buffer: RBS::Buffer) -> Array[item]
 
       def method_items_for_receiver_type: (AST::Types::t, include_private: bool, prefix: String, position: Position, items: Array[item]) -> void
 

--- a/sig/steep/source.rbs
+++ b/sig/steep/source.rbs
@@ -2,13 +2,23 @@ module Steep
   class Source
     extend NodeHelper
 
+    attr_reader buffer: RBS::Buffer
+
     attr_reader path: Pathname
 
     attr_reader node: Parser::AST::Node?
 
     attr_reader mapping: Hash[Parser::AST::Node, Array[AST::Annotation::t]]
 
-    def initialize: (path: Pathname, node: Parser::AST::Node?, mapping: Hash[Parser::AST::Node, Array[AST::Annotation::t]]) -> void
+    attr_reader comments: Array[Parser::Source::Comment]
+
+    def initialize: (
+      buffer: RBS::Buffer,
+      path: Pathname,
+      node: Parser::AST::Node?,
+      mapping: Hash[Parser::AST::Node, Array[AST::Annotation::t]],
+      comments: Array[Parser::Source::Comment]
+    ) -> void
 
     class Builder < ::Parser::Builders::Default
       def string_value: (untyped token) -> untyped
@@ -57,6 +67,19 @@ module Steep
 
     # Returns a node and it's outer nodes
     def find_nodes: (line: Integer, column: Integer) -> ::Array[Parser::AST::Node]?
+
+    # Returns comment at the given position
+    #
+    # Note that a cursor position that is at the beginning of a comment returns `nil`.
+    #
+    # ```ruby
+    # .#. .H.e.l.l.o.
+    # ^                   => Returns nil
+    #   ^                 => Returns the comment
+    #               ^     => Returns the comment
+    # ```
+    #
+    def find_comment: (line: Integer, column: Integer) -> Parser::Source::Comment?
 
     def self.delete_defs: (Parser::AST::Node node, Set[Parser::AST::Node] allow_list) -> Parser::AST::Node
 

--- a/sig/steep/source.rbs
+++ b/sig/steep/source.rbs
@@ -14,7 +14,7 @@ module Steep
       def string_value: (untyped token) -> untyped
     end
 
-    def self.new_parser: () -> Parser::Ruby31
+    def self.new_parser: () -> Parser::Ruby32
 
     def self.parse: (String source_code, path: Pathname, factory: AST::Types::Factory) -> Source
 

--- a/sig/steep/source.rbs
+++ b/sig/steep/source.rbs
@@ -36,8 +36,8 @@ module Steep
     #
     # Yields arrays, inner node first, outer node last -- `[heredoc_node, *outer_node, node]`.
     #
-    def each_heredoc_node: (?Parser::AST::Node? node, ?Array[Parser::AST::Node] parents) { (Array[Parser::AST::Node]) -> void } -> void
-                         | (?Parser::AST::Node? node, ?Array[Parser::AST::Node] parents) -> Enumerator[Array[Parser::AST::Node], void]
+    def each_heredoc_node: (?Parser::AST::Node? node, ?Array[Parser::AST::Node] parents) { ([Array[Parser::AST::Node], Parser::Source::Map & Parser::AST::_Heredoc]) -> void } -> void
+                         | (?Parser::AST::Node? node, ?Array[Parser::AST::Node] parents) -> Enumerator[[Array[Parser::AST::Node], Parser::Source::Map & Parser::AST::_Heredoc], void]
 
     # Returns array of nodes that is located inside heredoc
     #

--- a/sig/steep/type_inference/context_array.rbs
+++ b/sig/steep/type_inference/context_array.rbs
@@ -2,36 +2,37 @@ module Steep
   module TypeInference
     class ContextArray
       class Entry
-        attr_reader range: untyped
+        attr_reader range: Range[Integer]
 
-        attr_reader context: untyped
+        attr_reader context: Context
 
-        attr_reader sub_entries: untyped
+        attr_reader sub_entries: Set[Entry]
 
-        def initialize: (range: untyped, context: untyped) -> void
+        def initialize: (range: Range[Integer], context: Context) -> void
       end
 
-      attr_reader buffer: untyped
+      attr_reader buffer: RBS::Buffer
 
-      attr_reader root: untyped
+      attr_reader root: Entry
 
-      def initialize: (buffer: untyped, context: untyped, ?range: untyped) -> void
+      def initialize: (buffer: RBS::Buffer, context: Context, ?range: Range[Integer]) -> void
 
-      def range: () -> untyped
+      def range: () -> Range[Integer]
 
-      def self.from_source: (source: untyped, ?range: untyped?, ?context: untyped?) -> untyped
+      def self.from_source: (source: Source, ?range: Range[Integer]?, context: Context) -> ContextArray
 
-      def insert_context: (untyped range, context: untyped, ?entry: untyped) -> untyped
+      def insert_context: (Range[Integer] range, context: Context, ?entry: Entry) -> void
 
-      def each_entry: () { (untyped) -> untyped } -> untyped
+      def each_entry: () { (Entry) -> void } -> void
+                    | () -> Enumerator[Entry, void]
 
-      def context_at: (untyped index, ?entry: untyped) -> (nil | untyped)
+      def context_at: (Integer index, ?entry: Entry) -> Context?
 
-      def []: (untyped index) -> untyped
+      def []: (Integer index) -> Context?
 
-      def at: (line: untyped, column: untyped) -> untyped
+      def at: (line: Integer, column: Integer) -> Context?
 
-      def merge: (untyped subtree) -> untyped
+      def merge: (ContextArray subtree) -> void
     end
   end
 end

--- a/sig/steep/typing.rbs
+++ b/sig/steep/typing.rbs
@@ -1,11 +1,13 @@
+use Steep::TypeInference::Context, Steep::TypeInference::ContextArray, Steep::TypeInference::MethodCall
+
 module Steep
   class Typing
     class UnknownNodeError < StandardError
-      attr_reader op: untyped
+      attr_reader op: Symbol
 
-      attr_reader node: untyped
+      attr_reader node: Parser::AST::Node
 
-      def initialize: (untyped op, node: untyped) -> void
+      def initialize: (Symbol op, node: Parser::AST::Node) -> void
     end
 
     attr_reader source: Source
@@ -16,43 +18,43 @@ module Steep
 
     attr_reader parent: Typing?
 
-    attr_reader parent_last_update: untyped
+    attr_reader parent_last_update: Integer?
 
-    attr_reader last_update: untyped
+    attr_reader last_update: Integer
 
-    attr_reader should_update: untyped
+    attr_reader should_update: bool
 
-    attr_reader contexts: untyped
+    attr_reader contexts: ContextArray
 
-    attr_reader root_context: untyped
+    attr_reader root_context: Context
 
-    attr_reader method_calls: untyped
+    attr_reader method_calls: Hash[Parser::AST::Node, MethodCall::t]
 
-    attr_reader source_index: untyped
+    attr_reader source_index: Index::SourceIndex
 
-    def initialize: (source: untyped, root_context: untyped, ?parent: untyped?, ?parent_last_update: untyped, ?contexts: untyped?, ?source_index: untyped?) -> void
+    def initialize: (source: Source, root_context: Context, ?parent: Typing?, ?parent_last_update: Integer?, ?contexts: ContextArray?, ?source_index: Index::SourceIndex?) -> void
 
     def add_error: (Diagnostic::Ruby::Base error) -> void
 
-    def add_typing: (Parser::AST::Node node, AST::Types::t `type`, top) -> untyped
+    def add_typing: (Parser::AST::Node node, AST::Types::t `type`, top) -> void
 
-    def add_call: (untyped node, untyped call) -> untyped
+    def add_call: (Parser::AST::Node node, MethodCall::t call) -> void
 
-    def add_context: (Range[Integer] range, context: TypeInference::Context) -> void
+    def add_context: (Range[Integer] range, context: Context) -> void
 
-    def has_type?: (untyped node) -> untyped
+    def has_type?: (Parser::AST::Node node) -> bool
 
     def type_of: (node: Parser::AST::Node) -> AST::Types::t
 
     def call_of: (node: Parser::AST::Node) -> TypeInference::MethodCall::t
 
-    def add_context_for_node: (untyped node, context: untyped) -> untyped
+    def add_context_for_node: (Parser::AST::Node node, context: Context) -> void
 
-    def block_range: (untyped node) -> ::Range[untyped]
+    def block_range: (Parser::AST::Node node) -> Range[Integer]
 
-    def add_context_for_body: (untyped node, context: untyped) -> untyped
+    def add_context_for_body: (Parser::AST::Node node, context: Context) -> void
 
-    def context_at: (line: Integer, column: Integer) -> TypeInference::Context
+    def context_at: (line: Integer, column: Integer) -> Context
 
     def dump: (untyped io) -> untyped
 
@@ -61,7 +63,7 @@ module Steep
     def new_child: [A] (Range[Integer] range) { (Typing) -> A } -> A
                  | (Range[Integer]) -> Typing
 
-    def each_typing: () { (Parser::AST::Node, AST::Types::t) -> void } -> void
+    def each_typing: () { ([Parser::AST::Node, AST::Types::t]) -> void } -> void
 
     # Push the current changes to the `#parent` typing
     #

--- a/test/ast/node/type_application_test.rb
+++ b/test/ast/node/type_application_test.rb
@@ -3,6 +3,7 @@ require_relative "../../test_helper"
 class AST__Node__TypeApplicationTest < Minitest::Test
   include TestHelper
   include FactoryHelper
+  include SubtypingHelper
 
   def buffer(string)
     buffer = RBS::Buffer.new(name: "foo.rbs", content: string)
@@ -10,13 +11,13 @@ class AST__Node__TypeApplicationTest < Minitest::Test
   end
 
   def test_one_type
-    with_factory do
+    with_checker do
       loc = buffer("$String")
 
       app = Steep::AST::Node::TypeApplication.parse(loc)
 
       assert_equal "String", app.type_str
-      app.types(nil, factory, []).tap do |types|
+      app.types(nil, checker, []).tap do |types|
         assert_equal 1, types.size
         assert_equal parse_type("::String"), types[0]
         assert_equal "String", types[0].location.source
@@ -25,13 +26,13 @@ class AST__Node__TypeApplicationTest < Minitest::Test
   end
 
   def test_sequence_type
-    with_factory do
+    with_checker do
       loc = buffer("$ String, Integer")
 
       app = Steep::AST::Node::TypeApplication.parse(loc)
 
       assert_equal "String, Integer", app.type_str
-      app.types(nil, factory, []).tap do |types|
+      app.types(nil, checker, []).tap do |types|
         assert_equal 2, types.size
 
         assert_equal parse_type("::String"), types[0]

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -505,4 +505,18 @@ bar()
       end
     end
   end
+
+  def test_on_steep_type_application
+    with_checker do
+      CompletionProvider.new(source_text: <<~RUBY, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+        [1, 2].inject([]) do |x, y| #$ Ar
+        end
+      RUBY
+
+        provider.run(line: 1, column: 33).tap do |items|
+          assert_equal [TypeName("Array")], items.map(&:relative_type_name)
+        end
+      end
+    end
+  end
 end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -492,4 +492,17 @@ bar()
       end
     end
   end
+
+  def test_on_steep_type_assertion
+    with_checker do
+      CompletionProvider.new(source_text: <<~RUBY, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+        x = [] #: Ar
+      RUBY
+
+        provider.run(line: 1, column: 12).tap do |items|
+          assert_equal [TypeName("Array")], items.map(&:relative_type_name)
+        end
+      end
+    end
+  end
 end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -469,11 +469,25 @@ bar()
   def test_on_comment
     with_checker do
       CompletionProvider.new(source_text: <<~RUBY, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
-        x = [] #: Array[String]
+        x = [] # Hoge hoge
       RUBY
 
         provider.run(line: 1, column: 10).tap do |items|
           assert_empty items
+        end
+      end
+    end
+  end
+
+  def test_on_steep_inline_comment
+    with_checker do
+      CompletionProvider.new(source_text: <<~RUBY, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+        # @type var x: Ar
+        x = []
+      RUBY
+
+        provider.run(line: 1, column: 17).tap do |items|
+          assert_equal [TypeName("Array")], items.map(&:relative_type_name)
         end
       end
     end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -76,7 +76,7 @@ self.cl
       end
     end
   end
-  
+
   def test_on_method_identifier_colon2
     with_checker do
       CompletionProvider.new(source_text: <<-EOR, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
@@ -461,6 +461,19 @@ bar()
             assert_equal ["() -> ::String"], items[0].method_types.map(&:to_s)
             assert_equal [MethodName("::Integer#to_s"), MethodName("::String#to_s")], items[0].method_names
           end
+        end
+      end
+    end
+  end
+
+  def test_on_comment
+    with_checker do
+      CompletionProvider.new(source_text: <<~RUBY, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+        x = [] #: Array[String]
+      RUBY
+
+        provider.run(line: 1, column: 10).tap do |items|
+          assert_empty items
         end
       end
     end

--- a/test/context_array_test.rb
+++ b/test/context_array_test.rb
@@ -59,7 +59,7 @@ bar do |x|
 end
 EOF
 
-      array = ContextArray.from_source(source: source)
+      array = ContextArray.from_source(source: source, context: nil)
 
       range2 = dig(source.node, 1, 1).loc.end.end_pos..dig(source.node, 1).loc.end.begin_pos
       range3 = dig(source.node, 1, 2).yield_self {|n| n.loc.expression.begin_pos..n.loc.expression.end_pos }

--- a/test/lsp_formatter_test.rb
+++ b/test/lsp_formatter_test.rb
@@ -8,7 +8,7 @@ class LSPFormatterTest < Minitest::Test
   LSPFormatter = Diagnostic::LSPFormatter
 
   def node
-    ::Parser::Ruby31.parse("1+2")
+    ::Parser::Ruby32.parse("1+2")
   end
 
   def test_severity_for

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -826,4 +826,19 @@ super { } # $ nil
       end
     end
   end
+
+  def test_find_comment
+    with_factory() do |factory|
+      source = Steep::Source.parse(<<~RUBY, path: Pathname("foo.rb"), factory: factory)
+        # comment 1
+        # comment 2
+        x = 123 # comment 3
+      RUBY
+
+      assert_nil source.find_comment(line: 1, column: 0)
+      assert_equal "# comment 1", source.find_comment(line: 1, column: 1).text
+      assert_equal "# comment 2", source.find_comment(line: 2, column: 1).text
+      assert_equal "# comment 3", source.find_comment(line: 3, column: 13).text
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10134,6 +10134,8 @@ hash = array #: Hash[Symbol, String]
 
   def test_assertion_as_type_fool_success
     with_checker(<<-RBS) do |checker|
+        class Pathname
+        end
       RBS
       source = parse_ruby(<<-RUBY)
 path = nil #: Pathname?

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8614,7 +8614,7 @@ end
       with_standard_construction(checker, source) do |construction, typing|
         type, _ = construction.synthesize(source.node)
 
-        assert_equal parse_type("[X, untyped]", variables: [:X]), typing.context_at(line: 6, column: 5).type_env[:z]
+        assert_equal parse_type("[X, untyped]", variables: [:X]), typing.context_at(line: 7, column: 5).type_env[:z]
       end
     end
   end


### PR DESCRIPTION
Let RBS type name completion work in inline annotations, type assertions, and type applications.

```ruby
# @type var xs: Arra   <= Here
xs = []

path = nil #: Path  <= Here
```

Note that the completion in comments doesn't pop up automatically. You have to trigger completion explicitly, with `Ctrl+Space` or equivalent.

Closes #722
Closes #718 