### PR TITLE
completion: Support completion for optional chaining (&.)

### DIFF
--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -665,9 +665,11 @@ module Steep
 
       def unwrap_optional(type)
         if type.is_a?(AST::Types::Union) && type.types.include?(AST::Builtin.nil_type)
-          type.types.reject! { |t| t == AST::Builtin.nil_type }
+          types = type.types.reject { |t| t == AST::Builtin.nil_type }
+          AST::Types::Union.new(types: types, location: type.location)
+        else
+          type
         end
-        type
       end
     end
   end

--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -384,7 +384,7 @@ module Steep
           # foo::← ba
           items.push(*items_for_colon2(position: position))
 
-        when node.type == :csend && at_end?(position, of: (_ = node.loc).dot) && (_ = node.loc).dot.source == "&."
+        when node.type == :csend && at_end?(position, of: (_ = node.loc).dot)
           # foo&.← ba
           receiver_type =
             case (type = typing.type_of(node: node.children[0]))

--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -243,9 +243,16 @@ module Steep
           Steep.logger.info "recovering syntax error: #{exn.inspect}"
           case possible_trigger
           when "."
-            source_text[index-1] = " "
-            type_check!(source_text, line: line, column: column)
-            items_for_dot(position: position)
+            if source_text[index-2] == "&"
+              source_text[index-1] = " "
+              source_text[index-2] = " "
+              type_check!(source_text, line: line, column: column)
+              items_for_qcall(position: position)
+            else
+              source_text[index-1] = " "
+              type_check!(source_text, line: line, column: column)
+              items_for_dot(position: position)
+            end
           when "@"
             source_text[index-1] = " "
             type_check!(source_text, line: line, column: column)
@@ -329,6 +336,19 @@ module Steep
 
           method_items_for_receiver_type(receiver_type, include_private: false, prefix: prefix, position: position, items: items)
 
+        when node.type == :csend && node.children[0] && at_end?(position, of: (_ = node.loc).selector)
+          # foo&.ba ←
+          receiver_type =
+            case (type = typing.type_of(node: node.children[0]))
+            when AST::Types::Self
+              context.self_type
+            else
+              unwrap_optional(type)
+            end
+          prefix = node.children[1].to_s
+
+          method_items_for_receiver_type(receiver_type, include_private: false, prefix: prefix, position: position, items: items)
+
         when node.type == :const && node.children[0] == nil && at_end?(position, of: node.loc)
           # Foo ← (const)
           prefix = node.children[1].to_s
@@ -364,6 +384,18 @@ module Steep
           # foo::← ba
           items.push(*items_for_colon2(position: position))
 
+        when node.type == :csend && at_end?(position, of: (_ = node.loc).dot) && (_ = node.loc).dot.source == "&."
+          # foo&.← ba
+          receiver_type =
+            case (type = typing.type_of(node: node.children[0]))
+            when AST::Types::Self
+              context.self_type
+            else
+              unwrap_optional(type)
+            end
+
+          method_items_for_receiver_type(receiver_type, include_private: false, prefix: "", position: position, items: items)
+
         when node.type == :ivar && at_end?(position, of: node.loc)
           # @fo ←
           instance_variable_items_for_context(context, position: position, prefix: node.children[0].to_s, items: items)
@@ -395,6 +427,36 @@ module Steep
                 context.self_type
               else
                 type
+              end
+
+            items = [] #: Array[item]
+            method_items_for_receiver_type(receiver_type, include_private: false, prefix: "", position: position, items: items)
+            items
+          rescue Typing::UnknownNodeError
+            []
+          end
+        else
+          []
+        end
+      end
+
+      def items_for_qcall(position:)
+        # foo&. ←
+        shift_pos = position-2
+        node, *_parents = source.find_nodes(line: shift_pos.line, column: shift_pos.column)
+        node ||= source.node
+
+        return [] unless node
+
+        if at_end?(shift_pos, of: node.loc)
+          begin
+            context = typing.context_at(line: position.line, column: position.column)
+            receiver_type =
+              case (type = typing.type_of(node: node))
+              when AST::Types::Self
+                context.self_type
+              else
+                unwrap_optional(type)
               end
 
             items = [] #: Array[item]
@@ -599,6 +661,13 @@ module Steep
         # instances of new classes, so don't show it as
         # an LSP option
         name == :initialize
+      end
+
+      def unwrap_optional(type)
+        if type.is_a?(AST::Types::Union) && type.types.include?(AST::Builtin.nil_type)
+          type.types.reject! { |t| t == AST::Builtin.nil_type }
+        end
+        type
       end
     end
   end

--- a/sig/steep/services/completion_provider.rbs
+++ b/sig/steep/services/completion_provider.rbs
@@ -208,6 +208,8 @@ module Steep
 
       def items_for_dot: (position: Position) -> Array[item]
 
+      def items_for_qcall: (position: Position) -> Array[item]
+
       def items_for_colon2: (position: Position) -> Array[item]
 
       def items_for_atmark: (position: Position) -> Array[item]
@@ -227,6 +229,9 @@ module Steep
       def index_for: (String, line: Integer, column: Integer) -> Integer
 
       def disallowed_method?: (Symbol name) -> bool
+
+      def unwrap_optional: (AST::Types::t) -> AST::Types::t
+
     end
   end
 end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -146,6 +146,34 @@ end
     end
   end
 
+  def test_qcall_trigger
+    with_checker do
+      CompletionProvider.new(source_text: <<-EOR, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+n = [1].first
+n&.to
+      EOR
+
+        provider.run(line: 2, column: 3).tap do |items|
+          assert_equal [
+            :class,
+            :is_a?,
+            :itself,
+            :nil?,
+            :tap,
+            :to_int,
+            :to_s,
+            :zero?
+          ],
+          items.map(&:identifier).sort
+        end
+
+        provider.run(line: 2, column: 5).tap do |items|
+          assert_equal [:to_int, :to_s], items.map(&:identifier).sort
+        end
+      end
+    end
+  end
+
   def test_on_atmark
     with_checker <<EOF do
 class Hello


### PR DESCRIPTION
The optional chaining allows to developers to call method only if the receiver is not nil.  Therefore, CompletionProvider should consider the receiver is not nil if the optional chaining operator is given.

This fix unwraps the Optional[T] from receiver_type on completion for the optional chaining.  It will provide better completion for developers.