### PR TITLE
Support early return code using "and return"

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1751,8 +1751,12 @@ module Steep
 
             type =
               case
+              when left_type.is_a?(AST::Types::Bot)
+                left_type
               when check_relation(sub_type: left_type, super_type: AST::Types::Boolean.new).success?
                 union_type(left_type, right_type)
+              when left_type != AST::Builtin.nil_type && right_type.is_a?(AST::Types::Bot)
+                right_type
               else
                 union_type(right_type, AST::Builtin.nil_type)
               end
@@ -1803,8 +1807,12 @@ module Steep
 
             type =
               case
+              when left_type.is_a?(AST::Types::Bot)
+                left_type
               when check_relation(sub_type: left_type, super_type: AST::Builtin.bool_type).success? && !left_type.is_a?(AST::Types::Any)
                 AST::Builtin.bool_type
+              when left_falsy.unreachable && right_type.is_a?(AST::Types::Bot)
+                right_type
               else
                 union_type(left_type, right_type)
               end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6135,6 +6135,14 @@ x + 1
 c = [1].first
 return if (y = c.nil?)
 c + 1
+
+d = [1].first
+puts "nil!" and return if d.nil?
+d + 1
+
+e = [1].first
+nil or return if e.nil?
+e + 1
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|


### PR DESCRIPTION
Do type narrowing if an early return statement uses "and return".

ex:

    render and return unless user

refs: #824