### PR TITLE
Cast from union for faster type checking

### DIFF
--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -346,11 +346,12 @@ module Steep
                     end
 
                     if class_var
+                      loc = class_var.location #: RBS::Location[untyped, untyped]?
                       @errors << Diagnostic::Signature::ClassVariableDuplicationError.new(
                         class_name: definition.type_name,
                         other_class_name: parent.declared_in,
                         variable_name: name,
-                        location: class_var.location&.[](:name)
+                        location: loc&.[](:name) || raise
                       )
                     end
                   end


### PR DESCRIPTION
Generating a shape for `class_var.location` takes seconds because it is a union type more than 10 constructs. `nil | RBS::Location[...] | RBS::Location[...] | RBS::Location[...] | ...`. Giving a type `RBS::Location[untyped, untyped]?` beforehand makes the shape generation much faster.

This change makes type checking the `validator.rb` using released (and the HEAD) version of Steep faster. Not an improvement of the type checking algorithm itself.