### PR TITLE
Refactor occurrence typing

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1882,19 +1882,23 @@ module Steep
             end
 
             if truthy.unreachable
-              typing.add_error(
-                Diagnostic::Ruby::UnreachableBranch.new(
-                  node: true_clause || node
+              if true_clause
+                typing.add_error(
+                  Diagnostic::Ruby::UnreachableBranch.new(
+                    node: true_clause || node
+                  )
                 )
-              )
+              end
             end
 
             if falsy.unreachable
-              typing.add_error(
-                Diagnostic::Ruby::UnreachableBranch.new(
-                  node: false_clause || node
+              if false_clause
+                typing.add_error(
+                  Diagnostic::Ruby::UnreachableBranch.new(
+                    node: false_clause || node
+                  )
                 )
-              )
+              end
             end
 
             node_type = union_type_unify(true_pair&.type || AST::Builtin.nil_type, false_pair&.type || AST::Builtin.nil_type)

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1786,7 +1786,8 @@ module Steep
             if left_type.is_a?(AST::Types::Logic::Env)
               left_type = left_type.type
             end
-            left_type, _ = checker.factory.unwrap_optional(left_type)
+            le, _ = checker.factory.partition_union(left_type)
+            left_type = le || AST::Types::Bot.new
 
             right_type, constr, right_context =
               constr
@@ -4650,8 +4651,7 @@ module Steep
     end
 
     def unwrap(type)
-      truthy, _ = checker.factory.unwrap_optional(type)
-      truthy
+      checker.factory.unwrap_optional(type) || AST::Types::Bot.new
     end
 
     def deep_expand_alias(type)

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -62,9 +62,11 @@ module Steep
           truthy_env = type.truthy
           falsy_env = type.falsy
 
+          truthy_type, falsy_type = factory.partition_union(type.type)
+
           return [
-            Result.new(env: truthy_env, type: TRUE, unreachable: false),
-            Result.new(env: falsy_env, type: FALSE, unreachable: false)
+            Result.new(env: truthy_env, type: truthy_type || TRUE, unreachable: !truthy_type),
+            Result.new(env: falsy_env, type: falsy_type || FALSE, unreachable: !falsy_type)
           ]
         end
 

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -71,7 +71,7 @@ module Steep
         case node.type
         when :lvar
           name = node.children[0]
-          truthy_type, falsy_type = factory.unwrap_optional?(type)
+          truthy_type, falsy_type = factory.partition_union(type)
 
           truthy_result =
             if truthy_type
@@ -127,7 +127,7 @@ module Steep
           receiver_type = typing.type_of(node: receiver)
 
           truthy_receiver, falsy_receiver = evaluate_node(env: env, node: receiver)
-          truthy_type, _ = factory.unwrap_optional?(type)
+          truthy_type, _ = factory.partition_union(type)
 
           truthy_result, falsy_result = evaluate_node(
             env: truthy_receiver.env,
@@ -157,7 +157,7 @@ module Steep
             end
           else
             if env[node]
-              truthy_type, falsy_type = factory.unwrap_optional?(type)
+              truthy_type, falsy_type = factory.partition_union(type)
 
               truthy_result =
                 if truthy_type
@@ -178,7 +178,7 @@ module Steep
           end
         end
 
-        truthy_type, falsy_type = factory.unwrap_optional?(type)
+        truthy_type, falsy_type = factory.partition_union(type)
         return [
           Result.new(type: truthy_type || BOT, env: env, unreachable: truthy_type.nil?),
           Result.new(type: falsy_type || BOT, env: env, unreachable: falsy_type.nil?)
@@ -271,7 +271,7 @@ module Steep
         when AST::Types::Logic::ReceiverIsNil
           if receiver && arguments.size.zero?
             receiver_type = typing.type_of(node: receiver)
-            truthy_receiver, falsy_receiver = factory.unwrap_optional?(receiver_type)
+            truthy_receiver, falsy_receiver = factory.partition_union(receiver_type)
 
             truthy_env, falsy_env = refine_node_type(
               env: env,

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -68,6 +68,13 @@ module Steep
           ]
         end
 
+        if type.is_a?(AST::Types::Bot)
+          return [
+            Result.new(env: env, type: type, unreachable: true),
+            Result.new(env: env, type: type, unreachable: true),
+          ]
+        end
+
         case node.type
         when :lvar
           name = node.children[0]

--- a/sig/steep/ast/types/factory.rbs
+++ b/sig/steep/ast/types/factory.rbs
@@ -59,9 +59,34 @@ module Steep
         #
         def flatten_union: (t `type`, ?Array[t] acc) -> Array[t]
 
-        def unwrap_optional: (Types::t `type`) -> [Types::t, Types::t]
+        # Partition the type components in union types to truthy ones and falsy ones
+        #
+        # * Returns a pair of *truthy* type and *falsy* type
+        # * The pair may contain `nil` if given type always evaluates to truthy or falsy
+        # * Expand (unfold) the type aliases automatically
+        #
+        # ```ruby
+        # partition_union?(`Integer?`)                          # => [`Integer`, `nil`]
+        # partition_union?(`Integer | String | nil | false`)    # => [`Integer | String`, `nil | false`]
+        # partition_union?(`bool`)                              # => [`bool`, `bool`]
+        # partition_union?(`nil`)                               # => [nil, `nil`]
+        # ```
+        #
+        def partition_union: (Types::t) -> [Types::t?, Types::t?]
 
-        def unwrap_optional?: (Types::t) -> [Types::t?, Types::t?]
+        # Returns a type that doesn't have `nil` in the union component
+        #
+        # * Returns `nil` if given type is `nil`
+        # * **Doesn't expand type alias automatically**
+        #
+        # ```ruby
+        # unwrap_optional(`String?`)                               # => `String`
+        # unwrap_optional(`String | Integer | false | nil`)        # => `String | Integer | false`
+        # unwrap_optional(`nil`)                                   # => nil
+        # unwrap_optional(`boolish`)                               # => `boolish`
+        # ```
+        #
+        def unwrap_optional: (Types::t) -> Types::t?
 
         def module_name?: (TypeName type_name) -> bool
 

--- a/smoke/and/a.rb
+++ b/smoke/and/a.rb
@@ -1,7 +1,7 @@
 # @type var b: String
 # @type var c: ::Integer
 
-a = "foo"
+a = ["foo"].sample
 
 b = a && a.to_str
 

--- a/smoke/and/test_expectations.yml
+++ b/smoke/and/test_expectations.yml
@@ -10,8 +10,8 @@
         character: 17
     severity: ERROR
     message: |-
-      Cannot assign a value of type `(::String | nil)` to a variable of type `::String`
-        (::String | nil) <: ::String
+      Cannot assign a value of type `(nil | ::String)` to a variable of type `::String`
+        (nil | ::String) <: ::String
           nil <: ::String
     code: Ruby::IncompatibleAssignment
   - range:
@@ -23,9 +23,7 @@
         character: 17
     severity: ERROR
     message: |-
-      Cannot assign a value of type `(::String | nil)` to a variable of type `::Integer`
-        (::String | nil) <: ::Integer
-          ::String <: ::Integer
-            ::Object <: ::Integer
-              ::BasicObject <: ::Integer
+      Cannot assign a value of type `(nil | ::String)` to a variable of type `::Integer`
+        (nil | ::String) <: ::Integer
+          nil <: ::Integer
     code: Ruby::IncompatibleAssignment

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -711,4 +711,76 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_and_shortcut__truthy
+    run_type_check_test(
+      signatures: {},
+      code: {
+        "a.rb" => <<~RUBY
+          x = [1].first
+          1 and return unless x
+          x + 1
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_and_shortcut__false
+    run_type_check_test(
+      signatures: {},
+      code: {
+        "a.rb" => <<~RUBY
+          x = [1].first
+          return and true unless x
+          x + 1
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_or_shortcut__nil
+    run_type_check_test(
+      signatures: {},
+      code: {
+        "a.rb" => <<~RUBY
+          x = [1].first
+          nil and return unless x
+          x + 1
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_or_shortcut__false
+    run_type_check_test(
+      signatures: {},
+      code: {
+        "a.rb" => <<~RUBY
+          x = [1].first
+          false and return unless x
+          x + 1
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -754,7 +754,7 @@ class TypeCheckTest < Minitest::Test
       code: {
         "a.rb" => <<~RUBY
           x = [1].first
-          nil and return unless x
+          nil or return unless x
           x + 1
         RUBY
       },
@@ -772,7 +772,7 @@ class TypeCheckTest < Minitest::Test
       code: {
         "a.rb" => <<~RUBY
           x = [1].first
-          false and return unless x
+          x or return unless x
           x + 1
         RUBY
       },

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -4442,7 +4442,7 @@ EOF
 
         assert_no_error typing
         assert_equal parse_type("::String"), pair.context.type_env[:a]
-        assert_equal parse_type("::String?"), pair.context.type_env[:b]
+        assert_equal parse_type("::String"), pair.context.type_env[:b]
         assert_equal parse_type("untyped"), pair.context.type_env[:c]
       end
     end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3557,7 +3557,7 @@ EOF
         assert_no_error typing
 
         assert_equal parse_type("::Integer"), pair.context.type_env[:x]
-        assert_equal parse_type("::Integer?"), pair.context.type_env[:y]
+        assert_equal parse_type("::Integer"), pair.context.type_env[:y]
       end
     end
   end


### PR DESCRIPTION
* Introduce `#unwrap_optional` and `#partition_union`, for safe-navigation-operator and truthy/falsy test
* Fix `UnreachableBranch` detection in `:if` typing
* Detect unreachable branch with `bot` type
* Refactor `:and` and `:or` node shortcut