### PR TITLE
Reuse the latest result to keep SignatureHelp opened while typing

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -406,7 +406,8 @@ module Steep
                 )
               end
 
-              LSP::Interface::SignatureHelp.new(
+              @last_signature_help_line = job.line
+              @last_signature_help_result = LSP::Interface::SignatureHelp.new(
                 signatures: signatures,
                 active_signature: index
               )
@@ -414,7 +415,8 @@ module Steep
           end
         end
       rescue Parser::SyntaxError
-        # Ignore syntax error
+        # Reuse the latest result to keep SignatureHelp opened while typing
+        @last_signature_help_result if @last_signature_help_line == job.line
       end
     end
   end

--- a/sig/steep/server/interaction_worker.rbs
+++ b/sig/steep/server/interaction_worker.rbs
@@ -52,6 +52,10 @@ module Steep
 
       module LSP = LanguageServer::Protocol
 
+      @last_signature_help_line: Integer
+
+      @last_signature_help_result: LanguageServer::Protocol::Interface::SignatureHelp
+
       attr_reader service: Services::TypeCheckService
 
       def initialize: (project: Project, reader: Reader, writer: Writer, ?queue: Queue) -> void


### PR DESCRIPTION
>Is sending the latest signature help response better if SyntaxError is raised?

It seems this approach working fine to me :-)

![preview](https://github.com/soutaro/steep/assets/748828/8de9c38c-2234-4a7e-93c2-aacb701d3e14)
