### PR TITLE
Resolve type names from TypeAssertion and TypeApplication

### DIFF
--- a/lib/steep/ast/node/type_assertion.rb
+++ b/lib/steep/ast/node/type_assertion.rb
@@ -18,12 +18,14 @@ module Steep
 
         def type(context, subtyping, type_vars)
           if ty = RBS::Parser.parse_type(type_location.buffer, range: type_location.range, variables: type_vars, require_eof: true)
+            resolver = RBS::Resolver::TypeNameResolver.new(subtyping.factory.env)
+            ty = ty.map_type_name {|name| resolver.resolve(name, context: context) || name.absolute! }
+
             validator = Signature::Validator.new(checker: subtyping)
             validator.validate_type(ty)
 
             unless validator.has_error?
-              ty = subtyping.factory.type(ty)
-              subtyping.factory.absolute_type(ty, context: context)
+              subtyping.factory.type(ty)
             end
           else
             nil

--- a/test/ast/node/type_application_test.rb
+++ b/test/ast/node/type_application_test.rb
@@ -11,16 +11,21 @@ class AST__Node__TypeApplicationTest < Minitest::Test
   end
 
   def test_one_type
-    with_checker do
-      loc = buffer("$String")
+    with_checker(<<~RBS) do
+        class Foo
+          class Bar
+          end
+        end
+      RBS
+      loc = buffer("$Bar")
 
       app = Steep::AST::Node::TypeApplication.parse(loc)
 
-      assert_equal "String", app.type_str
-      app.types(nil, checker, []).tap do |types|
+      assert_equal "Bar", app.type_str
+      app.types([nil, TypeName("::Foo")], checker, []).tap do |types|
         assert_equal 1, types.size
-        assert_equal parse_type("::String"), types[0]
-        assert_equal "String", types[0].location.source
+        assert_equal parse_type("::Foo::Bar"), types[0]
+        assert_equal "Bar", types[0].location.source
       end
     end
   end

--- a/test/ast/node/type_assertion_test.rb
+++ b/test/ast/node/type_assertion_test.rb
@@ -1,0 +1,45 @@
+require_relative "../../test_helper"
+
+class AST__Node__TypeAssertionTest < Minitest::Test
+  include TestHelper
+  include FactoryHelper
+  include SubtypingHelper
+
+  def buffer(string)
+    buffer = RBS::Buffer.new(name: "foo.rbs", content: string)
+    RBS::Location.new(buffer, 0, string.size)
+  end
+
+  def test_type
+    with_checker do
+      loc = buffer(": String")
+
+      assertion = Steep::AST::Node::TypeAssertion.parse(loc)
+
+      assert_equal "String", assertion.type_str
+      assert_predicate assertion, :type_syntax?
+
+      type = assertion.type(nil, checker, [])
+      assert_equal parse_type("::String"), type
+    end
+  end
+
+  def test_relative_type
+    with_checker(<<~RBS) do
+        class Foo
+          class Bar
+          end
+        end
+      RBS
+      loc = buffer(": Array[Bar]")
+
+      assertion = Steep::AST::Node::TypeAssertion.parse(loc)
+
+      assert_equal "Array[Bar]", assertion.type_str
+      assert_predicate assertion, :type_syntax?
+
+      type = assertion.type([nil, TypeName("::Foo")], checker, [])
+      assert_equal parse_type("::Array[::Foo::Bar]"), type
+    end
+  end
+end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -783,4 +783,30 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_type_assertion__generic_type_error
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Foo
+            class Bar
+            end
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class Foo
+            a = [] #: Array[Bar]
+            a.map {|x| x } #$ Bar
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
It reports an type validation error like:

```
lib/steep/services/signature_help_provider.rb:65:16: [error] UnexpectedError: lib/steep/services/signature_help_provider.rb:65:28...65:32: ::Array expects parameters [Elem], but given args []
│ Diagnostic ID: Ruby::UnexpectedError
│
└         items = [] #: Array[Item]
                  ~~~~~~~~~~~~~~~~~
```