### PR TITLE
Fix unreachability test

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2019,9 +2019,6 @@ module Steep
               branch_results = [] #: Array[Pair]
 
               condition_constr = constr
-              clause_constr = constr
-
-              next_branch_reachable = true
 
               whens.each do |when_clause|
                 when_clause_constr = condition_constr
@@ -2032,7 +2029,6 @@ module Steep
                 *tests, body = when_clause.children
 
                 branch_reachable = false
-                false_branch_reachable = false
 
                 tests.each do |test|
                   test_type, condition_constr = condition_constr.synthesize(test, condition: true)
@@ -2043,11 +2039,8 @@ module Steep
                   condition_constr = condition_constr.update_type_env { falsy_env }
                   body_envs << truthy_env
 
-                  branch_reachable ||= next_branch_reachable && !truthy.unreachable
-                  false_branch_reachable ||= !falsy.unreachable
+                  branch_reachable ||= !truthy.unreachable
                 end
-
-                next_branch_reachable &&= false_branch_reachable
 
                 if body
                   branch_results <<

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1398,8 +1398,11 @@ module Steep
         when :true, :false
           ty = node.type == :true ? AST::Types::Literal.new(value: true) : AST::Types::Literal.new(value: false)
 
-          if hint && check_relation(sub_type: ty, super_type: hint).success? && !hint.is_a?(AST::Types::Any) && !hint.is_a?(AST::Types::Top)
+          case
+          when hint && check_relation(sub_type: ty, super_type: hint).success? && !hint.is_a?(AST::Types::Any) && !hint.is_a?(AST::Types::Top)
             add_typing(node, type: hint)
+          when condition
+            add_typing(node, type: ty)
           else
             add_typing(node, type: AST::Types::Boolean.new)
           end

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -417,6 +417,10 @@ module Steep
           end
 
           [truthy_types, falsy_types]
+        when AST::Types::Boolean
+          [[arg_type], [arg_type]]
+        when AST::Types::Top, AST::Types::Any
+          [[arg_type], [arg_type]]
         else
           types = [arg_type]
 

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -890,7 +890,17 @@ class TypeCheckTest < Minitest::Test
       expectations: <<~YAML
         ---
         - file: a.rb
-          diagnostics: []
+          diagnostics:
+          - range:
+              start:
+                line: 13
+                character: 2
+              end:
+                line: 13
+                character: 12
+            severity: ERROR
+            message: Type `nil` does not have method `is_untyped`
+            code: Ruby::NoMethod
       YAML
     )
   end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -972,4 +972,52 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_case_when__untyped_value
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          foo = true #: untyped
+
+          case foo
+          when nil
+            1
+          when true
+            2
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_case_when__bool_value
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          foo = true #: bool
+
+          case foo
+          when false
+            1
+          when true
+            2
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -428,16 +428,6 @@ class TypeCheckTest < Minitest::Test
             severity: ERROR
             message: Type `::String` does not have method `is_a_string`
             code: Ruby::NoMethod
-          - range:
-              start:
-                line: 7
-                character: 0
-              end:
-                line: 7
-                character: 19
-            severity: ERROR
-            message: The branch is unreachable
-            code: Ruby::UnreachableBranch
       YAML
     )
   end
@@ -901,6 +891,84 @@ class TypeCheckTest < Minitest::Test
             severity: ERROR
             message: Type `nil` does not have method `is_untyped`
             code: Ruby::NoMethod
+      YAML
+    )
+  end
+
+  def test_case_when__no_subject__reachability
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          case
+          when false
+            :a
+          when nil
+            :b
+          when "".is_a?(NilClass)
+            :c
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 3
+                character: 2
+              end:
+                line: 3
+                character: 4
+            severity: ERROR
+            message: The branch is unreachable
+            code: Ruby::UnreachableBranch
+          - range:
+              start:
+                line: 5
+                character: 2
+              end:
+                line: 5
+                character: 4
+            severity: ERROR
+            message: The branch is unreachable
+            code: Ruby::UnreachableBranch
+          - range:
+              start:
+                line: 7
+                character: 2
+              end:
+                line: 7
+                character: 4
+            severity: ERROR
+            message: The branch is unreachable
+            code: Ruby::UnreachableBranch
+      YAML
+    )
+  end
+
+  def test_case_when__no_subject__reachability_no_continue
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          case
+          when true
+            :a
+          when 1
+            :b
+          else
+            :c
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
       YAML
     )
   end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3804,8 +3804,8 @@ EOF
 
         assert_empty typing.errors
 
-        assert_equal parse_type("bool"), pair.context.type_env[:a]
-        assert_equal parse_type("bool"), pair.context.type_env[:b]
+        assert_equal parse_type("false"), pair.context.type_env[:a]
+        assert_equal parse_type("true"), pair.context.type_env[:b]
       end
     end
   end


### PR DESCRIPTION
This PR fixes two case-when typing problems.

1. Case-when without subject may result in unexpected `UnreachableBranch`, when one `when` clause is detected *always* true and all of the following `when`s are *unreachable*.
2. Case-when with `untyped`, `top`, or `bool` subject with equality values results in `UnreachableBranch`.

This PR also reverts #841 because having no-`untyped` is better, while `bot` is the exception that `untyped` wins over `bot`.
