### PR TITLE
Fix type inference problem

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3913,13 +3913,15 @@ module Steep
             end
 
             if hint && !fvs.empty?
-              if check_relation(sub_type: method_type.type.return_type, super_type: hint, constraints: constraints).success?
-                method_type, solved, s = apply_solution(errors, node: node, method_type: method_type) do
-                  constraints.solution(checker, variables: fvs, context: ccontext)
+              if hint.free_variables.subset?(self_type.free_variables)
+                if check_relation(sub_type: method_type.type.return_type, super_type: hint, constraints: constraints).success?
+                  method_type, solved, s = apply_solution(errors, node: node, method_type: method_type) do
+                    constraints.solution(checker, variables: fvs, context: ccontext)
+                  end
                 end
-              end
 
-              method_type.block or raise
+                method_type.block or raise
+              end
             end
 
             # Method accepts block

--- a/lib/steep/type_inference/context.rb
+++ b/lib/steep/type_inference/context.rb
@@ -126,7 +126,9 @@ module Steep
 
         def upper_bounds
           table.each_value.with_object({}) do |type_param, bounds|
-            bounds[type_param.name] = type_param.upper_bound
+            if type_param.upper_bound
+              bounds[type_param.name] = type_param.upper_bound
+            end
           end
         end
 


### PR DESCRIPTION
Nested block calls with type variable reports unexpected type error.

```ruby
"".yield_self do       # { (String) -> X1 } -> X1
  123.yield_self do    # { (Integer) -> X2 } -> X2
    true               # bool
  end
end
```

Here, we expect the type propagation from `bool` to `X2` to `X1`, but type checker first solves `X2` to `X1`. And `bool` cannot be `X1`, because `X1` is not a bound type variable in `123.yield_self` call.

This PR is to limit generating constraints between `X2` and `X1` only if the hint (`X1`) is a free variable of `self`. (For generic classes.)

This was caused by #789.