### PR TITLE
Update `#configure_code_diagnostics` type

### DIFF
--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -143,27 +143,6 @@ module Steep
           @repo_paths.push(*paths.map {|s| Pathname(s) })
         end
 
-        # Configure the code diagnostics printing setup.
-        #
-        # Yields a hash, and the update the hash in the block.
-        #
-        # ```rb
-        # D = Steep::Diagnostic
-        #
-        # configure_code_diagnostics do |hash|
-        #   # Assign one of :error, :warning, :information, :hint or :nil to error classes.
-        #   hash[D::Ruby::UnexpectedPositionalArgument] = :error
-        # end
-        # ```
-        #
-        # Passing a hash is also allowed.
-        #
-        # ```rb
-        # D = Steep::Diagnostic
-        #
-        # configure_code_diagnostics(D::Ruby.lenient)
-        # ```
-        #
         def configure_code_diagnostics(hash = nil)
           if hash
             code_diagnostics_config.merge!(hash)

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -662,7 +662,7 @@ module Steep
 
       ALL: Array[singleton(Base)]
 
-      type template = Hash[singleton(Base), LSPFormatter::severity]
+      type template = Hash[singleton(Base), LSPFormatter::severity?]
 
       self.@all_error: template?
       self.@default: template?

--- a/sig/steep/project/dsl.rbs
+++ b/sig/steep/project/dsl.rbs
@@ -1,3 +1,5 @@
+use Steep::Diagnostic::Ruby::template
+
 module Steep
   class Project
     class DSL
@@ -71,10 +73,13 @@ module Steep
         # D = Steep::Diagnostic
         #
         # configure_code_diagnostics(D::Ruby.lenient)
+        # configure_code_diagnostics(D::Ruby.strict) do |config|
+        #   config[D::Ruby::NoMethod] = nil
+        # end
         # ```
         #
-        def configure_code_diagnostics: (Hash[untyped, untyped] hash) -> void
-                                      | () { (Hash[untyped, untyped]) -> void } -> void
+        def configure_code_diagnostics: (template hash) ?{ (template) -> void }-> void
+                                      | () { (template) -> void }-> void
 
         def collection_config: (Pathname path) -> void
 


### PR DESCRIPTION
Allow `#configure_code_diagnostics` receive both `template` and block to customize it.