### PR TITLE
Support type narrowing by `Module#<`

### DIFF
--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -68,6 +68,12 @@ module Steep
           end
         end
 
+        class ArgIsAncestor < Base
+          def initialize(location: nil)
+            @location = location
+          end
+        end
+
         class Env < Base
           attr_reader :truthy, :falsy, :type
 

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -766,6 +766,15 @@ module Steep
                 )
               )
             end
+          when :<, :<=
+            case defined_in
+            when RBS::BuiltinNames::Module.name
+              return method_type.with(
+                type: method_type.type.with(
+                  return_type: AST::Types::Logic::ArgIsAncestor.new(location: method_type.type.return_type.location)
+                )
+              )
+            end
           end
         end
 

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -367,6 +367,32 @@ module Steep
               [truthy_result, falsy_result]
             end
           end
+
+        when AST::Types::Logic::ArgIsAncestor
+          if receiver && (arg = arguments[0])
+            receiver_type = typing.type_of(node: receiver)
+            arg_type = factory.deep_expand_alias(typing.type_of(node: arg))
+
+            if arg_type.is_a?(AST::Types::Name::Singleton)
+              truthy_type = arg_type
+              falsy_type = receiver_type
+              truthy_env, falsy_env = refine_node_type(
+                env: env,
+                node: receiver,
+                truthy_type: truthy_type,
+                falsy_type: falsy_type
+              )
+
+              truthy_result = Result.new(type: TRUE, env: truthy_env, unreachable: false)
+              truthy_result.unreachable! unless truthy_type
+
+              falsy_result = Result.new(type: FALSE, env: falsy_env, unreachable: false)
+              falsy_result.unreachable! unless falsy_type
+
+              [truthy_result, falsy_result]
+            end
+          end
+
         when AST::Types::Logic::Not
           if receiver
             truthy_result, falsy_result = evaluate_node(env: env, node: receiver)

--- a/sig/steep/ast/types.rbs
+++ b/sig/steep/ast/types.rbs
@@ -6,7 +6,7 @@ module Steep
            | Intersection  | Record | Tuple | Union
            | Name::Alias | Name::Instance | Name::Interface | Name::Singleton
            | Proc | Var
-           | Logic::Not | Logic::ReceiverIsNil | Logic::ReceiverIsNotNil | Logic::ReceiverIsArg | Logic::ArgIsReceiver | Logic::ArgEqualsReceiver | Logic::Env
+           | Logic::Not | Logic::ReceiverIsNil | Logic::ReceiverIsNotNil | Logic::ReceiverIsArg | Logic::ArgIsReceiver | Logic::ArgEqualsReceiver | Logic::ArgIsAncestor | Logic::Env
 
       # Variables and special types that is subject for substitution
       #

--- a/sig/steep/ast/types/logic.rbs
+++ b/sig/steep/ast/types/logic.rbs
@@ -52,6 +52,11 @@ module Steep
           def initialize: (?location: untyped?) -> void
         end
 
+        # A type for `Class#<` or `Class#<=` call results.
+        class ArgIsAncestor < Base
+          def initialize: (?location: untyped?) -> void
+        end
+
         # A type with truthy/falsy type environment.
         class Env < Base
           attr_reader truthy: TypeInference::TypeEnv

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1644,4 +1644,30 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_class_narrowing
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          module Foo
+            def self.foo: () -> void
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          klass = Class.new()
+
+          if klass < Foo
+            klass.foo()
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
Module#< and Module#<= means the argument is the ancestor of the receiver.  Thefore this allows to Steep to do narrowing the type of the receiver to the given argument.