### PR TITLE
Avoid inifinite loop in `#shape`

### DIFF
--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -71,6 +71,18 @@ module Steep
 
         # Substitution for immediate type expressions
         def subst: () -> Substitution
+
+        # Returns `self_type`, or `nil` when it is `Types::Self`
+        #
+        def self_type?: () -> AST::Types::t?
+
+        # Returns `class_type`, or `nil` when it is `Types::Class`
+        #
+        def class_type?: () -> AST::Types::t?
+
+        # Returns `instanc_type`, or `nil` when it is `Types::Instance`
+        #
+        def instance_type?: () -> AST::Types::t?
       end
 
       attr_reader factory: AST::Types::Factory


### PR DESCRIPTION
Having `Self`, `Instance`, or `Class` as `self_type:`, `instance_type:`, or `class_type` may result in infinite recursive call of `#shape` which causes *interaction* worker unexpected exit with `SystemStackError`.