### PR TITLE
langserver: Support --with-expectations-path option

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -228,6 +228,9 @@ module Steep
       Drivers::Langserver.new(stdout: stdout, stderr: stderr, stdin: stdin).tap do |command|
         OptionParser.new do |opts|
           opts.on("--steepfile=PATH") {|path| command.steepfile = Pathname(path) }
+          opts.on("--with-expectations[=PATH]", "Type check with expectations saved in PATH (or steep_expectations.yml)") do |path|
+            command.with_expectations_path = Pathname(path || "steep_expectations.yml")
+          end
           handle_jobs_option command.jobs_option, opts
           handle_logging_options opts
         end.parse!(argv)
@@ -347,6 +350,9 @@ TEMPLATE
           opts.on("--delay-shutdown") { command.delay_shutdown = true }
           opts.on("--max-index=COUNT") {|count| command.max_index = Integer(count) }
           opts.on("--index=INDEX") {|index| command.index = Integer(index) }
+          opts.on("--with-expectations[=PATH]", "Type check with expectations saved in PATH (or steep_expectations.yml)") do |path|
+            command.with_expectations_path = Pathname(path || "steep_expectations.yml")
+          end
         end.parse!(argv)
 
         command.commandline_args.push(*argv)

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -8,6 +8,7 @@ module Steep
       attr_reader :type_check_queue
       attr_reader :type_check_thread
       attr_reader :jobs_option
+      attr_accessor :with_expectations_path
 
       include Utils::DriverHelper
 
@@ -36,7 +37,7 @@ module Steep
         @project = load_config()
 
         interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: project.steepfile_path, steep_command: jobs_option.steep_command)
-        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: jobs_option.steep_command, count: jobs_option.jobs_count_value)
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: jobs_option.steep_command, count: jobs_option.jobs_count_value, with_expectations_path: with_expectations_path)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -9,6 +9,7 @@ module Steep
       attr_accessor :max_index
       attr_accessor :index
       attr_accessor :commandline_args
+      attr_accessor :with_expectations_path
 
       include Utils::DriverHelper
 
@@ -33,7 +34,8 @@ module Steep
                                                  reader: reader,
                                                  writer: writer,
                                                  assignment: assignment,
-                                                 commandline_args: commandline_args)
+                                                 commandline_args: commandline_args,
+                                                 with_expectations_path: with_expectations_path)
                    when :interaction
                      Server::InteractionWorker.new(project: project, reader: reader, writer: writer)
                    else

--- a/lib/steep/expectations.rb
+++ b/lib/steep/expectations.rb
@@ -199,6 +199,10 @@ module Steep
       new()
     end
 
+    def include?(path:, diagnostic:)
+      (self.diagnostics[path] || []).include?(diagnostic)
+    end
+
     def to_yaml
       array = [] #: Array[{ "file" => String, "diagnostics" => Array[untyped] }]
 

--- a/sig/steep/drivers/langserver.rbs
+++ b/sig/steep/drivers/langserver.rbs
@@ -15,6 +15,8 @@ module Steep
 
       attr_reader jobs_option: Utils::JobsOption
 
+      attr_accessor with_expectations_path: Pathname?
+
       include Utils::DriverHelper
 
       def initialize: (stdout: untyped, stderr: untyped, stdin: untyped) -> void

--- a/sig/steep/drivers/worker.rbs
+++ b/sig/steep/drivers/worker.rbs
@@ -19,6 +19,8 @@ module Steep
 
       attr_accessor commandline_args: Array[String]
 
+      attr_accessor with_expectations_path: Pathname?
+
       include Utils::DriverHelper
 
       def initialize: (stdout: IO, stderr: IO, stdin: IO) -> void

--- a/sig/steep/expectations.rbs
+++ b/sig/steep/expectations.rbs
@@ -65,6 +65,8 @@ module Steep
 
     def self.empty: () -> instance
 
+    def include?: (path: Pathname, diagnostic: Diagnostic) -> bool
+
     def to_yaml: () -> String
 
     def self.load: (path: Pathname, content: String) -> instance

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -25,6 +25,8 @@ module Steep
 
       attr_reader current_type_check_guid: String?
 
+      attr_reader expectations: Expectations?
+
       class WorkspaceSymbolJob
         attr_reader id: String
 
@@ -104,7 +106,8 @@ module Steep
         reader: LSP::Transport::Io::Reader,
         writer: LSP::Transport::Io::Writer,
         assignment: PathAssignment,
-        commandline_args: Array[String]
+        commandline_args: Array[String],
+        with_expectations_path: Pathname?
       ) -> void
 
       def handle_request: (untyped request) -> void

--- a/sig/steep/server/worker_process.rbs
+++ b/sig/steep/server/worker_process.rbs
@@ -53,7 +53,8 @@ module Steep
         steep_command: String?,
         ?patterns: Array[String],
         ?delay_shutdown: bool,
-        ?index: [Integer, Integer]?
+        ?index: [Integer, Integer]?,
+        ?with_expectations_path: Pathname?
       ) -> WorkerProcess
 
       def self.fork_worker: (
@@ -62,7 +63,8 @@ module Steep
         steepfile: Pathname,
         patterns: Array[String],
         delay_shutdown: bool,
-        index: [Integer, Integer]?
+        index: [Integer, Integer]?,
+        with_expectations_path: Pathname?
       ) -> WorkerProcess
 
       def self.spawn_worker: (
@@ -72,7 +74,8 @@ module Steep
         steep_command: ::String,
         patterns: Array[String],
         delay_shutdown: bool,
-        index: [Integer, Integer]?
+        index: [Integer, Integer]?,
+        with_expectations_path: Pathname?
       ) -> WorkerProcess
 
       def self.start_typecheck_workers: (
@@ -80,7 +83,8 @@ module Steep
         args: Array[String],
         steep_command: ::String?,
         ?count: Integer,
-        ?delay_shutdown: bool
+        ?delay_shutdown: bool,
+        ?with_expectations_path: Pathname?
       ) -> Array[WorkerProcess]
 
       def <<: (untyped message) -> void

--- a/test/expectations_test.rb
+++ b/test/expectations_test.rb
@@ -82,4 +82,45 @@ YAML
     assert_equal [ds[0]], result.missing_diagnostics
     assert_equal [ds[2]], result.unexpected_diagnostics
   end
+
+  def test_include?
+    es = Expectations.load(path: Pathname("steep_expectations.yml"), content: <<YAML)
+- file: a.rb
+  diagnostics:
+    - range:
+        start: { line: 4, character: 0 }
+        end: { line: 4, character: 7 }
+      severity: ERROR
+      message: |
+        Cannot assign a value of type `::String` to a variable of type `::Symbol`
+          ::String <: ::Symbol
+            ::Object <: ::Symbol
+              ::BasicObject <: ::Symbol
+      code: Ruby::UnresolvedOverloading
+YAML
+
+    assert es.include?(path: Pathname("a.rb"), diagnostic: Diagnostic.new(
+        start_position: { line: 3, character: 0 },
+        end_position: { line: 3, character: 7 },
+        severity: :error,
+        code: "Ruby::UnresolvedOverloading",
+        message: <<~MSG
+          Cannot assign a value of type `::String` to a variable of type `::Symbol`
+            ::String <: ::Symbol
+              ::Object <: ::Symbol
+                ::BasicObject <: ::Symbol
+        MSG
+      )
+    )
+
+    refute es.include?(path: Pathname("b.rb"), diagnostic:
+      Diagnostic.new(
+        start_position: { line: 3, character: 0 },
+        end_position: { line: 3, character: 7 },
+        severity: :error,
+        code: "Ruby::UnresolvedOverloading",
+        message: "Diagnostic 1"
+      )
+    )
+  end
 end

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -66,6 +66,7 @@ class TypeCheckWorkerTest < Minitest::Test
             project: project,
             assignment: assignment,
             commandline_args: [],
+            with_expectations_path: nil,
             reader: worker_reader,
             writer: worker_writer)
         ) do |worker|
@@ -102,6 +103,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -135,6 +137,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -183,6 +186,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -247,6 +251,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -294,6 +299,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -345,6 +351,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -392,6 +399,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -446,6 +454,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -494,6 +503,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -553,6 +563,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -615,6 +626,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          with_expectations_path: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -659,6 +671,7 @@ EOF
         project: project,
         assignment: assignment,
         commandline_args: [],
+        with_expectations_path: nil,
         reader: worker_reader,
         writer: worker_writer
       )
@@ -703,6 +716,7 @@ EOF
         project: project,
         assignment: assignment,
         commandline_args: [],
+        with_expectations_path: nil,
         reader: worker_reader,
         writer: worker_writer
       )
@@ -728,6 +742,7 @@ RUBY
         project: project,
         assignment: assignment,
         commandline_args: [],
+        with_expectations_path: nil,
         reader: worker_reader,
         writer: worker_writer
       )
@@ -769,6 +784,7 @@ RUBY
         project: project,
         assignment: assignment,
         commandline_args: [],
+        with_expectations_path: nil,
         reader: worker_reader,
         writer: worker_writer
       )


### PR DESCRIPTION
Add `--with-expectations=PATH` option to the langserver subcommand. It suppresses warnings and info messages using expectations file like check command does.  And it helps to users to develop RBS files gradually.