### PR TITLE
Add types for LSP::Constant::MessageType

### DIFF
--- a/sig/shims/language-server_protocol.rbs
+++ b/sig/shims/language-server_protocol.rbs
@@ -78,6 +78,18 @@ module LanguageServer
         MARKDOWN: "markdown"
       end
 
+      class MessageType
+        type t = 1 | 2 | 3 | 4
+
+        ERROR: 1
+
+        WARNING: 2
+
+        INFO: 3
+
+        LOG: 4
+      end
+
       module DiagnosticSeverity
         type t = 1 | 2 | 3 | 4
 


### PR DESCRIPTION
refs: https://github.com/mtsmfm/language_server-protocol-ruby/blob/main/lib/language_server/protocol/constant/message_type.rb