### PR TITLE
langserver: Add --severity-level option

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -208,6 +208,9 @@ module Steep
       Drivers::Langserver.new(stdout: stdout, stderr: stderr, stdin: stdin).tap do |command|
         OptionParser.new do |opts|
           opts.on("--steepfile=PATH") {|path| command.steepfile = Pathname(path) }
+          opts.on("--severity-level=LEVEL", /^error|warning|information|hint$/, "Specify the minimum diagnostic severity to be recognized as an error (defaults: warning): error, warning, information, or hint") do |level|
+            command.severity_level = level.to_sym
+          end
           handle_jobs_option command.jobs_option, opts
           handle_logging_options opts
         end.parse!(argv)
@@ -325,6 +328,9 @@ TEMPLATE
           opts.on("--steepfile=PATH") {|path| command.steepfile = Pathname(path) }
           opts.on("--name=NAME") {|name| command.worker_name = name }
           opts.on("--delay-shutdown") { command.delay_shutdown = true }
+          opts.on("--severity-level=LEVEL", /^error|warning|information|hint$/, "Specify the minimum diagnostic severity to be recognized as an error (defaults: warning): error, warning, information, or hint") do |level|
+            command.severity_level = level.to_sym
+          end
           opts.on("--max-index=COUNT") {|count| command.max_index = Integer(count) }
           opts.on("--index=INDEX") {|index| command.index = Integer(index) }
         end.parse!(argv)

--- a/lib/steep/drivers/checkfile.rb
+++ b/lib/steep/drivers/checkfile.rb
@@ -105,6 +105,7 @@ module Steep
           steepfile: project.steepfile_path,
           args: [],
           delay_shutdown: true,
+          severity_level: nil,
           steep_command: jobs_option.steep_command,
           count: count
         )

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -5,6 +5,7 @@ module Steep
       attr_reader :stderr
       attr_reader :stdin
       attr_reader :write_mutex
+      attr_accessor :severity_level
       attr_reader :type_check_queue
       attr_reader :type_check_thread
       attr_reader :jobs_option
@@ -16,6 +17,7 @@ module Steep
         @stderr = stderr
         @stdin = stdin
         @write_mutex = Mutex.new
+        @severity_level = :warning
         @type_check_queue = Queue.new
         @jobs_option = Utils::JobsOption.new(jobs_count_modifier: -1)
       end
@@ -36,7 +38,7 @@ module Steep
         @project = load_config()
 
         interaction_worker = Server::WorkerProcess.start_worker(:interaction, name: "interaction", steepfile: project.steepfile_path, steep_command: jobs_option.steep_command)
-        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: jobs_option.steep_command, count: jobs_option.jobs_count_value)
+        typecheck_workers = Server::WorkerProcess.start_typecheck_workers(steepfile: project.steepfile_path, args: [], steep_command: jobs_option.steep_command, count: jobs_option.jobs_count_value, severity_level: severity_level)
 
         master = Server::Master.new(
           project: project,

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -6,6 +6,7 @@ module Steep
       attr_accessor :worker_type
       attr_accessor :worker_name
       attr_accessor :delay_shutdown
+      attr_accessor :severity_level
       attr_accessor :max_index
       attr_accessor :index
       attr_accessor :commandline_args
@@ -33,7 +34,8 @@ module Steep
                                                  reader: reader,
                                                  writer: writer,
                                                  assignment: assignment,
-                                                 commandline_args: commandline_args)
+                                                 commandline_args: commandline_args,
+                                                 severity_level: severity_level)
                    when :interaction
                      Server::InteractionWorker.new(project: project, reader: reader, writer: writer)
                    else

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -18,7 +18,7 @@ module Steep
         @index = index
       end
 
-      def self.start_worker(type, name:, steepfile:, steep_command:, index: nil, delay_shutdown: false, patterns: [])
+      def self.start_worker(type, name:, steepfile:, steep_command:, index: nil, delay_shutdown: false, severity_level: :warning, patterns: [])
         begin
           unless steep_command
             fork_worker(
@@ -27,6 +27,7 @@ module Steep
               steepfile: steepfile,
               index: index,
               delay_shutdown: delay_shutdown,
+              severity_level: severity_level,
               patterns: patterns
             )
           else
@@ -41,12 +42,13 @@ module Steep
             steep_command: steep_command || "steep",
             index: index,
             delay_shutdown: delay_shutdown,
+            severity_level: severity_level,
             patterns: patterns
           )
         end
       end
 
-      def self.fork_worker(type, name:, steepfile:, index:, delay_shutdown:, patterns:)
+      def self.fork_worker(type, name:, steepfile:, index:, delay_shutdown:, severity_level:, patterns:)
         stdin_in, stdin_out = IO.pipe
         stdout_in, stdout_out = IO.pipe
 
@@ -56,6 +58,7 @@ module Steep
         worker.worker_type = type
         worker.worker_name = name
         worker.delay_shutdown = delay_shutdown
+        worker.severity_level = severity_level
         if (max, this = index)
           worker.max_index = max
           worker.index = this
@@ -91,7 +94,7 @@ module Steep
         )
       end
 
-      def self.spawn_worker(type, name:, steepfile:, steep_command:, index:, delay_shutdown:, patterns:)
+      def self.spawn_worker(type, name:, steepfile:, steep_command:, index:, delay_shutdown:, severity_level:, patterns:)
         args = ["--name=#{name}", "--steepfile=#{steepfile}"]
         args << (%w(debug info warn error fatal unknown)[Steep.logger.level].yield_self {|log_level| "--log-level=#{log_level}" })
 
@@ -106,6 +109,10 @@ module Steep
 
         if delay_shutdown
           args << "--delay-shutdown"
+        end
+
+        if severity_level
+          args << "--severity=#{severity_level}"
         end
 
         command = case type
@@ -130,7 +137,7 @@ module Steep
         new(reader: reader, writer: writer, stderr: stderr, wait_thread: thread, name: name, index: index&.[](1))
       end
 
-      def self.start_typecheck_workers(steepfile:, args:, steep_command:, count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false)
+      def self.start_typecheck_workers(steepfile:, args:, steep_command:, count: [Etc.nprocessors - 1, 1].max, delay_shutdown: false, severity_level: :warning)
         count.times.map do |i|
           start_worker(
             :typecheck,
@@ -140,6 +147,7 @@ module Steep
             index: [count, i],
             patterns: args,
             delay_shutdown: delay_shutdown,
+            severity_level: severity_level
           )
         end
       end

--- a/sig/steep/drivers/langserver.rbs
+++ b/sig/steep/drivers/langserver.rbs
@@ -9,6 +9,8 @@ module Steep
 
       attr_reader write_mutex: Thread::Mutex
 
+      attr_accessor severity_level: Diagnostic::LSPFormatter::severity
+
       attr_reader type_check_queue: Thread::Queue
 
       attr_reader type_check_thread: Thread

--- a/sig/steep/drivers/worker.rbs
+++ b/sig/steep/drivers/worker.rbs
@@ -13,6 +13,8 @@ module Steep
 
       attr_accessor delay_shutdown: bool
 
+      attr_accessor severity_level: Diagnostic::LSPFormatter::severity
+
       attr_accessor max_index: Integer
 
       attr_accessor index: Integer

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -25,6 +25,8 @@ module Steep
 
       attr_reader current_type_check_guid: String?
 
+      attr_reader severity_level: Diagnostic::LSPFormatter::severity
+
       class WorkspaceSymbolJob
         attr_reader id: String
 
@@ -104,7 +106,8 @@ module Steep
         reader: LSP::Transport::Io::Reader,
         writer: LSP::Transport::Io::Writer,
         assignment: PathAssignment,
-        commandline_args: Array[String]
+        commandline_args: Array[String],
+        severity_level: Diagnostic::LSPFormatter::severity
       ) -> void
 
       def handle_request: (untyped request) -> void
@@ -128,6 +131,8 @@ module Steep
                | StatsJob
 
       def handle_job: (job) -> void
+
+      def keep_diagnostic?: (untyped diagnostic, severity_level: Diagnostic::LSPFormatter::severity) -> bool
 
       def typecheck_progress: (guid: String, path: Pathname) -> void
 

--- a/sig/steep/server/worker_process.rbs
+++ b/sig/steep/server/worker_process.rbs
@@ -53,6 +53,7 @@ module Steep
         steep_command: String?,
         ?patterns: Array[String],
         ?delay_shutdown: bool,
+        ?severity_level: Diagnostic::LSPFormatter::severity,
         ?index: [Integer, Integer]?
       ) -> WorkerProcess
 
@@ -62,6 +63,7 @@ module Steep
         steepfile: Pathname,
         patterns: Array[String],
         delay_shutdown: bool,
+        severity_level: Diagnostic::LSPFormatter::severity,
         index: [Integer, Integer]?
       ) -> WorkerProcess
 
@@ -72,6 +74,7 @@ module Steep
         steep_command: ::String,
         patterns: Array[String],
         delay_shutdown: bool,
+        severity_level: Diagnostic::LSPFormatter::severity,
         index: [Integer, Integer]?
       ) -> WorkerProcess
 
@@ -80,7 +83,8 @@ module Steep
         args: Array[String],
         steep_command: ::String?,
         ?count: Integer,
-        ?delay_shutdown: bool
+        ?delay_shutdown: bool,
+        ?severity_level: Diagnostic::LSPFormatter::severity
       ) -> Array[WorkerProcess]
 
       def <<: (untyped message) -> void

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -66,6 +66,7 @@ class TypeCheckWorkerTest < Minitest::Test
             project: project,
             assignment: assignment,
             commandline_args: [],
+            severity_level: :warning,
             reader: worker_reader,
             writer: worker_writer)
         ) do |worker|
@@ -102,6 +103,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -135,6 +137,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -183,6 +186,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -247,6 +251,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -294,6 +299,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -345,6 +351,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -392,6 +399,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -446,6 +454,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -494,6 +503,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -553,6 +563,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: nil,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -615,6 +626,7 @@ class TypeCheckWorkerTest < Minitest::Test
           project: project,
           assignment: assignment,
           commandline_args: [],
+          severity_level: :warning,
           reader: worker_reader,
           writer: worker_writer
         )
@@ -659,6 +671,7 @@ EOF
         project: project,
         assignment: assignment,
         commandline_args: [],
+        severity_level: :warning,
         reader: worker_reader,
         writer: worker_writer
       )
@@ -703,6 +716,7 @@ EOF
         project: project,
         assignment: assignment,
         commandline_args: [],
+        severity_level: :warning,
         reader: worker_reader,
         writer: worker_writer
       )
@@ -728,6 +742,7 @@ RUBY
         project: project,
         assignment: assignment,
         commandline_args: [],
+        severity_level: :warning,
         reader: worker_reader,
         writer: worker_writer
       )
@@ -769,6 +784,7 @@ RUBY
         project: project,
         assignment: assignment,
         commandline_args: [],
+        severity_level: :warning,
         reader: worker_reader,
         writer: worker_writer
       )


### PR DESCRIPTION
Currently, langserver does not support `--severity-level` option. Therefore the diagnostics are different with `steep check` command by default because the result of `steep check` is filtered by severity-level warning by default.  On the other hand, the result of `steep langserver` is not filtered at all.

This adds `--severity-level` option to the `steep langserver` command to control the severity level through the option.  And it defaults to "warning" level as same as other subcommand does.