### PR TITLE
Proposal: Add method annotations: primitive:nil? and primitive:not_nil?

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -767,6 +767,20 @@ module Steep
               )
             end
           end
+
+          if method_def.annotations.any? {|annotation| annotation.string == "primitive:nil?" }
+            return method_type.with(
+              type: method_type.type.with(
+                return_type: AST::Types::Logic::ReceiverIsNil.new(location: method_type.type.return_type.location)
+              )
+            )
+          elsif method_def.annotations.any? {|annotation| annotation.string == "primitive:not_nil?" }
+            return method_type.with(
+              type: method_type.type.with(
+                return_type: AST::Types::Logic::ReceiverIsNotNil.new(location: method_type.type.return_type.location)
+              )
+            )
+          end
         end
 
         method_type

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6152,6 +6152,46 @@ e + 1
     end
   end
 
+  def test_logic_receiver_is_nil_via_annotation
+    with_checker(<<-RBS) do |checker|
+      class Object
+        %a{primitive:nil?}
+        def blank?: () -> bool
+      end
+    RBS
+      source = parse_ruby(<<-RUBY)
+a = [1].first
+return if a.blank?
+a + 1
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_logic_receiver_is_not_nil_via_annotation
+    with_checker(<<-RBS) do |checker|
+      class Object
+        %a{primitive:not_nil?}
+        def present?: () -> bool
+      end
+    RBS
+      source = parse_ruby(<<-RUBY)
+a = [1].first
+return unless a.present?
+a + 1
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_logic_receiver_is_arg
     with_checker(<<-RBS) do |checker|
     RBS


### PR DESCRIPTION
To represent methods like `Object#blank?` and `Object#present?` in ActiveSupport, this adds method annotations `primitive:nil?` and `primitive:not_nil?`.

They will be considered as same as `nil?` and not `nil?` internally.

refs: #472


Please let me know your opinion about implementation, the naming of annotations, and so on.