### PR TITLE
Fix unexpected error when DifferentMethodParameterKind

### DIFF
--- a/lib/steep/type_inference/method_params.rb
+++ b/lib/steep/type_inference/method_params.rb
@@ -453,7 +453,7 @@ module Steep
           has_error = false
 
           keywords.each do |keyword|
-            rest_types << keyword_params.requireds[keyword] || keyword_params.optionals[keyword]
+            rest_types << (keyword_params.requireds[keyword] || keyword_params.optionals[keyword])
             has_error = true
           end
           keywords.clear

--- a/test/method_params_test.rb
+++ b/test/method_params_test.rb
@@ -370,6 +370,23 @@ class MethodParamsTest < Minitest::Test
         end
       end
 
+      MethodParams.build(node: node, method_type: parse_method_type("(?foo: String) -> void")).tap do |params|
+        assert_equal 1, params.size
+
+        assert_equal(
+          MethodParams::KeywordRestParameter.new(
+            name: :foo,
+            type: parse_type("String"),
+            node: params.args[0]
+          ),
+          params[:foo]
+        )
+
+        assert_any!(params.errors, size: 1) do |error|
+          assert_instance_of DifferentMethodParameterKind, error
+        end
+      end
+
       MethodParams.build(node: node, method_type: parse_method_type("(**Symbol) -> void")).tap do |params|
         assert_equal 1, params.size
 


### PR DESCRIPTION
I encountered a pattern that was causing unexpected errors, so I have fixed it.
It seems that `<<` takes precedence over `||`.
This pattern was occurring with `Ripper.tokenize`.

https://github.com/ruby/ruby/blob/7816307b30189ec7d71d6ce704a9aebd0395d447/ext/ripper/lib/ripper/lexer.rb#L25

https://github.com/ruby/rbs/blob/abcc97d3c8b024856ba9603a7ef22d422652ff42/stdlib/ripper/0/ripper.rbs#L1097

### Repro

```
$ cat t.rb
class Foo
  def foo(**kw)
  end
end

$ cat t.rbs
class Foo
  def foo: (?a: boolish) -> void
end

$ cat Steepfile
target :app do
  check "t.rb"
  signature "t.rbs"
end

$ steep check
# Type checking files:

......................................................................[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)] Unexpected error: RuntimeError
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   /Users/yuki.kurihara/src/github.com/ksss/steep/lib/steep/ast/types/union.rb:16:in `build'
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   /Users/yuki.kurihara/src/github.com/ksss/steep/lib/steep/type_inference/method_params.rb:467:in `build'
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   /Users/yuki.kurihara/src/github.com/ksss/steep/lib/steep/type_construction.rb:199:in `for_new_method'
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   /Users/yuki.kurihara/src/github.com/ksss/steep/lib/steep/type_construction.rb:278:in `with_method_constr'
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   /Users/yuki.kurihara/src/github.com/ksss/steep/lib/steep/type_construction.rb:942:in `block (2 levels) in synthesize'
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   <internal:kernel>:148:in `yield_self'
[Steep 1.5.3] [typecheck:typecheck@2] [background] [#typecheck_source(path=t.rb)] [#type_check_file(t.rb@app)] [synthesize:(1:1)] [synthesize:(2:3)]   /Users/yuki.kurihara/src/github.com/ksss/steep/lib/steep/type_construction.rb:937:in `block in synthesize'
...(snip)
```