### PR TITLE
`nil` is not a `NilClass`

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -549,9 +549,7 @@ module Steep
           end
 
         when relation.super_type.is_a?(AST::Types::Nil) && AST::Builtin::NilClass.instance_type?(relation.sub_type)
-          Success(relation)
-
-        when relation.sub_type.is_a?(AST::Types::Nil) && AST::Builtin::NilClass.instance_type?(relation.super_type)
+          # NilClass <: nil
           Success(relation)
 
         when relation.sub_type.is_a?(AST::Types::Literal)

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -408,8 +408,12 @@ end
 
   def test_nil_type
     with_checker do |checker|
-      assert_success_check checker, "nil", "::NilClass"
       assert_success_check checker, "::NilClass", "nil"
+      
+      assert_fail_check checker, "nil", "::NilClass"
+      assert_fail_check checker, "nil", "::Object"
+      assert_success_check checker, "nil", "top"
+      assert_success_check checker, "nil", "untyped"
     end
   end
 


### PR DESCRIPTION
It allows `nil` to be an `Object`.