### PR TITLE
Better completion with module alias and `use` directives

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -227,9 +227,11 @@ module Steep
           )
         )
 
+        type_name = sig_service.latest_env.normalize_type_name(type_name)
+
         case type_name.kind
         when :class
-          env = sig_service.latest_env #: RBS::Environment
+          env = sig_service.latest_env
           class_entry = env.module_class_entry(type_name) or raise
 
           case class_entry

--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -115,7 +115,7 @@ module Steep
             when RBS::Environment::ClassAliasEntry, RBS::Environment::ModuleAliasEntry
               entry.decl
             else
-              raise
+              raise "absolute_type_name=#{absolute_type_name}, relative_type_name=#{relative_type_name}"
             end
           else
             raise

--- a/lib/steep/services/type_name_completion.rb
+++ b/lib/steep/services/type_name_completion.rb
@@ -183,10 +183,11 @@ module Steep
         end
 
         name.absolute? or raise
+        normalized_name = env.normalize_type_name?(name) or raise "Cannot normalize given type name `#{name}`"
 
         name.namespace.path.reverse_each.inject(RBS::TypeName.new(namespace: RBS::Namespace.empty, name: name.name)) do |relative_name, component|
           if type_name_resolver.resolve(relative_name, context: context) == name
-            return [name, relative_name]
+            return [normalized_name, relative_name]
           end
 
           RBS::TypeName.new(
@@ -195,10 +196,10 @@ module Steep
           )
         end
 
-          [name, name.relative!]
         if type_name_resolver.resolve(name.relative!, context: context) == name && !resolve_used_name(name.relative!)
+          [normalized_name, name.relative!]
         else
-          [name, name]
+          [normalized_name, name]
         end
       end
 

--- a/lib/steep/services/type_name_completion.rb
+++ b/lib/steep/services/type_name_completion.rb
@@ -31,15 +31,20 @@ module Steep
 
           case prefix
           when /\A((::\w+[A-Z])+(::)?)/
-            NamespacePrefix.new(RBS::Namespace.parse($1.reverse), $1.size)
+            namespace = $1 or raise
+            NamespacePrefix.new(RBS::Namespace.parse(namespace.reverse), namespace.size)
           when /\A::/
             NamespacePrefix.new(RBS::Namespace.root, 2)
           when /\A(\w*[A-Za-z_])((::\w+[A-Z])+(::)?)/
-            NamespacedIdentPrefix.new(RBS::Namespace.parse($2.reverse), $1.reverse, $1.size + $2.size)
+            namespace = $1 or raise
+            identifier = $2 or raise
+            NamespacedIdentPrefix.new(RBS::Namespace.parse(identifier.reverse), namespace.reverse, namespace.size + identifier.size)
           when /\A(\w*[A-Za-z_])::/
-            NamespacedIdentPrefix.new(RBS::Namespace.root, $1.reverse, $1.size + 2)
+            namespace = $1 or raise
+            NamespacedIdentPrefix.new(RBS::Namespace.root, namespace.reverse, namespace.size + 2)
           when /\A(\w*[A-Za-z_])/
-            RawIdentPrefix.new($1.reverse)
+            identifier = $1 or raise
+            RawIdentPrefix.new(identifier.reverse)
           end
         end
       end
@@ -92,23 +97,65 @@ module Steep
         if block
           env = self.env
 
+          table = {} #: Hash[RBS::Namespace, Array[RBS::TypeName]]
+          env.class_decls.each_key do |type_name|
+            yield(type_name)
+            (table[type_name.namespace] ||= []) << type_name
+          end
+          env.type_alias_decls.each_key do |type_name|
+            yield(type_name)
+            (table[type_name.namespace] ||= []) << type_name
+          end
+          env.interface_decls.each_key do |type_name|
+            yield(type_name)
+            (table[type_name.namespace] ||= []) << type_name
+          end
+          env.class_alias_decls.each_key do |type_name|
+            yield(type_name)
+            (table[type_name.namespace] ||= []) << type_name
+          end
+
+          env.class_alias_decls.each_key do |alias_name|
+            normalized_name = env.normalize_module_name?(alias_name) or next
+            each_type_name_under(alias_name, normalized_name, table: table, &block)
+          end
+
+          resolve_pairs = [] #: Array[[RBS::TypeName, RBS::TypeName]]
+
           map.instance_eval do
             @map.each_key do |name|
               relative_name = RBS::TypeName.new(name: name, namespace: RBS::Namespace.empty)
               if absolute_name = resolve?(relative_name)
                 if env.type_name?(absolute_name)
                   # Yields only if the relative type name resolves to existing absolute type name
-                  yield relative_name
+                  resolve_pairs << [relative_name, absolute_name]
                 end
               end
             end
           end
-          env.class_decls.each_key(&block)
-          env.class_alias_decls.each_key(&block)
-          env.type_alias_decls.each_key(&block)
-          env.interface_decls.each_key(&block)
+
+          resolve_pairs.each do |use_name, absolute_name|
+            yield use_name
+            each_type_name_under(use_name, absolute_name, table: table, &block)
+          end
         else
           enum_for :each_type_name
+        end
+      end
+
+      def each_type_name_under(module_name, normalized_name, table:, &block)
+        if children = table.fetch(normalized_name.to_namespace, nil)
+          module_namespace = module_name.to_namespace
+
+          children.each do |normalized_child_name|
+            child_name = RBS::TypeName.new(namespace: module_namespace, name: normalized_child_name.name)
+
+            yield child_name
+
+            if normalized_child_name.class?
+              each_type_name_under(child_name, env.normalize_module_name(normalized_child_name), table: table, &block)
+            end
+          end
         end
       end
 
@@ -144,7 +191,12 @@ module Steep
             type_name.split.any? {|sym| sym.to_s.downcase.include?(prefix.ident.downcase) }
           end
         when Prefix::NamespacedIdentPrefix
-          absolute_namespace = type_name_resolver.resolve(prefix.namespace.to_type_name, context: context)&.to_namespace || prefix.namespace
+          absolute_namespace =
+            if prefix.namespace.empty?
+              RBS::Namespace.root
+            else
+              type_name_resolver.resolve(prefix.namespace.to_type_name, context: context)&.to_namespace || prefix.namespace
+            end
 
           each_type_name.filter do|name|
             name.namespace == absolute_namespace &&

--- a/sig/steep/services/type_name_completion.rbs
+++ b/sig/steep/services/type_name_completion.rbs
@@ -112,8 +112,19 @@ module Steep
 
       def format_constant_name: (TypeName) -> String
 
+      private
+
+      # Yield type names defined in the environment
+      #
+      # * Yields an absolute type name if it is defined in the environment
+      # * Yields an relative type name if it is imported with `use` declerative
+      #
+      # Alias classes/modules and types under them are yielded.
+      #
       def each_type_name: () { (TypeName) -> void } -> void
                         | () -> Enumerator[TypeName, void]
+
+      def each_type_name_under: (TypeName module_name, TypeName normalized_name, table: Hash[Namespace, Array[TypeName]]) { (TypeName) -> void } -> void
 
       def each_outer_module: (?Resolver::context) { (Namespace) -> void } -> Namespace
                            | () -> Enumerator[Namespace, void]

--- a/sig/steep/services/type_name_completion.rbs
+++ b/sig/steep/services/type_name_completion.rbs
@@ -112,6 +112,8 @@ module Steep
 
       def format_constant_name: (TypeName) -> String
 
+      def resolve_used_name: (TypeName) -> TypeName?
+
       private
 
       # Yield type names defined in the environment

--- a/test/type_name_completion_test.rb
+++ b/test/type_name_completion_test.rb
@@ -75,6 +75,8 @@ class TypeNameCompletionTest < Minitest::Test
       # Returns all type names that shares the prefix and contains the identifier case-insensitively
       assert_equal [TypeName("::Foo::Bar::baz")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("::Foo::Bar::"), "ba"))
 
+      assert_equal [TypeName("::Foo")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("::"), "Fo"))
+
       # Returns all type names that shares the prefix
       assert_equal [TypeName("::Foo::Bar::baz"), TypeName("::Foo::Bar::_Quax")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacePrefix.new(RBS::Namespace.parse("::Foo::Bar::")))
     end
@@ -98,6 +100,65 @@ class TypeNameCompletionTest < Minitest::Test
       assert completion.each_type_name.include?(TypeName("ExistingClass"))
     end
   end
+
+  def test_each_type_name_alias
+    with_factory({ "a.rbs" => <<~RBS }) do |factory|
+        module Foo
+          module Bar = ::Bar
+        end
+
+        module Bar
+          module Baz = Integer
+        end
+      RBS
+
+      buf = factory.env.buffers.find {|buf| File.basename(buf.name) == "a.rbs" } or raise
+      dirs, _ = factory.env.signatures[buf]
+
+      completion = Services::TypeNameCompletion.new(
+        env: factory.env,
+        context: nil,
+        dirs: dirs
+      )
+
+      assert completion.each_type_name.include?(TypeName("::Foo"))
+      assert completion.each_type_name.include?(TypeName("::Foo::Bar"))
+      assert completion.each_type_name.include?(TypeName("::Foo::Bar::Baz"))
+      assert completion.each_type_name.include?(TypeName("::Bar"))
+      assert completion.each_type_name.include?(TypeName("::Bar::Baz"))
+    end
+  end
+
+  def test_each_type_name_alias_use
+    with_factory({ "a.rbs" => <<~RBS }) do |factory|
+        use Foo as FOO, Baz as BAZ
+
+        module Foo
+          module Bar = BAZ
+        end
+
+        module Baz
+          type t = Integer
+        end
+      RBS
+
+      buf = factory.env.buffers.find {|buf| File.basename(buf.name) == "a.rbs" } or raise
+      dirs, _ = factory.env.signatures[buf]
+
+      completion = Services::TypeNameCompletion.new(
+        env: factory.env,
+        context: nil,
+        dirs: dirs
+      )
+
+      type_names = completion.each_type_name.to_set
+
+      assert type_names.include?(TypeName("FOO"))
+      assert type_names.include?(TypeName("FOO::Bar"))
+      assert type_names.include?(TypeName("FOO::Bar::t"))
+    end
+  end
+
 
   def test_relative_name_in_context
     with_factory({ "a.rbs" => <<~RBS}) do |factory|
@@ -140,11 +201,36 @@ class TypeNameCompletionTest < Minitest::Test
       assert_operator completion.find_type_names(nil), :include?, TypeName("String")
       assert_operator completion.find_type_names(nil), :include?, TypeName("::String")
 
-      assert_equal [TypeName("Foo")], completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Foo"))
+      assert_operator completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Foo")), :include?, TypeName("Foo")
 
       assert_equal [TypeName("::Object"), TypeName("Foo")], completion.resolve_name_in_context(TypeName("Foo"))
       assert_equal [TypeName("::Integer"), TypeName("String")], completion.resolve_name_in_context(TypeName("String"))
       assert_equal [TypeName("::String"), TypeName("::String")], completion.resolve_name_in_context(TypeName("::String"))
+    end
+  end
+
+  def test_find_type_names_module_alias
+    with_factory({ "a.rbs" => <<~RBS }, nostdlib: true) do |factory|
+        class Foo
+          module Bar
+            type id = Integer
+          end
+        end
+
+        class Baz = Foo::Bar
+      RBS
+
+      completion = Services::TypeNameCompletion.new(env: factory.env, context: nil, dirs: [])
+
+      assert_equal(
+        [TypeName("::Baz::id")],
+        completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacePrefix.new(RBS::Namespace.parse("Baz::")))
+      )
+
+      assert_equal(
+        [TypeName("::Baz::id")],
+        completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("Baz::"), "i"))
+      )
     end
   end
 end


### PR DESCRIPTION
Type name completion didn't work with module/class aliases or `use` directives

```rbs
use Foo as Foo2

module Foo
  module Bar
  end
end

module Foo1 = Foo

type t1 = Foo1::B    # <= Completion didn't work because `Foo1` is a module alias
type t2 = Foo2::B   # <= Completion didn't work because `Foo2` is a `use` type name
```

This also fixes a completion triggered with an _absolute_ type name -- `::Foo`.
