### PR TITLE
Run with `--jobs=2` automatically on CI

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -84,6 +84,18 @@ module Steep
       end
     end
 
+    def setup_jobs_for_ci(jobs_option)
+      if ENV["CI"]
+        unless jobs_option.jobs_count
+          stderr.puts Rainbow("CI environment is detected but no `--jobs` option is given.").yellow
+          stderr.puts "  Using `[2, #{jobs_option.default_jobs_count} (# or processors)].min` to avoid hitting memory limit."
+          stderr.puts "  Specify `--jobs` option to increase the number of jobs."
+
+          jobs_option.jobs_count = [2, jobs_option.default_jobs_count].min
+        end
+      end
+    end
+
     def process_init
       Drivers::Init.new(stdout: stdout, stderr: stderr).tap do |command|
         OptionParser.new do |opts|
@@ -116,6 +128,8 @@ module Steep
           handle_logging_options opts
         end.parse!(argv)
 
+        setup_jobs_for_ci(check.jobs_option)
+
         check.command_line_patterns.push *argv
       end.run
     end
@@ -139,6 +153,8 @@ module Steep
           handle_logging_options opts
         end.parse!(argv)
 
+        setup_jobs_for_ci(check.jobs_option)
+
         check.command_line_args.push *argv
       end.run
     end
@@ -153,6 +169,8 @@ module Steep
           handle_jobs_option check.jobs_option, opts
           handle_logging_options opts
         end.parse!(argv)
+
+        setup_jobs_for_ci(check.jobs_option)
 
         check.command_line_patterns.push *argv
       end.run
@@ -198,6 +216,8 @@ module Steep
           handle_jobs_option command.jobs_option, opts
           handle_logging_options opts
         end.parse!(argv)
+
+        setup_jobs_for_ci(command.jobs_option)
 
         dirs = argv.map {|dir| Pathname(dir) }
         command.dirs.push(*dirs)

--- a/sig/steep/cli.rbs
+++ b/sig/steep/cli.rbs
@@ -24,6 +24,8 @@ module Steep
 
     def handle_jobs_option: (Drivers::Utils::JobsOption jobs_option, OptionParser opts) -> void
 
+    def setup_jobs_for_ci: (Drivers::Utils::JobsOption) -> void
+
     def process_init: () -> Integer
 
     def process_check: () -> Integer


### PR DESCRIPTION
Steep invokes worker processes to type check files as many as the processors. But, computers running CI jobs typically have large number of processors, while the resources each CI job can use is limited.

Assume the CI computer has 32 cores, but only two of them are available for CI job. Steep spawns ~32 worker processes based on the number of cores. The problem is it often hits the memory limit by starting too many workers.

This PR is to fix the problem by setting the default `--jobs` number to `2` (or # of cores if it's smaller) when:

1. `CI` environment variable is defined, and
2. `--jobs` option is not set

This can slow the type checking job during CI if more than two cores are available. In that case, specify `--jobs` option explicitly based on the number of the available cores.

### Another possible implementation

This is kind of a workaround and calculating actually available number of processors would be a better solution for this problem. This is left for future work. 😃 