### PR TITLE
Start type check on change

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -110,6 +110,7 @@ require "steep/services/stats_calculator"
 require "steep/services/file_loader"
 require "steep/services/goto_service"
 
+require "steep/server/delay_queue"
 require "steep/server/lsp_formatter"
 require "steep/server/change_buffer"
 require "steep/server/base_worker"

--- a/lib/steep/server/delay_queue.rb
+++ b/lib/steep/server/delay_queue.rb
@@ -1,0 +1,41 @@
+module Steep
+  module Server
+    class DelayQueue
+      attr_reader :delay, :thread, :queue, :last_task
+
+      def initialize(delay:)
+        @delay = delay
+
+        @queue = Thread::Queue.new
+
+        @thread = Thread.new do
+          while (scheduled_at, proc = queue.pop)
+            # @type var scheduled_at: Time
+            # @type var proc: ^() -> void
+
+            diff = scheduled_at - Time.now
+            case
+            when diff > 0.1
+              sleep diff
+            when diff > 0
+              while Time.now < scheduled_at
+                # nop
+                sleep 0
+              end
+            end
+
+            if proc.equal?(last_task)
+              proc[]
+            end
+          end
+        end
+      end
+
+      def execute(&block)
+        @last_task = block
+        scheduled_at = Time.now + delay
+        queue << [scheduled_at, block]
+      end
+    end
+  end
+end

--- a/sig/steep/server/delay_queue.rbs
+++ b/sig/steep/server/delay_queue.rbs
@@ -1,0 +1,37 @@
+module Steep
+  module Server
+    # DelayQueue provides a queue that delays running given job
+    #
+    # 1. The `delay` is specific to a DelayQueue instance, not job specific
+    # 2. It executes only the last job
+    #
+    # ```ruby
+    # queue = DelayQueue.new(delay: 0.5)
+    # queue.execute { pp 1 }
+    # queue.execute { pp 2 }
+    # queue.execute { pp 3 }
+    #
+    # # => Will print only `3`, and the jobs printing `1` and `2` will be discarded
+    # ```
+    #
+    # The job will run on `#thread`.
+    #
+    class DelayQueue
+      attr_reader delay: Float
+
+      attr_reader thread: Thread
+
+      attr_reader queue: Thread::Queue
+
+      attr_reader last_task: Proc
+
+      def initialize: (delay: Float) -> void
+
+      # The `#execute` method is not thread safe
+      #
+      # You should synchronize yourself if you want to call the method from multiple threads.
+      #
+      def execute: () { () -> void } -> void
+    end
+  end
+end

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -225,6 +225,8 @@ module Steep
 
       attr_accessor typecheck_automatically: bool
 
+      attr_reader start_type_checking_queue: DelayQueue
+
       def initialize: (project: Project, reader: untyped, writer: untyped, interaction_worker: WorkerProcess?, typecheck_workers: Array[WorkerProcess], ?queue: Thread::Queue) -> void
 
       # Start the Steep language server

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -753,12 +753,16 @@ end
         RUBY
         ui.save_file(project.absolute_path(Pathname("sig/foo.rbs")))
 
-        ui.workspace_symbol().tap do |symbols|
-          assert symbols.find { |symbol| symbol[:name] == "FooClassNew" }
+        finally_holds do
+          ui.workspace_symbol().tap do |symbols|
+            assert symbols.find { |symbol| symbol[:name] == "FooClassNew" }
+          end
         end
 
-        ui.workspace_symbol("array").tap do |symbols|
-          assert symbols.find { |symbol| symbol[:name] == "Array" }
+        finally_holds do
+          ui.workspace_symbol("array").tap do |symbols|
+            assert symbols.find { |symbol| symbol[:name] == "Array" }
+          end
         end
       end
 


### PR DESCRIPTION
Instead of waiting for a `didSave` notification, start type checking after `didChange` notification with 0.1secs delay.

This improves responsiveness especially with editor configuration without auto-save.

#933 