### PR TITLE
Reset file content on `didOpen` notification

### DIFF
--- a/lib/steep/server/change_buffer.rb
+++ b/lib/steep/server/change_buffer.rb
@@ -61,6 +61,15 @@ module Steep
           end
         end
       end
+
+      def reset_change(uri:, text:)
+        push_buffer do |changes|
+          if path = Steep::PathHelper.to_pathname(uri)
+            path = project.relative_path(path)
+            changes[path] = [Services::ContentChange.new(text: text)]
+          end
+        end
+      end
     end
   end
 end

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -610,6 +610,7 @@ module Steep
         when "textDocument/didOpen"
           if path = pathname(message[:params][:textDocument][:uri])
             controller.update_priority(open: path)
+            broadcast_notification(message)
           end
 
         when "textDocument/didClose"

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -70,8 +70,15 @@ module Steep
         when "initialize"
           load_files(project: project, commandline_args: commandline_args)
           writer.write({ id: request[:id], result: nil})
+
         when "textDocument/didChange"
           collect_changes(request)
+
+        when "textDocument/didOpen"
+          uri = request[:params][:textDocument][:uri]
+          text = request[:params][:textDocument][:text]
+          reset_change(uri: uri, text: text)
+
         when "workspace/symbol"
           query = request[:params][:query]
           queue << WorkspaceSymbolJob.new(id: request[:id], query: query)

--- a/sig/steep/server/change_buffer.rbs
+++ b/sig/steep/server/change_buffer.rbs
@@ -27,6 +27,10 @@ module Steep
       # Load changes from a request with `DidChangeTextDocumentParams` into `buffered_changes`
       #
       def collect_changes: (untyped request) -> void
+
+      # Reset the content of `uri` to `text`
+      # 
+      def reset_change: (uri: String, text: String) -> void
     end
   end
 end


### PR DESCRIPTION
Let master forward `didOpen` notification to workers.

Workers reset the file content from the notification. This would provide a way to recover from broken buffer status.

Note that the `didOpen` notification won't start type checking. This may look weird, but won't cause an actual problem when we use the file watchers.

#933 