### PR TITLE
Proposal: Add a new diagnostic type: NoMethodByNil

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -303,6 +303,30 @@ module Steep
         end
       end
 
+      class NoMethodByNil < Base
+        attr_reader :type
+        attr_reader :method
+
+        def initialize(node:, type:, method:)
+          loc = case node.type
+                when :send
+                  loc = _ = nil
+                  loc ||= node.loc.operator if node.loc.respond_to?(:operator)
+                  loc ||= node.loc.selector if node.loc.respond_to?(:selector)
+                  loc
+                when :block
+                  node.children[0].loc.selector
+                end
+          super(node: node, location: loc || node.loc.expression)
+          @type = type
+          @method = method
+        end
+
+        def header_line
+          "Type `#{type}` does not have method `#{method}`"
+        end
+      end
+
       class ReturnTypeMismatch < Base
         attr_reader :expected
         attr_reader :actual
@@ -1035,6 +1059,7 @@ module Steep
             MethodReturnTypeAnnotationMismatch => :hint,
             MultipleAssignmentConversionError => :hint,
             NoMethod => :error,
+            NoMethodByNil => :error,
             ProcHintIgnored => :hint,
             ProcTypeExpected => :hint,
             RBSError => :information,
@@ -1093,6 +1118,7 @@ module Steep
             MethodReturnTypeAnnotationMismatch => :error,
             MultipleAssignmentConversionError => :error,
             NoMethod => :error,
+            NoMethodByNil => :error,
             ProcHintIgnored => :information,
             ProcTypeExpected => :error,
             RBSError => :error,
@@ -1151,6 +1177,7 @@ module Steep
             MethodReturnTypeAnnotationMismatch => nil,
             MultipleAssignmentConversionError => nil,
             NoMethod => :information,
+            NoMethodByNil => :information,
             ProcHintIgnored => nil,
             ProcTypeExpected => nil,
             RBSError => :information,

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3387,13 +3387,20 @@ module Steep
           end
         end
 
+        interface_type = interface&.type || receiver_type
+        if interface_type.is_a?(AST::Types::Union) && interface_type.types.any? {|type| type.is_a?(AST::Types::Nil) }
+          error = Diagnostic::Ruby::NoMethodByNil.new(node: node, method: method_name, type: interface_type)
+        else
+          error = Diagnostic::Ruby::NoMethod.new(node: node, method: method_name, type: interface_type)
+        end
+
         constr.add_call(
           TypeInference::MethodCall::NoMethodError.new(
             node: node,
             context: context.call_context,
             method_name: method_name,
             receiver_type: receiver_type,
-            error: Diagnostic::Ruby::NoMethod.new(node: node, method: method_name, type: interface&.type || receiver_type)
+            error: error
           )
         )
       end

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -139,6 +139,9 @@ module Steep
         def header_line: () -> ::String
       end
 
+      class NoMethodByNil < NoMethod
+      end
+
       class ReturnTypeMismatch < Base
         attr_reader expected: untyped
 

--- a/smoke/regexp/test_expectations.yml
+++ b/smoke/regexp/test_expectations.yml
@@ -1,615 +1,615 @@
 ---
 - file: a.rb
   diagnostics:
-  - range:
-      start:
-        line: 2
-        character: 6
-      end:
-        line: 2
-        character: 9
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 5
-        character: 6
-      end:
-        line: 5
-        character: 9
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 8
-        character: 6
-      end:
-        line: 8
-        character: 9
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 11
-        character: 6
-      end:
-        line: 11
-        character: 9
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 14
-        character: 10
-      end:
-        line: 14
-        character: 13
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 17
-        character: 10
-      end:
-        line: 17
-        character: 13
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 20
-        character: 10
-      end:
-        line: 20
-        character: 13
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 23
-        character: 10
-      end:
-        line: 23
-        character: 13
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 26
-        character: 9
-      end:
-        line: 26
-        character: 12
-    severity: ERROR
-    message: Type `::String` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 29
-        character: 13
-      end:
-        line: 29
-        character: 16
-    severity: ERROR
-    message: Type `(::MatchData | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 32
-        character: 13
-      end:
-        line: 32
-        character: 16
-    severity: ERROR
-    message: Type `(::String | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 35
-        character: 8
-      end:
-        line: 35
-        character: 11
-    severity: ERROR
-    message: Type `::String` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 38
-        character: 14
-      end:
-        line: 38
-        character: 17
-    severity: ERROR
-    message: Type `(::Regexp | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 41
-        character: 8
-      end:
-        line: 41
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 44
-        character: 8
-      end:
-        line: 44
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 47
-        character: 8
-      end:
-        line: 47
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 50
-        character: 8
-      end:
-        line: 50
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 53
-        character: 8
-      end:
-        line: 53
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 56
-        character: 8
-      end:
-        line: 56
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 59
-        character: 8
-      end:
-        line: 59
-        character: 11
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 62
-        character: 12
-      end:
-        line: 62
-        character: 15
-    severity: ERROR
-    message: Type `bool` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 68
-        character: 11
-      end:
-        line: 68
-        character: 14
-    severity: ERROR
-    message: Type `bool` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 71
-        character: 11
-      end:
-        line: 71
-        character: 14
-    severity: ERROR
-    message: Type `::Encoding` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 74
-        character: 17
-      end:
-        line: 74
-        character: 20
-    severity: ERROR
-    message: Type `bool` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 77
-        character: 8
-      end:
-        line: 77
-        character: 11
-    severity: ERROR
-    message: Type `(::MatchData | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 80
-        character: 8
-      end:
-        line: 80
-        character: 11
-    severity: ERROR
-    message: Type `(::MatchData | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 83
-        character: 4
-      end:
-        line: 83
-        character: 7
-    severity: ERROR
-    message: Type `::MatchData` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 87
-        character: 4
-      end:
-        line: 87
-        character: 7
-    severity: ERROR
-    message: Type `::MatchData` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 91
-        character: 10
-      end:
-        line: 91
-        character: 13
-    severity: ERROR
-    message: Type `bool` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 94
-        character: 10
-      end:
-        line: 94
-        character: 13
-    severity: ERROR
-    message: Type `bool` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 97
-        character: 17
-      end:
-        line: 97
-        character: 20
-    severity: ERROR
-    message: Type `::Hash[::String, ::Array[::Integer]]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 100
-        character: 8
-      end:
-        line: 100
-        character: 11
-    severity: ERROR
-    message: Type `::Array[::String]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 103
-        character: 10
-      end:
-        line: 103
-        character: 13
-    severity: ERROR
-    message: Type `::Integer` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 106
-        character: 9
-      end:
-        line: 106
-        character: 12
-    severity: ERROR
-    message: Type `::String` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 109
-        character: 17
-      end:
-        line: 109
-        character: 20
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
+    - range:
+        start:
+          line: 2
+          character: 6
+        end:
+          line: 2
+          character: 9
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 5
+          character: 6
+        end:
+          line: 5
+          character: 9
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 8
+          character: 6
+        end:
+          line: 8
+          character: 9
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 11
+          character: 6
+        end:
+          line: 11
+          character: 9
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 14
+          character: 10
+        end:
+          line: 14
+          character: 13
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 17
+          character: 10
+        end:
+          line: 17
+          character: 13
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 20
+          character: 10
+        end:
+          line: 20
+          character: 13
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 23
+          character: 10
+        end:
+          line: 23
+          character: 13
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 26
+          character: 9
+        end:
+          line: 26
+          character: 12
+      severity: ERROR
+      message: Type `::String` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 29
+          character: 13
+        end:
+          line: 29
+          character: 16
+      severity: ERROR
+      message: Type `(::MatchData | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 32
+          character: 13
+        end:
+          line: 32
+          character: 16
+      severity: ERROR
+      message: Type `(::String | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 35
+          character: 8
+        end:
+          line: 35
+          character: 11
+      severity: ERROR
+      message: Type `::String` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 38
+          character: 14
+        end:
+          line: 38
+          character: 17
+      severity: ERROR
+      message: Type `(::Regexp | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 41
+          character: 8
+        end:
+          line: 41
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 44
+          character: 8
+        end:
+          line: 44
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 47
+          character: 8
+        end:
+          line: 47
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 50
+          character: 8
+        end:
+          line: 50
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 53
+          character: 8
+        end:
+          line: 53
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 56
+          character: 8
+        end:
+          line: 56
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 59
+          character: 8
+        end:
+          line: 59
+          character: 11
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 62
+          character: 12
+        end:
+          line: 62
+          character: 15
+      severity: ERROR
+      message: Type `bool` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 68
+          character: 11
+        end:
+          line: 68
+          character: 14
+      severity: ERROR
+      message: Type `bool` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 71
+          character: 11
+        end:
+          line: 71
+          character: 14
+      severity: ERROR
+      message: Type `::Encoding` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 74
+          character: 17
+        end:
+          line: 74
+          character: 20
+      severity: ERROR
+      message: Type `bool` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 77
+          character: 8
+        end:
+          line: 77
+          character: 11
+      severity: ERROR
+      message: Type `(::MatchData | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 80
+          character: 8
+        end:
+          line: 80
+          character: 11
+      severity: ERROR
+      message: Type `(::MatchData | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 83
+          character: 4
+        end:
+          line: 83
+          character: 7
+      severity: ERROR
+      message: Type `::MatchData` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 87
+          character: 4
+        end:
+          line: 87
+          character: 7
+      severity: ERROR
+      message: Type `::MatchData` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 91
+          character: 10
+        end:
+          line: 91
+          character: 13
+      severity: ERROR
+      message: Type `bool` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 94
+          character: 10
+        end:
+          line: 94
+          character: 13
+      severity: ERROR
+      message: Type `bool` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 97
+          character: 17
+        end:
+          line: 97
+          character: 20
+      severity: ERROR
+      message: Type `::Hash[::String, ::Array[::Integer]]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 100
+          character: 8
+        end:
+          line: 100
+          character: 11
+      severity: ERROR
+      message: Type `::Array[::String]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 103
+          character: 10
+        end:
+          line: 103
+          character: 13
+      severity: ERROR
+      message: Type `::Integer` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 106
+          character: 9
+        end:
+          line: 106
+          character: 12
+      severity: ERROR
+      message: Type `::String` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 109
+          character: 17
+        end:
+          line: 109
+          character: 20
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
 - file: b.rb
   diagnostics:
-  - range:
-      start:
-        line: 3
-        character: 14
-      end:
-        line: 3
-        character: 17
-    severity: ERROR
-    message: Type `(::String | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 6
-        character: 14
-      end:
-        line: 6
-        character: 17
-    severity: ERROR
-    message: Type `(::String | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 9
-        character: 14
-      end:
-        line: 9
-        character: 17
-    severity: ERROR
-    message: Type `(::String | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 12
-        character: 14
-      end:
-        line: 12
-        character: 17
-    severity: ERROR
-    message: Type `::Array[(::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 15
-        character: 14
-      end:
-        line: 15
-        character: 17
-    severity: ERROR
-    message: Type `::Array[(::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 18
-        character: 10
-      end:
-        line: 18
-        character: 13
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 21
-        character: 10
-      end:
-        line: 21
-        character: 13
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 24
-        character: 10
-      end:
-        line: 24
-        character: 13
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 27
-        character: 13
-      end:
-        line: 27
-        character: 16
-    severity: ERROR
-    message: Type `::Array[(::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 30
-        character: 8
-      end:
-        line: 30
-        character: 11
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 33
-        character: 8
-      end:
-        line: 33
-        character: 11
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 36
-        character: 8
-      end:
-        line: 36
-        character: 11
-    severity: ERROR
-    message: Type `(::Integer | nil)` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 39
-        character: 11
-      end:
-        line: 39
-        character: 14
-    severity: ERROR
-    message: Type `::Integer` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 42
-        character: 19
-      end:
-        line: 42
-        character: 22
-    severity: ERROR
-    message: Type `::Hash[::String, (::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 45
-        character: 10
-      end:
-        line: 45
-        character: 13
-    severity: ERROR
-    message: Type `::Array[::String]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 48
-        character: 11
-      end:
-        line: 48
-        character: 14
-    severity: ERROR
-    message: Type `([::Integer, ::Integer] | [nil, nil])` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 51
-        character: 11
-      end:
-        line: 51
-        character: 14
-    severity: ERROR
-    message: Type `([::Integer, ::Integer] | [nil, nil])` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 54
-        character: 11
-      end:
-        line: 54
-        character: 14
-    severity: ERROR
-    message: Type `([::Integer, ::Integer] | [nil, nil])` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 57
-        character: 15
-      end:
-        line: 57
-        character: 18
-    severity: ERROR
-    message: Type `::String` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 60
-        character: 14
-      end:
-        line: 60
-        character: 17
-    severity: ERROR
-    message: Type `::String` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 63
-        character: 11
-      end:
-        line: 63
-        character: 14
-    severity: ERROR
-    message: Type `::Regexp` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 66
-        character: 9
-      end:
-        line: 66
-        character: 12
-    severity: ERROR
-    message: Type `::Integer` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 69
-        character: 11
-      end:
-        line: 69
-        character: 14
-    severity: ERROR
-    message: Type `::String` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 72
-        character: 9
-      end:
-        line: 72
-        character: 12
-    severity: ERROR
-    message: Type `::Array[(::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 75
-        character: 14
-      end:
-        line: 75
-        character: 17
-    severity: ERROR
-    message: Type `::Array[(::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 78
-        character: 14
-      end:
-        line: 78
-        character: 17
-    severity: ERROR
-    message: Type `::Array[(::String | nil)]` does not have method `foo`
-    code: Ruby::NoMethod
+    - range:
+        start:
+          line: 3
+          character: 14
+        end:
+          line: 3
+          character: 17
+      severity: ERROR
+      message: Type `(::String | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 6
+          character: 14
+        end:
+          line: 6
+          character: 17
+      severity: ERROR
+      message: Type `(::String | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 9
+          character: 14
+        end:
+          line: 9
+          character: 17
+      severity: ERROR
+      message: Type `(::String | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 12
+          character: 14
+        end:
+          line: 12
+          character: 17
+      severity: ERROR
+      message: Type `::Array[(::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 15
+          character: 14
+        end:
+          line: 15
+          character: 17
+      severity: ERROR
+      message: Type `::Array[(::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 18
+          character: 10
+        end:
+          line: 18
+          character: 13
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 21
+          character: 10
+        end:
+          line: 21
+          character: 13
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 24
+          character: 10
+        end:
+          line: 24
+          character: 13
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 27
+          character: 13
+        end:
+          line: 27
+          character: 16
+      severity: ERROR
+      message: Type `::Array[(::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 30
+          character: 8
+        end:
+          line: 30
+          character: 11
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 33
+          character: 8
+        end:
+          line: 33
+          character: 11
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 36
+          character: 8
+        end:
+          line: 36
+          character: 11
+      severity: ERROR
+      message: Type `(::Integer | nil)` does not have method `foo`
+      code: Ruby::NoMethodByNil
+    - range:
+        start:
+          line: 39
+          character: 11
+        end:
+          line: 39
+          character: 14
+      severity: ERROR
+      message: Type `::Integer` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 42
+          character: 19
+        end:
+          line: 42
+          character: 22
+      severity: ERROR
+      message: Type `::Hash[::String, (::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 45
+          character: 10
+        end:
+          line: 45
+          character: 13
+      severity: ERROR
+      message: Type `::Array[::String]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 48
+          character: 11
+        end:
+          line: 48
+          character: 14
+      severity: ERROR
+      message: Type `([::Integer, ::Integer] | [nil, nil])` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 51
+          character: 11
+        end:
+          line: 51
+          character: 14
+      severity: ERROR
+      message: Type `([::Integer, ::Integer] | [nil, nil])` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 54
+          character: 11
+        end:
+          line: 54
+          character: 14
+      severity: ERROR
+      message: Type `([::Integer, ::Integer] | [nil, nil])` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 57
+          character: 15
+        end:
+          line: 57
+          character: 18
+      severity: ERROR
+      message: Type `::String` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 60
+          character: 14
+        end:
+          line: 60
+          character: 17
+      severity: ERROR
+      message: Type `::String` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 63
+          character: 11
+        end:
+          line: 63
+          character: 14
+      severity: ERROR
+      message: Type `::Regexp` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 66
+          character: 9
+        end:
+          line: 66
+          character: 12
+      severity: ERROR
+      message: Type `::Integer` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 69
+          character: 11
+        end:
+          line: 69
+          character: 14
+      severity: ERROR
+      message: Type `::String` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 72
+          character: 9
+        end:
+          line: 72
+          character: 12
+      severity: ERROR
+      message: Type `::Array[(::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 75
+          character: 14
+        end:
+          line: 75
+          character: 17
+      severity: ERROR
+      message: Type `::Array[(::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod
+    - range:
+        start:
+          line: 78
+          character: 14
+        end:
+          line: 78
+          character: 17
+      severity: ERROR
+      message: Type `::Array[(::String | nil)]` does not have method `foo`
+      code: Ruby::NoMethod

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -738,7 +738,7 @@ class TypeCheckTest < Minitest::Test
                 character: 21
             severity: ERROR
             message: Type `(::Integer | nil)` does not have method `no_method_in_else`
-            code: Ruby::NoMethod
+            code: Ruby::NoMethodByNil
       YAML
     )
   end
@@ -793,7 +793,7 @@ class TypeCheckTest < Minitest::Test
                 character: 21
             severity: ERROR
             message: Type `(::Integer | nil)` does not have method `no_method_in_else`
-            code: Ruby::NoMethod
+            code: Ruby::NoMethodByNil
       YAML
     )
   end
@@ -859,7 +859,7 @@ class TypeCheckTest < Minitest::Test
                 character: 17
             severity: ERROR
             message: Type `(::String | nil)` does not have method `+`
-            code: Ruby::NoMethod
+            code: Ruby::NoMethodByNil
       YAML
     )
   end
@@ -901,7 +901,7 @@ class TypeCheckTest < Minitest::Test
                 character: 17
             severity: ERROR
             message: Type `(::String | nil)` does not have method `+`
-            code: Ruby::NoMethod
+            code: Ruby::NoMethodByNil
       YAML
     )
   end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -2028,7 +2028,7 @@ end while line = gets
 
         assert_equal 1, typing.errors.size
         typing.errors[0].tap do |error|
-          assert_instance_of Diagnostic::Ruby::NoMethod, error
+          assert_instance_of Diagnostic::Ruby::NoMethodByNil, error
           assert_equal parse_type("::String?"), error.type
           assert_equal :+, error.method
         end
@@ -3882,7 +3882,7 @@ EOF
 
         assert_equal 1, typing.errors.size
         typing.errors[0].yield_self do |error|
-          assert_instance_of Diagnostic::Ruby::NoMethod, error
+          assert_instance_of Diagnostic::Ruby::NoMethodByNil, error
           assert_equal :no_such_method, error.method
         end
       end
@@ -9461,7 +9461,7 @@ RUBY
 
         assert_typing_error(typing, size: 1) do |errors|
           errors[0].tap do |error|
-            assert_instance_of Diagnostic::Ruby::NoMethod, error
+            assert_instance_of Diagnostic::Ruby::NoMethodByNil, error
             assert_equal :+, error.method
           end
         end
@@ -10479,7 +10479,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
         type, _, context = construction.synthesize(source.node)
 
         assert_all!(typing.errors) do |error|
-          assert_operator error, :is_a?, Diagnostic::Ruby::NoMethod
+          assert_operator error, :is_a?, Diagnostic::Ruby::NoMethodByNil
           assert_instance_of Parser::Source::Range, error.location
         end
       end


### PR DESCRIPTION
Add a new diagnostic type; NoMethodByNil, that is emitted to no method calls for the objects having optional types.  It's separated from NoMethod to control the visiblity of these diagnostics individually.

It's useful to find the methods not having appropriate types on checking the Ruby application by filtering NoMethod diagnostics.