### PR TITLE
Fewer `UnresolvedOverloading`

### DIFF
--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -98,19 +98,19 @@ module Steep
       end
 
       class UnresolvedOverloading < Base
-        attr_reader node: untyped
+        attr_reader node (): Parser::AST::Node
 
-        attr_reader receiver_type: untyped
+        attr_reader receiver_type: AST::Types::t
 
-        attr_reader method_name: untyped
+        attr_reader method_name: Symbol
 
-        attr_reader method_types: untyped
+        attr_reader method_types: Array[Interface::MethodType]
 
-        def initialize: (node: untyped, receiver_type: untyped, method_name: untyped, method_types: untyped) -> void
+        def initialize: (node: Parser::AST::Node, receiver_type: AST::Types::t, method_name: Symbol, method_types: Array[Interface::MethodType]) -> void
 
-        def header_line: () -> ::String
+        def header_line: () -> String
 
-        def detail_lines: () -> untyped
+        def detail_lines: () -> String
       end
 
       class ArgumentTypeMismatch < Base

--- a/smoke/block/test_expectations.yml
+++ b/smoke/block/test_expectations.yml
@@ -98,31 +98,27 @@
   - range:
       start:
         line: 10
-        character: 0
+        character: 12
       end:
         line: 10
-        character: 29
+        character: 28
     severity: ERROR
     message: |-
-      Cannot find compatible overloading of method `map` of type `::Array[::Integer]`
-      Method types:
-        def map: [U] () { (::Integer) -> U } -> ::Array[U]
-               | () -> ::Enumerator[::Integer, ::Array[untyped]]
-    code: Ruby::UnresolvedOverloading
+      Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(::Integer) -> U(3)`
+        ::Proc <: ^(::Integer) -> U(3)
+    code: Ruby::BlockTypeMismatch
   - range:
       start:
         line: 11
-        character: 0
+        character: 12
       end:
         line: 11
-        character: 21
+        character: 20
     severity: ERROR
     message: |-
-      Cannot find compatible overloading of method `map` of type `::Array[::Integer]`
-      Method types:
-        def map: [U] () { (::Integer) -> U } -> ::Array[U]
-               | () -> ::Enumerator[::Integer, ::Array[untyped]]
-    code: Ruby::UnresolvedOverloading
+      Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(::Integer) -> U(4)`
+        ::Proc <: ^(::Integer) -> U(4)
+    code: Ruby::BlockTypeMismatch
 - file: e.rb
   diagnostics:
   - range:

--- a/smoke/enumerator/test_expectations.yml
+++ b/smoke/enumerator/test_expectations.yml
@@ -10,11 +10,11 @@
         character: 3
     severity: ERROR
     message: |-
-      Cannot find compatible overloading of method `with_object` of type `::Enumerator[::Integer, ::Array[::Integer]]`
-      Method types:
-        def with_object: [U] (U) { (::Integer, U) -> untyped } -> U
-                       | [U] (U) -> ::Enumerator[[::Integer, U], U]
-    code: Ruby::UnresolvedOverloading
+      Unsatisfiable constraint `::String <: U(1) <: ::Hash[::Symbol, ::String]` is generated through (U(1)) { (::Integer, U(1)) -> untyped } -> U(1)
+        ::String <: ::Hash[::Symbol, ::String]
+          ::Object <: ::Hash[::Symbol, ::String]
+            ::BasicObject <: ::Hash[::Symbol, ::String]
+    code: Ruby::UnsatisfiableConstraint
 - file: b.rb
   diagnostics:
   - range:
@@ -40,8 +40,8 @@
         character: 3
     severity: ERROR
     message: |-
-      Cannot find compatible overloading of method `with_object` of type `::Enumerator[::Integer, ::Array[::Integer]]`
-      Method types:
-        def with_object: [U] (U) { (::Integer, U) -> untyped } -> U
-                       | [U] (U) -> ::Enumerator[[::Integer, U], U]
-    code: Ruby::UnresolvedOverloading
+      Unsatisfiable constraint `::Array[untyped] <: U(3) <: ::String` is generated through (U(3)) { (::Integer, U(3)) -> untyped } -> U(3)
+        ::Array[untyped] <: ::String
+          ::Object <: ::String
+            ::BasicObject <: ::String
+    code: Ruby::UnsatisfiableConstraint

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1317,18 +1317,16 @@ class TypeCheckTest < Minitest::Test
           - range:
               start:
                 line: 4
-                character: 4
+                character: 18
               end:
                 line: 6
                 character: 7
             severity: ERROR
             message: |-
-              Cannot find compatible overloading of method `yield_self` of type `::String`
-              Method types:
-                def yield_self: [X] () { (::String) -> X } -> X
-                              | () -> ::Enumerator[::String, untyped]
-            code: Ruby::UnresolvedOverloading
-      YAML
+              Cannot allow block body have type `::Symbol` because declared as type `T`
+                ::Symbol <: T
+            code: Ruby::BlockBodyTypeMismatch
+        YAML
     )
   end
 


### PR DESCRIPTION
`UnresolvedOverloading` error is not very helpful. The developers should read the error message carefully, and uncover what is causing type errors theirselves.

This PR is to report fewer `UnresolvedOverloading` by filtering arity type errors first.

If a required block is not given, we can guess it's not the intended method type overload. Same for other arguments.

Working for https://github.com/soutaro/steep/pull/937