### PR TITLE
Let label be whole method type in SignatureHelp

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -409,7 +409,7 @@ module Steep
             if (items, index = provider.run(line: job.line, column: job.column))
               signatures = items.map do |item|
                 LSP::Interface::SignatureInformation.new(
-                  label: "(#{item.method_type.type.param_to_s})",
+                  label: item.method_type.to_s,
                   parameters: item.parameters.map { |param| LSP::Interface::ParameterInformation.new(label: param)},
                   active_parameter: item.active_parameter,
                   documentation: item.comment&.yield_self do |comment|


### PR DESCRIPTION
<img width="604" alt="スクリーンショット 2023-10-26 17 19 17" src="https://github.com/soutaro/steep/assets/139089/e6d25d7a-38ba-425b-a1c4-8564b8ab9857">

It was displaying the type of parameters of the method type, but it was confusing, when return types or block types are different.

This PR displays the whole method type in the popup.