### PR TITLE
Let goto definition work from `UnresolvedOverloading` error calls

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3346,12 +3346,14 @@ module Steep
             method_name: method_name,
             method_types: method.method_types
           )
+          decls = method.method_types.each_with_object(Set[]) {|type, decls| decls.merge(type.method_decls) }
           call = TypeInference::MethodCall::Error.new(
             node: node,
             context: context.call_context,
             method_name: method_name,
             receiver_type: receiver_type,
-            errors: errors
+            errors: errors,
+            method_decls: decls
           )
         end
 


### PR DESCRIPTION
This fixes a bug that goto definition from method calls with errors don't work sometimes.

<img width="852" alt="スクリーンショット 2023-10-27 10 10 05" src="https://github.com/soutaro/steep/assets/139089/4e03c92c-0e9a-421b-ac80-50dd1938a684">

This is caused because `MethodCall::Error` instantiation doesn't have `method_decls` if `UnresolvedOverloading` is to be reported.

