### PR TITLE
Change severity of block diagnostics

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -1013,8 +1013,8 @@ module Steep
         @default ||= _ = all_error.merge(
           {
             ArgumentTypeMismatch => :error,
-            BlockBodyTypeMismatch => :hint,
-            BlockTypeMismatch => :hint,
+            BlockBodyTypeMismatch => :warning,
+            BlockTypeMismatch => :warning,
             BreakTypeMismatch => :hint,
             DifferentMethodParameterKind => :hint,
             FallbackAny => :hint,
@@ -1129,8 +1129,8 @@ module Steep
         @lenient ||= _ = all_error.merge(
           {
             ArgumentTypeMismatch => :information,
-            BlockBodyTypeMismatch => :hint,
-            BlockTypeMismatch => :hint,
+            BlockBodyTypeMismatch => :information,
+            BlockTypeMismatch => :information,
             BreakTypeMismatch => :hint,
             DifferentMethodParameterKind => nil,
             FallbackAny => nil,


### PR DESCRIPTION
Because of #941, new `BlockBodyTypeMismatch` may be reported. Having lower severity than `UnresolveOverloading` make the users feel the diagnostics are disappeared.

This is not what we want, and gibing higher severity will preserve the type errors.