### PR TITLE
Assign types on method calls in mlhs node

### DIFF
--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -663,7 +663,7 @@ module Steep
         if parent
           case parent.type
           when :const
-            const_name = typing.source_index.reference(constant_node: parent)
+            const_name = typing.source_index.reference(constant_node: parent) or raise "Unknown node in source_index: #{parent}"
             consts = context.type_env.constant_env.children(const_name)
           end
         else

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2908,6 +2908,8 @@ module Steep
             _, constr = constr.gvasgn(asgn_node, type)
           when :mlhs
             constr = (constr.type_masgn_type(asgn_node, type, masgn: masgn, optional: optional) or return)
+          else
+            _, constr = constr.synthesize_children(asgn_node).add_typing(asgn_node, type: AST::Builtin.any_type)
           end
 
           if node.type == :splat

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -412,6 +412,27 @@ bar()
     end
   end
 
+  def test_on_colon2_call_masgn
+    with_checker <<EOF do
+class Hello
+  class World
+  end
+end
+EOF
+      CompletionProvider.new(source_text: <<-EOR, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+Hello::
+a, b = []
+      EOR
+
+        provider.run(line: 1, column: 7).tap do |items|
+          items.grep(CompletionProvider::ConstantItem).tap do |items|
+            assert_equal [:World], items.map(&:identifier).sort
+          end
+        end
+      end
+    end
+  end
+
   def test_simple_method_name_item_two_defs
     with_checker <<~RBS do
         class TestClass


### PR DESCRIPTION
It caused an error during completion:

```
[Steep 1.6.0.pre.1] [interaction:interaction] [background] Unexpected error: #<NoMethodError: undefined method `class?' for nil:NilClass>
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/rbs-3.2.2/lib/rbs/environment.rb:337:in `normalize_module_name?'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/rbs-3.2.2/lib/rbs/environment.rb:333:in `normalize_module_name'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/rbs-3.2.2/lib/rbs/resolver/constant_resolver.rb:113:in `children'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/type_inference/constant_env.rb:38:in `children'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/services/completion_provider.rb:667:in `constant_items_for_context'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/services/completion_provider.rb:502:in `items_for_colon2'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/services/completion_provider.rb:403:in `items_for_trigger'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/services/completion_provider.rb:242:in `block in run'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep.rb:178:in `measure'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/services/completion_provider.rb:241:in `run'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/interaction_worker.rb:123:in `block (2 levels) in process_completion'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep.rb:178:in `measure'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/interaction_worker.rb:113:in `block in process_completion'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:135:in `block in tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:39:in `tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:135:in `tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/interaction_worker.rb:112:in `process_completion'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/interaction_worker.rb:38:in `block in handle_job'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:135:in `block in tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:39:in `tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:135:in `tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/interaction_worker.rb:24:in `handle_job'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/base_worker.rb:56:in `block (2 levels) in run'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:135:in `block in tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:39:in `tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/tagged_logging.rb:135:in `tagged'
[Steep 1.6.0.pre.1] [interaction:interaction] [background]   .../ruby/gems/3.2.0/gems/steep-1.6.0.pre.1/lib/steep/server/base_worker.rb:46:in `block in run'
```