### PR TITLE
Fix LSP text synchronization problems

### DIFF
--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -645,20 +645,22 @@ module Steep
 
             path = PathHelper.to_pathname(uri) or next
 
-            controller.push_changes(path)
+            unless controller.priority_paths.include?(path)
+              controller.push_changes(path)
 
-            case type
-            when 1, 2
-              content = path.read
-            when 4
-              # Deleted
-              content = ""
+              case type
+              when 1, 2
+                content = path.read
+              when 4
+                # Deleted
+                content = ""
+              end
+
+              broadcast_notification({
+                method: "$/file/reset",
+                params: { uri: uri, content: content }
+              })
             end
-
-            broadcast_notification({
-              method: "$/file/reset",
-              params: { uri: uri, content: content }
-            })
           end
 
           if typecheck_automatically

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -61,15 +61,29 @@ module Steep
 
         attr_reader target_paths: Array[TargetPaths]
 
+        # TargetPaths object keeps track of the expanded absolute paths of each target
+        #
+        # 1. *Library path* is a RBS file that is loaded as a part of a library
+        # 2. *Signature path* is a RBS file that is loaded as a part of the application library
+        # 3. *Code path* is a Ruby file that is being type checked
+        #
         class TargetPaths
           attr_reader project: Project
 
           attr_reader target: Project::Target
 
+          # Set of absolute paths of Ruby code
+          #
           attr_reader code_paths: Set[Pathname]
 
+          # Set of absolute paths of app signatures
+          #
           attr_reader signature_paths: Set[Pathname]
 
+          # Set of absolute paths of library signatures
+          #
+          # Unlike `code_paths` and `signature_paths`, the `library_paths` must be added explicitly not by `#add` method.
+          #
           attr_reader library_paths: Set[Pathname]
 
           def initialize: (project: Project, target: Project::Target) -> void
@@ -82,7 +96,14 @@ module Steep
 
           def code_path?: (Pathname path) -> bool
 
-          def add: (Pathname path) -> void
+          # Adds `path` to the object
+          #
+          # Returns `false` if the path is not a part of the project.
+          #
+          # Whether `path` is a code path or signature path is automatically detected.
+          # `library: true` is required to add the path to library path.
+          #
+          def add: (Pathname path, ?library: bool) -> bool
 
           alias << add
         end

--- a/test/master_type_check_controller_test.rb
+++ b/test/master_type_check_controller_test.rb
@@ -42,7 +42,7 @@ end
       end
 
       (RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs").tap do |path|
-        paths << path
+        paths.add(path, library: true)
 
         assert_equal Set[path], paths.library_paths
         assert_operator paths, :library_path?, path


### PR DESCRIPTION
`workspace/didChangeWatchedFiles` for opened files must be ignored because `textDocument/didChange` notification is also sent.

`TargetPaths` implementation had a bug that caused an issue that only the first target triggers type checking after edits.