### PR TITLE
Ignore smoke tests when packaging gem

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/soutaro/steep/blob/master/CHANGELOG.md"
 
   spec.files         = `git ls-files -z`.split("\x0").reject {|f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features|smoke)/})
   }
 
   spec.bindir        = "exe"


### PR DESCRIPTION
It is not necessary for runtime and makes it impossible to use the gem in symlink environments because of a space in "hello world.rb"