### PR TITLE
LSP supports textDocument/documentSymbol

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -109,6 +109,7 @@ require "steep/services/signature_help_provider"
 require "steep/services/stats_calculator"
 require "steep/services/file_loader"
 require "steep/services/goto_service"
+require "steep/services/document_symbol_provider"
 
 require "steep/server/delay_queue"
 require "steep/server/lsp_formatter"

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -573,6 +573,7 @@ module Steep
                         partialResults: true,
                         partialResult: true
                       },
+                      document_symbol_provider: true,
                       completion_provider: LSP::Interface::CompletionOptions.new(
                         trigger_characters: [".", "@", ":"],
                         work_done_progress: true
@@ -721,7 +722,7 @@ module Steep
             controller.update_priority(close: path)
           end
 
-        when "textDocument/hover", "textDocument/completion", "textDocument/signatureHelp"
+        when "textDocument/hover", "textDocument/completion", "textDocument/signatureHelp", "textDocument/documentSymbol"
           if interaction_worker
             if path = pathname(message[:params][:textDocument][:uri])
               result_controller << send_request(method: message[:method], params: message[:params], worker: interaction_worker) do |handler|

--- a/lib/steep/services/document_symbol_provider.rb
+++ b/lib/steep/services/document_symbol_provider.rb
@@ -1,0 +1,133 @@
+module Steep
+  module Services
+    class DocumentSymbolProvider
+
+      LSP = LanguageServer::Protocol
+
+      attr_reader :service
+
+      def initialize(service:)
+        @service = service
+      end
+
+      def content_for(path:)
+        project = service.project
+
+        target = project.targets_for_path(path)
+        case target
+        when Project::Target
+          nil
+        when Array
+          signature_service = service.signature_services[target[0].name]
+          env = signature_service.latest_env
+          buffer = env.buffers.find {|buf| buf.name.to_s == path.to_s } or return
+          (_dirs, decls = env.signatures[buffer]) or raise
+
+          # @type var document_symbols: Array[LSP::Interface::DocumentSymbol]
+          document_symbols = []
+          decls.each_with_object(document_symbols) do |decl, buffer|
+            build_document_symbols(decl, buffer)
+          end
+        end
+      end
+
+      def build_document_symbols(node, buffer, top_level: true)
+        case node
+        when ::RBS::AST::Declarations::Class, ::RBS::AST::Declarations::Module, ::RBS::AST::Declarations::Interface
+          range = build_range(node.location)
+          name = symbol_name_with_type_params(node, top_level: top_level)
+          kind = kind_from_ast_node(node)
+          children = node.members.each_with_object([]) do |member, children_buffer|
+            build_document_symbols(member, children_buffer, top_level: false)
+          end
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range, children: children)
+          buffer << document_symbol
+        when ::RBS::AST::Declarations::TypeAlias
+          range = build_range(node.location)
+          name = symbol_name_with_type_params(node, top_level: top_level)
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        when ::RBS::AST::Declarations::Constant
+          range = build_range(node.location)
+          name = trim_namespace_scope(node.name.to_s, top_level: top_level)
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        when ::RBS::AST::Declarations::ClassAlias, ::RBS::AST::Declarations::ModuleAlias
+          range = build_range(node.location)
+          name = trim_namespace_scope(node.new_name.to_s, top_level: false) + " = " + node.old_name.to_s
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        when ::RBS::AST::Members::MethodDefinition, ::RBS::AST::Members::AttrReader, ::RBS::AST::Members::AttrWriter, ::RBS::AST::Members::AttrAccessor
+          range = build_range(node.location)
+          name = node.name.to_s
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        when ::RBS::AST::Declarations::Global, ::RBS::AST::Members::InstanceVariable, ::RBS::AST::Members::ClassVariable, ::RBS::AST::Members::ClassInstanceVariable
+          range = build_range(node.location)
+          name = node.name.to_s
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        when ::RBS::AST::Members::Alias
+          range = build_range(node.location)
+          name = "alias(#{node.new_name.to_s}, #{node.old_name.to_s})"
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        when ::RBS::AST::Members::Include, ::RBS::AST::Members::Extend, ::RBS::AST::Members::Prepend
+          range = build_range(node.location)
+          name = "#{node.class.name.split("::").last.downcase}(#{node.name.to_s})"
+          kind = kind_from_ast_node(node)
+          document_symbol = LSP::Interface::DocumentSymbol.new(name: name, kind: kind, range: range, selection_range: range)
+          buffer << document_symbol
+        end
+      end
+
+      def build_range(location)
+        raise "location is nil" unless location
+        start_position = LSP::Interface::Position.new(line: location.start_line - 1, character: location.start_column)
+        end_position = LSP::Interface::Position.new(line: location.end_line - 1, character: location.end_column)
+        LSP::Interface::Range.new(start: start_position, end: end_position)
+      end
+
+      def kind_from_ast_node(node)
+        case node
+        when ::RBS::AST::Declarations::Class, ::RBS::AST::Declarations::ClassAlias, ::RBS::AST::Declarations::TypeAlias
+          LSP::Constant::SymbolKind::CLASS
+        when ::RBS::AST::Declarations::Module, ::RBS::AST::Declarations::ModuleAlias, ::RBS::AST::Members::Include, ::RBS::AST::Members::Extend, ::RBS::AST::Members::Prepend
+          LSP::Constant::SymbolKind::MODULE
+        when ::RBS::AST::Declarations::Interface
+          LSP::Constant::SymbolKind::INTERFACE
+        when ::RBS::AST::Members::MethodDefinition, ::RBS::AST::Members::AttrReader, ::RBS::AST::Members::AttrWriter, ::RBS::AST::Members::AttrAccessor, ::RBS::AST::Members::Alias
+          LSP::Constant::SymbolKind::METHOD
+        when ::RBS::AST::Declarations::Constant
+          LSP::Constant::SymbolKind::CONSTANT
+        when ::RBS::AST::Declarations::Global
+          LSP::Constant::SymbolKind::VARIABLE
+        when ::RBS::AST::Members::InstanceVariable, ::RBS::AST::Members::ClassVariable, ::RBS::AST::Members::ClassInstanceVariable
+          LSP::Constant::SymbolKind::PROPERTY
+        else
+          raise "Unexpected node: #{node}"
+        end
+      end
+
+      def trim_namespace_scope(name, top_level: true)
+        if top_level
+          name.start_with?("::") ? name.sub("::", "") : name
+        else
+          name.split("::")[-1]
+        end
+      end
+
+      def symbol_name_with_type_params(decl, top_level: true)
+        name = trim_namespace_scope(decl.name.to_s, top_level: top_level)
+        name += "[#{decl.type_params.map(&:to_s).join(", ")}]" if decl.type_params.size > 0
+        name
+      end
+    end
+  end
+end

--- a/sig/shims/language-server_protocol.rbs
+++ b/sig/shims/language-server_protocol.rbs
@@ -248,6 +248,14 @@ module LanguageServer
         def initialize: (contents: MarkupContent, range: Range) -> void
       end
 
+      class DocumentSymbol
+        include _Base
+
+        attr_reader range: Range
+
+        def initialize: (name: String, kind: Constant::SymbolKind::t, range: Range, selection_range: Range, ?children: Array[DocumentSymbol]?) -> void
+      end
+
       class CompletionList
         include _Base
 

--- a/sig/steep/services/document_symbol_provider.rbs
+++ b/sig/steep/services/document_symbol_provider.rbs
@@ -1,0 +1,32 @@
+use RBS::AST::Declarations
+
+module Steep
+  module Services
+    class DocumentSymbolProvider
+      module LSP = LanguageServer::Protocol
+
+      interface _Loc
+        def start_line: () -> Integer
+        def start_column: () -> Integer
+        def end_line: () -> Integer
+        def end_column: () -> Integer
+      end
+
+      attr_reader service: TypeCheckService
+
+      def initialize: (service: TypeCheckService) -> void
+
+      def content_for: (path: Pathname) -> Array[LanguageServer::Protocol::Interface::DocumentSymbol]?
+
+      def build_document_symbols: (Declarations::Base | RBS::AST::Members::Base, Array[LanguageServer::Protocol::Interface::DocumentSymbol], ?top_level: bool) -> void
+
+      def build_range: (_Loc?) -> LanguageServer::Protocol::Interface::Range
+
+      def trim_namespace_scope: (String, ?top_level: bool) -> String
+
+      def symbol_name_with_type_params: (Declarations::Class | Declarations::Module | Declarations::Interface | Declarations::TypeAlias, ?top_level: bool) -> String
+
+      def kind_from_ast_node: (Declarations::Base | RBS::AST::Members::Base) -> LanguageServer::Protocol::Constant::SymbolKind::t
+    end
+  end
+end

--- a/test/document_symbol_provider_test.rb
+++ b/test/document_symbol_provider_test.rb
@@ -1,0 +1,190 @@
+require_relative "test_helper"
+
+class DocumentSymbolProviderTest < Minitest::Test
+  include TestHelper
+  include ShellHelper
+
+  include Steep
+  DocumentSymbolProvider = Services::DocumentSymbolProvider
+  ContentChange = Services::ContentChange
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def typecheck_service(steepfile: <<RUBY)
+target :lib do
+  check "hello.rb"
+  signature "hello.rbs"
+end
+RUBY
+    project = Project.new(steepfile_path: current_dir + "Steepfile")
+    Project::DSL.parse(project, steepfile)
+
+    Services::TypeCheckService.new(project: project)
+  end
+
+  def test_class_declaration
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+class FooBar
+  @a: Integer
+  @@a: Integer
+  def f: (foo) -> void
+  attr_reader a: Integer
+end
+RBS
+        }
+      ) {}
+
+      target = service.project.targets.find {|target| target.name == :lib }
+      provider = DocumentSymbolProvider.new(service: service)
+
+      provider.content_for(path: Pathname("hello.rbs")).tap do |content|
+        assert_instance_of Array, content
+        assert_equal 1, content.size
+        assert_instance_of LanguageServer::Protocol::Interface::DocumentSymbol, content[0]
+        assert_equal "FooBar", content[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::CLASS, content[0].kind
+        assert_equal 4, content[0].children.size
+        assert_equal "@a", content[0].children[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::PROPERTY, content[0].children[0].kind
+        assert_equal "@@a", content[0].children[1].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::PROPERTY, content[0].children[1].kind
+        assert_equal "f", content[0].children[2].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::METHOD, content[0].children[2].kind
+        assert_equal "a", content[0].children[3].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::METHOD, content[0].children[3].kind
+      end
+    end
+  end
+
+  def test_module_declaration
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+module FooBar
+  A: Integer
+  type foo = Integer | String
+  alias new_id id
+end
+RBS
+        }
+      ) {}
+
+      target = service.project.targets.find {|target| target.name == :lib }
+      provider = DocumentSymbolProvider.new(service: service)
+
+      provider.content_for(path: Pathname("hello.rbs")).tap do |content|
+        assert_instance_of Array, content
+        assert_equal 1, content.size
+        assert_instance_of LanguageServer::Protocol::Interface::DocumentSymbol, content[0]
+        assert_equal "FooBar", content[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::MODULE, content[0].kind
+        assert_equal 3, content[0].children.size
+        assert_equal "A", content[0].children[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::CONSTANT, content[0].children[0].kind
+        assert_equal "foo", content[0].children[1].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::CLASS, content[0].children[1].kind
+        assert_equal "alias(new_id, id)", content[0].children[2].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::METHOD, content[0].children[2].kind
+      end
+    end
+  end
+
+  def test_interface_declaration
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+interface _FooBar
+  def f: (foo) -> void
+end
+RBS
+        }
+      ) {}
+
+      target = service.project.targets.find {|target| target.name == :lib }
+      provider = DocumentSymbolProvider.new(service: service)
+
+      provider.content_for(path: Pathname("hello.rbs")).tap do |content|
+        assert_instance_of Array, content
+        assert_equal 1, content.size
+        assert_instance_of LanguageServer::Protocol::Interface::DocumentSymbol, content[0]
+        assert_equal "_FooBar", content[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::INTERFACE, content[0].kind
+        assert_equal 1, content[0].children.size
+        assert_equal "f", content[0].children[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::METHOD, content[0].children[0].kind
+      end
+    end
+  end
+
+  def test_global_variable_declaration
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+$global: Integer
+RBS
+        }
+      ) {}
+
+      target = service.project.targets.find {|target| target.name == :lib }
+      provider = DocumentSymbolProvider.new(service: service)
+
+      provider.content_for(path: Pathname("hello.rbs")).tap do |content|
+        assert_instance_of Array, content
+        assert_equal 1, content.size
+        assert_instance_of LanguageServer::Protocol::Interface::DocumentSymbol, content[0]
+        assert_equal "$global", content[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::VARIABLE, content[0].kind
+      end
+    end
+  end
+
+  def test_module_include_extend_prepend
+    in_tmpdir do
+      service = typecheck_service
+
+      service.update(
+        changes: {
+          Pathname("hello.rbs") => [ContentChange.string(<<RBS)]
+class FooBar
+  include Comparable
+  extend Comparable
+  prepend Comparable
+end
+RBS
+        }
+      ) {}
+
+      target = service.project.targets.find {|target| target.name == :lib }
+      provider = DocumentSymbolProvider.new(service: service)
+
+      provider.content_for(path: Pathname("hello.rbs")).tap do |content|
+        assert_instance_of Array, content
+        assert_equal 1, content.size
+        assert_instance_of LanguageServer::Protocol::Interface::DocumentSymbol, content[0]
+        assert_equal 3, content[0].children.size
+        assert_equal "include(::Comparable)", content[0].children[0].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::MODULE, content[0].children[0].kind
+        assert_equal "extend(::Comparable)", content[0].children[1].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::MODULE, content[0].children[1].kind
+        assert_equal "prepend(::Comparable)", content[0].children[2].name
+        assert_equal LanguageServer::Protocol::Constant::SymbolKind::MODULE, content[0].children[2].kind
+      end
+    end
+  end
+end


### PR DESCRIPTION
LSP supports textDocument/documentSymbol request.

That is a useful feature for editor's outline plugins.

For example the following.

![swappy-20231124-062719](https://github.com/soutaro/steep/assets/116996/49e1c105-a8f3-4d06-80a0-0cfacd871d23)
