### PR TITLE
Default to check the entire current directory when there is no `Steepfile`

### DIFF
--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -12,7 +12,7 @@ module Steep
             end
           else
             if warnings # Silence warnings in children worker processes
-              warn "Cannot find a configuration at #{path}: `steep init` to scaffold. Using current directory..."
+              Steep.logger.error "Cannot find a configuration at #{path}: `steep init` to scaffold. Using current directory..."
             end
             Project.new(steepfile_path: nil, base_dir: Pathname.pwd).tap do |project|
               Project::DSL.new(project: project).target :'.' do

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -21,7 +21,7 @@ module Steep
 
       def run()
         Steep.logger.tagged("#{worker_type}:#{worker_name}") do
-          project = load_config()
+          project = load_config(warnings: false) # Main process has already emitted any warnings
 
           reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdin)
           writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdout)

--- a/lib/steep/project.rb
+++ b/lib/steep/project.rb
@@ -15,7 +15,7 @@ module Steep
         raise ArgumentError, "Project#initialize(base_dir:): neither base_dir nor steepfile_path given"
       end
 
-      unless steepfile_path&.absolute?
+      if steepfile_path and !steepfile_path.absolute?
         raise ArgumentError, "Project#initialize(steepfile_path:): steepfile_path should be absolute path"
       end
     end

--- a/lib/steep/project.rb
+++ b/lib/steep/project.rb
@@ -2,18 +2,22 @@ module Steep
   class Project
     attr_reader :targets
     attr_reader :steepfile_path
+    attr_reader :base_dir
 
-    def initialize(steepfile_path:)
+    def initialize(steepfile_path:, base_dir: nil)
       @targets = []
       @steepfile_path = steepfile_path
+      @base_dir = if base_dir
+        base_dir
+      elsif steepfile_path
+        steepfile_path.parent
+      else
+        raise ArgumentError, "Project#initialize(base_dir:): neither base_dir nor steepfile_path given"
+      end
 
       unless steepfile_path&.absolute?
-        raise "Project#initialize(steepfile_path:): steepfile_path should be absolute path"
+        raise ArgumentError, "Project#initialize(steepfile_path:): steepfile_path should be absolute path"
       end
-    end
-
-    def base_dir
-      steepfile_path.parent
     end
 
     def relative_path(path)

--- a/lib/steep/project.rb
+++ b/lib/steep/project.rb
@@ -7,7 +7,7 @@ module Steep
       @targets = []
       @steepfile_path = steepfile_path
 
-      unless steepfile_path.absolute?
+      unless steepfile_path&.absolute?
         raise "Project#initialize(steepfile_path:): steepfile_path should be absolute path"
       end
     end

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -92,7 +92,8 @@ module Steep
       end
 
       def self.spawn_worker(type, name:, steepfile:, steep_command:, index:, delay_shutdown:, patterns:)
-        args = ["--name=#{name}", "--steepfile=#{steepfile}"]
+        args = ["--name=#{name}"]
+        args << "--steepfile=#{steepfile}" if steepfile
         args << (%w(debug info warn error fatal unknown)[Steep.logger.level].yield_self {|log_level| "--log-level=#{log_level}" })
 
         if Steep.log_output.is_a?(String)

--- a/sig/steep/drivers/utils/driver_helper.rbs
+++ b/sig/steep/drivers/utils/driver_helper.rbs
@@ -6,7 +6,7 @@ module Steep
       module DriverHelper
         attr_accessor steepfile: Pathname?
 
-        def load_config: (?path: Pathname) -> Project
+        def load_config: (?path: Pathname, ?warnings: boolish) -> Project
 
         def request_id: () -> String
 

--- a/sig/steep/project.rbs
+++ b/sig/steep/project.rbs
@@ -2,9 +2,9 @@ module Steep
   class Project
     attr_reader targets: Array[Target]
 
-    attr_reader steepfile_path: Pathname
+    attr_reader steepfile_path: Pathname?
 
-    def initialize: (steepfile_path: Pathname) -> void
+    def initialize: (steepfile_path: Pathname?) -> void
 
     def base_dir: () -> Pathname
 

--- a/sig/steep/project.rbs
+++ b/sig/steep/project.rbs
@@ -4,9 +4,9 @@ module Steep
 
     attr_reader steepfile_path: Pathname?
 
-    def initialize: (steepfile_path: Pathname?) -> void
+    attr_reader base_dir: Pathname
 
-    def base_dir: () -> Pathname
+    def initialize: (steepfile_path: Pathname?, ?base_dir: Pathname?) -> void
 
     def relative_path: (Pathname path) -> Pathname
 

--- a/sig/steep/server/worker_process.rbs
+++ b/sig/steep/server/worker_process.rbs
@@ -49,7 +49,7 @@ module Steep
       def self.start_worker: (
         worker_type `type`,
         name: String,
-        steepfile: Pathname,
+        steepfile: Pathname?,
         steep_command: String?,
         ?patterns: Array[String],
         ?delay_shutdown: bool,
@@ -59,7 +59,7 @@ module Steep
       def self.fork_worker: (
         worker_type `type`,
         name: String,
-        steepfile: Pathname,
+        steepfile: Pathname?,
         patterns: Array[String],
         delay_shutdown: bool,
         index: [Integer, Integer]?
@@ -68,7 +68,7 @@ module Steep
       def self.spawn_worker: (
         worker_type `type`,
         name: String,
-        steepfile: Pathname,
+        steepfile: Pathname?,
         steep_command: ::String,
         patterns: Array[String],
         delay_shutdown: bool,
@@ -76,7 +76,7 @@ module Steep
       ) -> WorkerProcess
 
       def self.start_typecheck_workers: (
-        steepfile: Pathname,
+        steepfile: Pathname?,
         args: Array[String],
         steep_command: ::String?,
         ?count: Integer,

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -312,6 +312,21 @@ end
     end
   end
 
+  def test_check_no_steepfile
+    in_tmpdir do
+      (current_dir + "foo.rb").write(<<~EOF)
+        1 + 2
+      EOF
+
+      stdout, stderr, status = sh3(*steep, 'check')
+
+      assert_predicate status, :success?, stdout
+      assert_match /current directory/, stderr
+      assert_match /steep init/, stderr
+      assert_match /No type error detected\./, stdout
+    end
+  end
+
   def test_annotations
     in_tmpdir do
       (current_dir + "foo.rb").write(<<-RUBY)


### PR DESCRIPTION
This allows Steep to work out-of-the-box with no further setup required.
Though of course users are encouraged to set up their `Steepfile` according to their project structure.

May relate to https://github.com/soutaro/steep-vscode/pull/227#issuecomment-1630886992

#### Tests
* [x] Integration Test: no idea where to put it <.<
  * [x] DriverHelper: no unit test
  * [x] Project: empty unit test
  * [x] WorkerProcess: no unit test

### Q: Why current directory (rather than `lib` + `sig`)?
This matches the minimum (i.e., least set up) project structure of dumping everything in the project root.

## Recommended follow-up

* Utilize `nil`able `Steepfile` path in tests instead of leaving the `Steepfile` non-existent.