### PR TITLE
Ignore the `rbs_collection.lock.yaml` file if it’s missing or has syntax error

### DIFF
--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -4,12 +4,12 @@ module Steep
       module DriverHelper
         attr_accessor :steepfile
 
-        def load_config(path: steepfile || Pathname("Steepfile"))
+        def load_config(path: steepfile || Pathname("Steepfile"), warnings: false)
           raise "Cannot find a configuration at #{path}: `steep init` to scaffold" unless path.file?
 
           steep_file_path = path.absolute? ? path : Pathname.pwd + path
           Project.new(steepfile_path: steep_file_path).tap do |project|
-            Project::DSL.parse(project, path.read, filename: path.to_s)
+            Project::DSL.parse(project, path.read, filename: path.to_s, warnings: warnings)
           end
         end
 

--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -10,16 +10,6 @@ module Steep
           steep_file_path = path.absolute? ? path : Pathname.pwd + path
           Project.new(steepfile_path: steep_file_path).tap do |project|
             Project::DSL.parse(project, path.read, filename: path.to_s)
-
-            project.targets.each do |target|
-              if collection_lock = target.options.collection_lock
-                begin
-                  collection_lock.check_rbs_availability!
-                rescue RBS::Collection::Config::CollectionNotAvailable
-                  raise "Run `rbs collection install` to install type definitions"
-                end
-              end
-            end
           end
         end
 

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -21,7 +21,7 @@ module Steep
 
       def run()
         Steep.logger.tagged("#{worker_type}:#{worker_name}") do
-          project = load_config()
+          project = load_config(warnings: false) # Main process has already emitted any warnings
 
           reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdin)
           writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdout)

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -177,17 +177,18 @@ module Steep
         @@templates
       end
 
-      def initialize(project:)
+      def initialize(project:, warnings: true)
         @project = project
+        @warnings = warnings
       end
 
       def self.register_template(name, target)
         templates[name] = target
       end
 
-      def self.parse(project, code, filename: "Steepfile")
+      def self.parse(project, code, filename: "Steepfile", warnings: true)
         Steep.logger.tagged filename do
-          self.new(project: project).instance_eval(code, filename)
+          self.new(project: project, warnings: warnings).instance_eval(code, filename)
         end
       end
 
@@ -216,9 +217,9 @@ module Steep
               .from_lockfile(lockfile_path: lockfile_path, data: content)
               .tap(&:check_rbs_availability!)
           rescue RBS::Collection::Config::CollectionNotAvailable
-            warn "Run `rbs collection install` to install type definitions"
+            warn "Run `rbs collection install` to install type definitions" if @warnings
           rescue YAML::SyntaxError
-            warn "Syntax error in `#{lockfile_path}`"
+            warn "Syntax error in `#{lockfile_path}`" if @warnings
           end
         end
 

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -217,9 +217,11 @@ module Steep
               .from_lockfile(lockfile_path: lockfile_path, data: content)
               .tap(&:check_rbs_availability!)
           rescue RBS::Collection::Config::CollectionNotAvailable
-            warn "Run `rbs collection install` to install type definitions" if @warnings
+            Steep.logger.error "Run `rbs collection install` to install type definitions" if @warnings
+            nil
           rescue YAML::SyntaxError
-            warn "Syntax error in `#{lockfile_path}`" if @warnings
+            Steep.logger.error "Syntax error in `#{lockfile_path}`" if @warnings
+            nil
           end
         end
 

--- a/sig/steep/drivers/utils/driver_helper.rbs
+++ b/sig/steep/drivers/utils/driver_helper.rbs
@@ -6,7 +6,7 @@ module Steep
       module DriverHelper
         attr_accessor steepfile: Pathname?
 
-        def load_config: (?path: Pathname) -> Project
+        def load_config: (?path: Pathname, ?warnings: boolish) -> Project
 
         def request_id: () -> String
 

--- a/sig/steep/project/dsl.rbs
+++ b/sig/steep/project/dsl.rbs
@@ -26,6 +26,8 @@ module Steep
 
         attr_reader collection_config_path: Pathname?
 
+        @warnings: boolish
+
         NONE: untyped
 
         def project!: () -> Project
@@ -92,11 +94,11 @@ module Steep
 
       def self.templates: () -> Hash[Symbol, TargetDSL]
 
-      def initialize: (project: Project) -> void
+      def initialize: (project: Project, ?warnings: boolish) -> void
 
       def self.register_template: (Symbol name, TargetDSL target) -> void
 
-      def self.parse: (Project project, String code, ?filename: String) -> void
+      def self.parse: (Project project, String code, ?filename: String, ?warnings: boolish) -> void
 
       def target: (Symbol name, ?template: Symbol?) ?{ (TargetDSL) [self: TargetDSL] -> void } -> void
     end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -188,14 +188,20 @@ EOF
       current_dir.join('rbs_collection.yaml').write('')
       project = Project.new(steepfile_path: current_dir + "Steepfile")
 
-      assert_output nil, /rbs collection/ do
-        Project::DSL.parse(project, <<~EOF)
+      begin
+        Steep.log_output = StringIO.new
+
+        Project::DSL.parse(project, <<~RUBY)
           target :app do
           end
-        EOF
-      end
+        RUBY
 
-      assert_nil project.targets[0].options.collection_lock
+        assert_match /rbs collection/, Steep.log_output.string
+        #TODO: Test `error` severity
+        assert_nil project.targets[0].options.collection_lock
+      ensure
+        Steep.log_output = STDERR
+      end
     end
   end
 
@@ -204,15 +210,21 @@ EOF
       current_dir.join('rbs_collection.yaml').write('')
       current_dir.join('rbs_collection.lock.yaml').write(']')
       project = Project.new(steepfile_path: current_dir + "Steepfile")
-
-      assert_output nil, /syntax/i do
-        Project::DSL.parse(project, <<~EOF)
+      
+      begin
+        Steep.log_output = StringIO.new
+        
+        Project::DSL.parse(project, <<~RUBY)
           target :app do
           end
-        EOF
-      end
+        RUBY
 
-      assert_nil project.targets[0].options.collection_lock
+        assert_match /[Ss]yntax/, Steep.log_output.string
+        #TODO: Test `error` severity
+        assert_nil project.targets[0].options.collection_lock
+      ensure
+        Steep.log_output = STDERR
+      end
     end
   end
 

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -183,6 +183,39 @@ EOF
     end
   end
 
+  def test_collection_missing
+    in_tmpdir do
+      current_dir.join('rbs_collection.yaml').write('')
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      assert_output nil, /rbs collection/ do
+        Project::DSL.parse(project, <<~EOF)
+          target :app do
+          end
+        EOF
+      end
+
+      assert_nil project.targets[0].options.collection_lock
+    end
+  end
+
+  def test_collection_bad
+    in_tmpdir do
+      current_dir.join('rbs_collection.yaml').write('')
+      current_dir.join('rbs_collection.lock.yaml').write(']')
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      assert_output nil, /syntax/i do
+        Project::DSL.parse(project, <<~EOF)
+          target :app do
+          end
+        EOF
+      end
+
+      assert_nil project.targets[0].options.collection_lock
+    end
+  end
+
   def test_disable_collection
     in_tmpdir do
       current_dir.join('rbs_collection.yaml').write('')


### PR DESCRIPTION
By warning the problem instead of raising exceptions, it allows Steep to not crash (read: fail safe), especially when as a passive LSP.

The check on the RBS Collection configs lockfile (default: `./rbs_collection.lock.yaml`) is now per-target in the DSL rather than batch-processed after loading it.
The DSL actually loads the YAML before the batch can verify it. If the `rbs_collection.yaml` file exists but not the lockfile, this can crash in `Errno::ENOENT: No such file or directory @ rb_sysopen - path/to/rbs_collection.lock.yaml` before the batch can provide an informative error message.

#### Tests
* [x] Integration Test: in `steepfile_test.rb`
  * [x] DSL: functionality tested via Integration; `warnings` kwarg not tested
  * [x] DriverHelper: empty unit test