### PR TITLE
Handle absolute path

### DIFF
--- a/lib/steep/services/file_loader.rb
+++ b/lib/steep/services/file_loader.rb
@@ -15,8 +15,9 @@ module Steep
             absolute_path = base_dir + path
 
             if absolute_path.file?
-              if pattern =~ path
-                yield absolute_path.relative_path_from(base_dir)
+              relative_path = absolute_path.relative_path_from(base_dir)
+              if pattern =~ relative_path
+                yield relative_path
               end
             else
               files = if absolute_path.directory?

--- a/test/file_loader_test.rb
+++ b/test/file_loader_test.rb
@@ -27,6 +27,8 @@ class FileLoaderTest < Minitest::Test
 
       assert_equal [Pathname("lib/foo.rb"), Pathname("test/foo_test.rb")], loader.each_path_in_patterns(pat).to_a
       assert_equal [Pathname("lib/foo.rb")], loader.each_path_in_patterns(pat, ["lib"]).to_a
+      assert_equal [Pathname("lib/foo.rb")], loader.each_path_in_patterns(pat, ["lib/foo.rb"]).to_a
+      assert_equal [Pathname("lib/foo.rb")], loader.each_path_in_patterns(pat, [(current_dir + "lib/foo.rb".to_s)]).to_a
       assert_empty loader.each_path_in_patterns(pat, ["lib/parser.y"]).to_a
       assert_empty loader.each_path_in_patterns(pat, ["Rakefile"]).to_a
     end


### PR DESCRIPTION
During development of [this](https://github.com/dense-analysis/ale/pull/4671) I found out that this would work:

```
# Steepfile in /some/project/path
bundle exec steep check lib/foobar.rb
```

but this would fail:

```
# Steepfile in /some/project/path
bundle exec steep check /some/project/path/lib/foobar.rb
```

The pattern being relative, it had no chance to match the absolute path provided as argument.

Fixed by making absolute path relative to base_dir before checking against pattern.