### PR TITLE
Better recovery from collection problems

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -152,6 +152,10 @@ module Steep
     @logger || raise
   end
 
+  def self.ui_logger
+    @ui_logger || raise
+  end
+
   def self.new_logger(output, prev_level)
     ActiveSupport::TaggedLogging.new(Logger.new(output)).tap do |logger|
       logger.push_tags "Steep #{VERSION}"
@@ -165,12 +169,18 @@ module Steep
 
   def self.log_output=(output)
     @log_output = output
+
     prev_level = @logger&.level
     @logger = new_logger(output, prev_level)
+
+    prev_level = @ui_logger&.level
+    @ui_logger = new_logger(output, prev_level)
+
     output
   end
 
   @logger = nil
+  @ui_logger = nil
   self.log_output = STDERR
 
   def self.measure(message, level: :warn)

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -63,6 +63,7 @@ module Steep
     def handle_logging_options(opts)
       opts.on("--log-level=LEVEL", "Specify log level: debug, info, warn, error, fatal") do |level|
         Steep.logger.level = level
+        Steep.ui_logger.level = level
       end
 
       opts.on("--log-output=PATH", "Print logs to given path") do |file|
@@ -71,6 +72,7 @@ module Steep
 
       opts.on("--verbose", "Set log level to debug") do
         Steep.logger.level = Logger::DEBUG
+        Steep.ui_logger.level = Logger::DEBUG
       end
     end
 
@@ -129,7 +131,7 @@ module Steep
         end.parse!(argv)
 
         setup_jobs_for_ci(command.jobs_option)
-        
+
         command.command_line_patterns.push *argv
       end.run
     end
@@ -348,6 +350,9 @@ TEMPLATE
           opts.on("--max-index=COUNT") {|count| command.max_index = Integer(count) }
           opts.on("--index=INDEX") {|index| command.index = Integer(index) }
         end.parse!(argv)
+
+        # Disable any `ui_logger` output in workers
+        Steep.ui_logger.level = :fatal
 
         command.commandline_args.push(*argv)
       end.run

--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -20,11 +20,14 @@ module Steep
             end
           end.tap do |project|
             project.targets.each do |target|
-              if collection_lock = target.options.collection_lock
-                begin
-                  collection_lock.check_rbs_availability!
-                rescue RBS::Collection::Config::CollectionNotAvailable
-                  raise "Run `rbs collection install` to install type definitions"
+              case result = target.options.load_collection_lock
+              when nil, RBS::Collection::Config::Lockfile
+                # ok
+              else
+                if result == target.options.collection_config_path
+                  Steep.ui_logger.error { "rbs-collection setup is broken: `#{result}` is missing" }
+                else
+                  Steep.ui_logger.error { "Run `rbs collection install` to install type definitions" }
                 end
               end
             end

--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -4,16 +4,14 @@ module Steep
       module DriverHelper
         attr_accessor :steepfile
 
-        def load_config(path: steepfile || Pathname("Steepfile"), warnings: true)
+        def load_config(path: steepfile || Pathname("Steepfile"))
           if path.file?
             steep_file_path = path.absolute? ? path : Pathname.pwd + path
             Project.new(steepfile_path: steep_file_path).tap do |project|
               Project::DSL.parse(project, path.read, filename: path.to_s)
             end
           else
-            if warnings # Silence warnings in children worker processes
-              Steep.logger.error "Cannot find a configuration at #{path}: `steep init` to scaffold. Using current directory..."
-            end
+            Steep.ui_logger.error { "Cannot find a configuration at #{path}: `steep init` to scaffold. Using current directory..." }
             Project.new(steepfile_path: nil, base_dir: Pathname.pwd).tap do |project|
               Project::DSL.new(project: project).target :'.' do
                 check '.'

--- a/lib/steep/drivers/worker.rb
+++ b/lib/steep/drivers/worker.rb
@@ -21,7 +21,7 @@ module Steep
 
       def run()
         Steep.logger.tagged("#{worker_type}:#{worker_name}") do
-          project = load_config(warnings: false) # Main process has already emitted any warnings
+          project = load_config()
 
           reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdin)
           writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdout)

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -202,16 +202,13 @@ module Steep
           when Pathname
             target.collection_config_path
           when nil
-            project.absolute_path(RBS::Collection::Config::PATH)
+            default = project.absolute_path(RBS::Collection::Config::PATH)
+            if default.file?
+              default
+            end
           when false
             nil
           end
-
-        if config_path && config_path.file?
-          lockfile_path = RBS::Collection::Config.to_lockfile_path(config_path)
-          content = YAML.load_file(lockfile_path.to_s)
-          collection_lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lockfile_path, data: content)
-        end
 
         Project::Target.new(
           name: target.name,
@@ -224,7 +221,7 @@ module Steep
               stdlib_root: target.stdlib_root,
               repo_paths: target.repo_paths
             )
-            options.collection_lock = collection_lock
+            options.collection_config_path = config_path
           end,
           code_diagnostics_config: target.code_diagnostics_config
         ).tap do |target|

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -135,8 +135,8 @@ module Steep
         end
 
         def stdlib_path(core_root:, stdlib_root:)
-          @core_root = core_root ? Pathname(core_root) : core_root
-          @stdlib_root = stdlib_root ? Pathname(stdlib_root) : stdlib_root
+          @core_root = Pathname(core_root)
+          @stdlib_root = Pathname(stdlib_root)
         end
 
         def repo_path(*paths)

--- a/lib/steep/project/options.rb
+++ b/lib/steep/project/options.rb
@@ -3,7 +3,7 @@ module Steep
     class Options
       PathOptions = _ = Struct.new(:core_root, :stdlib_root, :repo_paths, keyword_init: true) do
         # @implements PathOptions
-        
+
         def customized_stdlib?
           stdlib_root != nil
         end
@@ -15,11 +15,48 @@ module Steep
 
       attr_reader :libraries
       attr_accessor :paths
-      attr_accessor :collection_lock
+      attr_accessor :collection_config_path
 
       def initialize
         @paths = PathOptions.new(repo_paths: [])
         @libraries = []
+      end
+
+      def collection_lock_path
+        if collection_config_path
+          RBS::Collection::Config.to_lockfile_path(collection_config_path)
+        end
+      end
+
+      def load_collection_lock(force: false)
+        @collection_lock = nil if force
+        @collection_lock ||=
+          if collection_config_path && collection_lock_path
+            case
+            when !collection_config_path.file?
+              collection_config_path
+            when !collection_lock_path.file?
+              collection_lock_path
+            else
+              begin
+                content = YAML.load_file(collection_lock_path)
+                lock_file = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: collection_lock_path, data: content)
+                lock_file.check_rbs_availability!
+                lock_file
+              rescue YAML::SyntaxError, RBS::Collection::Config::CollectionNotAvailable => exn
+                exn
+              end
+            end
+          end
+      end
+
+      def collection_lock
+        case config = load_collection_lock()
+        when RBS::Collection::Config::Lockfile
+          config
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/steep/server/worker_process.rb
+++ b/lib/steep/server/worker_process.rb
@@ -64,6 +64,7 @@ module Steep
 
         pid = fork do
           Process.setpgid(0, 0)
+          Steep.ui_logger.level = :fatal
           stdin_out.close
           stdout_in.close
           worker.run()

--- a/sig/shims/yaml.rbs
+++ b/sig/shims/yaml.rbs
@@ -1,0 +1,4 @@
+module Psych
+  class SyntaxError < StandardError
+  end
+end

--- a/sig/steep.rbs
+++ b/sig/steep.rbs
@@ -1,6 +1,13 @@
 module Steep
   VERSION: String
 
+  # `ui_logger` is a logger for user interaction messages
+  #
+  # The *main* process has the logger.
+  # The *worker* processes disables the logging through this.
+  #
+  def self.ui_logger: () -> (Logger & ActiveSupport::TaggedLogging)
+
   def self.logger: () -> (Logger & ActiveSupport::TaggedLogging)
 
   def self.new_logger: (IO output, Integer? prev_level) -> (Logger & ActiveSupport::TaggedLogging)
@@ -12,6 +19,8 @@ module Steep
   def self.log_error: (Exception exn, ?message: ::String) -> void
 
   self.@logger: (Logger & ActiveSupport::TaggedLogging)?
+
+  self.@ui_logger: (Logger & ActiveSupport::TaggedLogging)?
 
   class Sampler
     type sample = [String, Float]

--- a/sig/steep/drivers/utils/driver_helper.rbs
+++ b/sig/steep/drivers/utils/driver_helper.rbs
@@ -6,7 +6,7 @@ module Steep
       module DriverHelper
         attr_accessor steepfile: Pathname?
 
-        def load_config: (?path: Pathname, ?warnings: boolish) -> Project
+        def load_config: (?path: Pathname) -> Project
 
         def request_id: () -> String
 

--- a/sig/steep/project/dsl.rbs
+++ b/sig/steep/project/dsl.rbs
@@ -24,9 +24,13 @@ module Steep
 
         attr_reader project: Project?
 
-        attr_reader collection_config_path: Pathname?
-
-        NONE: untyped
+        # Attribute to keep track of collection configuration
+        #
+        # * `Pathname` means loading the configuration from the path
+        # * `nil` means no configuration is given
+        # * `false` means rbs-collection is disabled
+        #
+        attr_reader collection_config_path: Pathname | nil | false
 
         def project!: () -> Project
 
@@ -86,7 +90,7 @@ module Steep
         def disable_collection: () -> void
       end
 
-      attr_reader project: untyped
+      attr_reader project: Project
 
       @@templates: Hash[Symbol, TargetDSL]
 

--- a/sig/steep/project/options.rbs
+++ b/sig/steep/project/options.rbs
@@ -19,9 +19,29 @@ module Steep
 
       attr_accessor paths: PathOptions
 
-      attr_accessor collection_lock: RBS::Collection::Config::Lockfile?
+      attr_accessor collection_config_path: Pathname?
 
       def initialize: () -> void
+
+      # Returns path of lockfile
+      %a{pure} def collection_lock_path: () -> Pathname?
+
+      # Returns `Lockfile` instance if it can be loaded
+      #
+      %a{pure} def collection_lock: () -> RBS::Collection::Config::Lockfile?
+
+      @collection_lock: RBS::Collection::Config::Lockfile | Pathname | YAML::SyntaxError | RBS::Collection::Config::CollectionNotAvailable | nil
+
+      # Load collection configuration
+      #
+      # * Returns `Lockfile` instance if successfully loaded
+      # * Returns `nil` if collection is disabled
+      # * Returns `Pathname` if a file is missing
+      # * Returns `YAML::SyntaxError` or `CollectionNotAvailable` if an error is raised
+      #
+      # It keeps the last result unless `force: true` is specified.
+      #
+      def load_collection_lock: (?force: bool) -> (RBS::Collection::Config::Lockfile | Pathname | YAML::SyntaxError | RBS::Collection::Config::CollectionNotAvailable | nil)
     end
   end
 end

--- a/test/driver_helper_test.rb
+++ b/test/driver_helper_test.rb
@@ -1,0 +1,128 @@
+require_relative "test_helper"
+
+class DriverHelperTest < Minitest::Test
+  include Steep
+  include TestHelper
+  include ShellHelper
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def setup
+    @log_output = Steep.log_output
+    Steep.log_output = StringIO.new
+
+    super
+  end
+
+  def teardown
+    super
+
+    Steep.log_output = @log_output
+  end
+
+  class Test
+    include Steep::Drivers::Utils::DriverHelper
+  end
+
+  def test_load_config_successful__no_collection_file__no_configuration
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+        end
+      RUBY
+
+      Test.new.load_config(path: path)
+      refute_match /rbs collection install/, Steep.log_output.string
+    end
+  end
+
+  def test_load_config_successful__collection_disabled
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          disable_collection
+        end
+      RUBY
+
+      Test.new.load_config(path: path)
+      refute_match /rbs collection install/, Steep.log_output.string
+    end
+  end
+
+  def test_load_config_error__collection_file_missing
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          collection_config "test.yaml"
+        end
+      RUBY
+
+      Test.new.load_config(path: path)
+      assert_match /rbs-collection setup is broken/, Steep.log_output.string
+    end
+  end
+
+  def test_load_config_error__lock_file_missing
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          collection_config "test.yaml"
+        end
+      RUBY
+      current_dir.join("test.yaml").write("[]")
+
+      Test.new.load_config(path: path)
+      assert_match /rbs collection install/, Steep.log_output.string
+    end
+  end
+
+  def test_load_config_error__lock_file_is_broken
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          collection_config "test.yaml"
+        end
+      RUBY
+      current_dir.join("test.yaml").write("[]")
+      current_dir.join("test.lock.yaml").write("[")
+
+      Test.new.load_config(path: path)
+      assert_match /rbs collection install/, Steep.log_output.string
+    end
+  end
+
+  def test_load_config_error__collection_not_installed
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          collection_config "test.yaml"
+        end
+      RUBY
+      current_dir.join("test.yaml").write(<<~YAML)
+        sources:
+          - name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: c42c09528dd99252db98f0744181a6de54ec2f55
+            repo_dir: gems
+
+        # A directory to install the downloaded RBSs
+        path: .gem_rbs_collection
+      YAML
+      current_dir.join("test.lock.yaml").write(<<~YAML)
+        path: .gem_rbs_collection
+        gems: []
+      YAML
+
+      Test.new.load_config(path: path)
+      assert_match /rbs collection install/, Steep.log_output.string
+    end
+  end
+end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -27,7 +27,6 @@ target :app do
 end
 
 target :Gemfile, template: :gemfile do
-  stdlib_path(core_root: false, stdlib_root: false)
 end
 EOF
 
@@ -49,8 +48,8 @@ EOF
         assert_equal [], target.source_pattern.ignores
         assert_equal [], target.signature_pattern.patterns
         assert_equal ["gemfile"], target.options.libraries
-        assert_equal false, target.options.paths.core_root
-        assert_equal false, target.options.paths.stdlib_root
+        assert_nil target.options.paths.core_root
+        assert_nil target.options.paths.stdlib_root
       end
     end
   end

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -150,8 +150,7 @@ end
 EOF
 
       project.targets[0].tap do |target|
-        assert target.options.collection_lock
-        assert target.options.collection_lock.gem('securerandom')
+        assert_equal current_dir.join('rbs_collection.yaml'), target.options.collection_config_path
       end
     end
   end
@@ -176,8 +175,7 @@ end
 EOF
 
       project.targets[0].tap do |target|
-        assert target.options.collection_lock
-        assert target.options.collection_lock.gem('securerandom')
+        assert_equal current_dir.join('my-rbs_collection.yaml'), target.options.collection_config_path
       end
     end
   end
@@ -204,6 +202,70 @@ EOF
       project.targets[0].tap do |target|
         assert_nil target.options.collection_lock
       end
+    end
+  end
+
+  def test_collection_missing
+    in_tmpdir do
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<~RUBY)
+        target :app do
+        end
+      RUBY
+
+      assert_nil project.targets[0].options.load_collection_lock
+      assert_nil project.targets[0].options.collection_lock
+    end
+  end
+
+  def test_load_collection_missing_error
+    in_tmpdir do
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<~RUBY)
+        target :app do
+        end
+      RUBY
+
+      assert_nil project.targets[0].options.load_collection_lock()
+      assert_nil project.targets[0].options.collection_lock
+    end
+  end
+
+
+  def test_load_collection_syntax_error
+    in_tmpdir do
+      current_dir.join('rbs_collection.yaml').write('')
+      current_dir.join('rbs_collection.lock.yaml').write(']')
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<~RUBY)
+        target :app do
+        end
+      RUBY
+
+      assert_instance_of YAML::SyntaxError, project.targets[0].options.load_collection_lock
+      assert_nil project.targets[0].options.collection_lock
+    end
+  end
+
+  def test_load_collection_failed
+    in_tmpdir do
+      current_dir.join('rbs_collection.yaml').write('')
+      current_dir.join('rbs_collection.lock.yaml').write(<<~YAML)
+        path: .test_path
+        gems: []
+      YAML
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<~RUBY)
+        target :app do
+        end
+      RUBY
+
+      assert_instance_of RBS::Collection::Config::CollectionNotAvailable, project.targets[0].options.load_collection_lock
+      assert_nil project.targets[0].options.collection_lock
     end
   end
 end


### PR DESCRIPTION
This PR is to let Steep continue running even if rbs-collection is not correctly set up, while the type checking will fail.

Related to https://github.com/soutaro/steep/pull/969

It includes a commit about `Steep.ui_logger` which improves message printing.