### PR TITLE
Make defined? accept any type

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2348,11 +2348,9 @@ module Steep
           end
 
         when :defined?
-          each_child_node(node) do |child|
-            synthesize(child)
-          end
+          type_any_rec(node, only_children: true)
 
-          add_typing(node, type: AST::Builtin.any_type)
+          add_typing(node, type: AST::Builtin.optional(AST::Builtin::String.instance_type))
 
         when :gvasgn
           yield_self do
@@ -4667,8 +4665,8 @@ module Steep
       !nodes.empty? && nodes.all? {|child| child.type == :class || child.type == :module}
     end
 
-    def type_any_rec(node)
-      add_typing node, type: AST::Builtin.any_type
+    def type_any_rec(node, only_children: false)
+      add_typing node, type: AST::Builtin.any_type unless only_children
 
       each_child_node(node) do |child|
         type_any_rec(child)

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1811,4 +1811,21 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_defined?
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          defined? foo
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
Currently the "argument" given to `defined?` is typechecked—this doesn't exactly follow how Ruby handles `defined?`. (It evaluates everything up to the last method call).

A good usecase of this is to check if a method is defined (`raise "must have #foo method" unless defined? arg.foo`) as `.respond_to?` won't work on `top`s.