### PR TITLE
Skip pending UI jobs

### DIFF
--- a/lib/steep/server/change_buffer.rb
+++ b/lib/steep/server/change_buffer.rb
@@ -5,13 +5,13 @@ module Steep
       attr_reader :buffered_changes
 
       def push_buffer
-        @mutex.synchronize do
+        mutex.synchronize do
           yield buffered_changes
         end
       end
 
       def pop_buffer
-        changes = @mutex.synchronize do
+        changes = mutex.synchronize do
           copy = buffered_changes.dup
           buffered_changes.clear
           copy

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -18,6 +18,7 @@ module Steep
         @mutex = Mutex.new
         @service = Services::TypeCheckService.new(project: project)
         @buffered_changes = {}
+        @last_job_mutex = Mutex.new
       end
 
       def handle_job(job)
@@ -33,25 +34,61 @@ module Steep
           when ApplyChangeJob
             # nop
           when HoverJob
-            writer.write({ id: job.id, result: process_hover(job) })
+            writer.write(
+              {
+                id: job.id,
+                result: process_latest_job(job) { process_hover(job) }
+              }
+            )
           when CompletionJob
-            writer.write({ id: job.id, result: process_completion(job) })
+            writer.write(
+              {
+                id: job.id,
+                result: process_latest_job(job) { process_completion(job) }
+              }
+            )
           when SignatureHelpJob
-            writer.write({ id: job.id, result: process_signature_help(job) })
+            writer.write(
+              {
+                id: job.id,
+                result: process_latest_job(job) { process_signature_help(job) }
+              }
+            )
           end
         end
+      end
+
+      def process_latest_job(job)
+        @last_job_mutex.synchronize do
+          unless job.equal?(@last_job)
+            Steep.logger.debug { "Skipping interaction job: latest_job=#{@last_job.class}, skipped_job#{job.class}" }
+            return
+          end
+          @last_job = nil
+        end
+
+        yield
+      end
+
+      def queue_job(job)
+        @last_job_mutex.synchronize do
+          unless job.is_a?(ApplyChangeJob)
+            @last_job = job
+          end
+        end
+        queue << job
       end
 
       def handle_request(request)
         case request[:method]
         when "initialize"
           load_files(project: project, commandline_args: [])
-          queue << ApplyChangeJob.new
+          queue_job ApplyChangeJob.new
           writer.write({ id: request[:id], result: nil })
 
         when "textDocument/didChange"
           collect_changes(request)
-          queue << ApplyChangeJob.new
+          queue_job ApplyChangeJob.new
 
         when "textDocument/hover"
           id = request[:id]
@@ -60,7 +97,7 @@ module Steep
           line = request[:params][:position][:line]+1
           column = request[:params][:position][:character]
 
-          queue << HoverJob.new(id: id, path: path, line: line, column: column)
+          queue_job HoverJob.new(id: id, path: path, line: line, column: column)
 
         when "textDocument/completion"
           id = request[:id]
@@ -71,14 +108,14 @@ module Steep
           line, column = params[:position].yield_self {|hash| [hash[:line]+1, hash[:character]] }
           trigger = params.dig(:context, :triggerCharacter)
 
-          queue << CompletionJob.new(id: id, path: path, line: line, column: column, trigger: trigger)
+          queue_job CompletionJob.new(id: id, path: path, line: line, column: column, trigger: trigger)
         when "textDocument/signatureHelp"
           id = request[:id]
           params = request[:params]
           path = project.relative_path(PathHelper.to_pathname!(params[:textDocument][:uri]))
           line, column = params[:position].yield_self {|hash| [hash[:line]+1, hash[:character]] }
 
-          queue << SignatureHelpJob.new(id: id, path: path, line: line, column: column)
+          queue_job SignatureHelpJob.new(id: id, path: path, line: line, column: column)
         end
       end
 

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -10,13 +10,13 @@ module Steep
 
       LSP = LanguageServer::Protocol
 
-      attr_reader :service
+      attr_reader :service, :mutex
 
       def initialize(project:, reader:, writer:, queue: Queue.new)
         super(project: project, reader: reader, writer: writer)
         @queue = queue
-        @service = Services::TypeCheckService.new(project: project)
         @mutex = Mutex.new
+        @service = Services::TypeCheckService.new(project: project)
         @buffered_changes = {}
       end
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2349,7 +2349,6 @@ module Steep
 
         when :defined?
           type_any_rec(node, only_children: true)
-
           add_typing(node, type: AST::Builtin.optional(AST::Builtin::String.instance_type))
 
         when :gvasgn

--- a/sig/steep/server/change_buffer.rbs
+++ b/sig/steep/server/change_buffer.rbs
@@ -1,13 +1,15 @@
 module Steep
   module Server
-    module ChangeBuffer : _WithProject
+    module ChangeBuffer : _WithProject, _WithMutex
       interface _WithProject
         def project: () -> Project
       end
 
-      type changes = Hash[Pathname, Array[Services::ContentChange]]
+      interface _WithMutex
+        def mutex: () -> Mutex
+      end
 
-      attr_reader mutex: Thread::Mutex
+      type changes = Hash[Pathname, Array[Services::ContentChange]]
 
       attr_reader buffered_changes: changes
 
@@ -29,7 +31,7 @@ module Steep
       def collect_changes: (untyped request) -> void
 
       # Reset the content of `uri` to `text`
-      # 
+      #
       def reset_change: (uri: String, text: String) -> void
     end
   end

--- a/sig/steep/server/interaction_worker.rbs
+++ b/sig/steep/server/interaction_worker.rbs
@@ -64,6 +64,14 @@ module Steep
 
       def handle_job: (job) -> void
 
+      @last_job_mutex: Mutex
+
+      @last_job: job?
+
+      def process_latest_job: [T] (job) { () -> T } -> T?
+
+      def queue_job: (job) -> void
+
       type lsp_request = { id: String, method: String, params: untyped }
 
       def handle_request: (lsp_request) -> void

--- a/sig/steep/server/interaction_worker.rbs
+++ b/sig/steep/server/interaction_worker.rbs
@@ -58,6 +58,8 @@ module Steep
 
       attr_reader service: Services::TypeCheckService
 
+      attr_reader mutex: Mutex
+
       def initialize: (project: Project, reader: Reader, writer: Writer, ?queue: Queue) -> void
 
       def handle_job: (job) -> void

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -400,7 +400,7 @@ module Steep
     #
     def namespace_module?: (Parser::AST::Node node) -> bool
 
-    def type_any_rec: (Parser::AST::Node node) -> Pair
+    def type_any_rec: (Parser::AST::Node node, ?only_children: bool) -> Pair
 
     def unwrap: (AST::Types::t `type`) -> AST::Types::t
 


### PR DESCRIPTION
It looks like completion requests are sent multiple times from VSCode and it waits for seconds to finish all of them, while only the last completion request makes sense.

This PR skips prior UI jobs before processing the last queued one.

* Pros: UI responsiveness improvements
* Cons: UI requests loss -- dropping completion request always makes sense, but how about SignatureHelp?