### PR TITLE
Fix signature help

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -439,7 +439,9 @@ module Steep
           if target = project.target_for_source_path(job.path)
             file = service.source_files[job.path] or return
             subtyping = service.signature_services[target.name].current_subtyping or return
-            source = Source.parse(file.content, path: file.path, factory: subtyping.factory)
+            source =
+              Source.parse(file.content, path: file.path, factory: subtyping.factory)
+                .without_unrelated_defs(line: job.line, column: job.column)
 
             provider = Services::SignatureHelpProvider.new(source: source, subtyping: subtyping)
 

--- a/lib/steep/services/signature_help_provider.rb
+++ b/lib/steep/services/signature_help_provider.rb
@@ -76,7 +76,8 @@ module Steep
       end
 
       def last_argument_nodes_for(argument_nodes:, line:, column:)
-        return unless argument_nodes.last.children[2]  # No arguments
+        last = argument_nodes.last or raise
+        return unless last.children[2]  # No arguments
         return argument_nodes if argument_nodes.size > 1  # Cursor is on the last argument
 
         pos = buffer.loc_to_pos([line, column])
@@ -150,9 +151,9 @@ module Steep
             case last_argument_nodes[-3].type
             when :pair
               argname = last_argument_nodes[-3].children.first.children.first
-              if method_type.type.required_keywords[argname]
+              if method_type.type.required_keywords.key?(argname)
                 positionals + method_type.type.required_keywords.keys.index(argname).to_i + 1
-              elsif method_type.type.optional_keywords[argname]
+              elsif method_type.type.optional_keywords.key?(argname)
                 positionals + method_type.type.required_keywords.size + method_type.type.optional_keywords.keys.index(argname).to_i + 1
               elsif method_type.type.rest_keywords
                 positionals + method_type.type.required_keywords.size + method_type.type.optional_keywords.size
@@ -161,7 +162,7 @@ module Steep
               positionals + method_type.type.required_keywords.size + method_type.type.optional_keywords.size if method_type.type.rest_keywords
             end
           else
-            pos = node.children[2...].index { |c| c.location == last_argument_nodes[-2].location }.to_i
+            pos = (node.children[2...] || raise).index { |c| c.location == last_argument_nodes[-2].location }.to_i
             if method_type.type.rest_positionals
               [pos + 1, positionals - 1].min
             else
@@ -177,9 +178,9 @@ module Steep
             case argument_nodes[-3].type
             when :pair
               argname = argument_nodes[-3].children.first.children.first
-              if method_type.type.required_keywords[argname]
+              if method_type.type.required_keywords.key?(argname)
                 positionals + method_type.type.required_keywords.keys.index(argname).to_i
-              elsif method_type.type.optional_keywords[argname]
+              elsif method_type.type.optional_keywords.key?(argname)
                 positionals + method_type.type.required_keywords.size + method_type.type.optional_keywords.keys.index(argname).to_i
               elsif method_type.type.rest_keywords
                 positionals + method_type.type.required_keywords.size + method_type.type.optional_keywords.size
@@ -188,7 +189,7 @@ module Steep
               positionals + method_type.type.required_keywords.size + method_type.type.optional_keywords.size if method_type.type.rest_keywords
             end
           else
-            pos = node.children[2...].index { |c| c.location == argument_nodes[-2].location }.to_i
+            pos = (node.children[2...] || raise).index { |c| c.location == argument_nodes[-2].location }.to_i
             [pos, positionals - 1].min
           end
         end

--- a/lib/steep/services/signature_help_provider.rb
+++ b/lib/steep/services/signature_help_provider.rb
@@ -55,7 +55,7 @@ module Steep
               if begin_loc.end_pos <= pos && pos <= end_loc.begin_pos
                 # Given position is between open/close parens of args of send node
 
-                if parent && (parent.type == :block || parent.type == :numblock)
+                if parent && (parent.type == :block || parent.type == :numblock) && node.equal?(parent.children[0])
                   send_node = parent
                 else
                   send_node = node


### PR DESCRIPTION
Let signature help work inside block.

```rb
[1].each do |x|
  x.abs()               # Has shown signature help for `Array#each` where `Integer#abs` is expected
end
```