### PR TITLE
Fix UnexpectedError with unnamed arguments 

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -4393,7 +4393,7 @@ module Steep
       param_types = param_types_hash.each.with_object({}) do |pair, hash| #$ Hash[Symbol, [AST::Types::t, AST::Types::t?]]
         name, type = pair
         # skip unamed arguments `*`, `**` and `&`
-        next unless name
+        next if name.nil?
         hash[name] = [type, nil]
       end
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -4353,7 +4353,7 @@ module Steep
     def for_block(body_node, block_params:, block_param_hint:, block_type_hint:, block_block_hint:, block_annotations:, node_type_hint:, block_self_hint:)
       block_param_pairs = block_param_hint && block_params.zip(block_param_hint, block_block_hint, factory: checker.factory)
 
-      # @type var param_types_hash: Hash[Symbol, AST::Types::t]
+      # @type var param_types_hash: Hash[Symbol?, AST::Types::t]
       param_types_hash = {}
       if block_param_pairs
         block_param_pairs.each do |param, type|
@@ -4388,10 +4388,12 @@ module Steep
         end
       end
 
-      param_types_hash.delete_if {|name, _| SPECIAL_LVAR_NAMES.include?(name) }
+      param_types_hash.delete_if {|name, _| name && SPECIAL_LVAR_NAMES.include?(name) }
 
       param_types = param_types_hash.each.with_object({}) do |pair, hash| #$ Hash[Symbol, [AST::Types::t, AST::Types::t?]]
         name, type = pair
+        # skip unamed arguments `*`, `**` and `&`
+        next unless name
         hash[name] = [type, nil]
       end
 

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -57,8 +57,9 @@ module Steep
 
         def variable_types
           each_param.with_object({}) do |param, hash|
+            var_name = param.var || next
             # @type var hash: Hash[Symbol, AST::Types::t?]
-            hash[param.var] = param.type
+            hash[var_name] = param.type
           end
         end
 

--- a/lib/steep/type_inference/block_params.rb
+++ b/lib/steep/type_inference/block_params.rb
@@ -134,10 +134,17 @@ module Steep
           else
             var = arg.children[0]
             type = annotations.var_type(lvar: var)
-
             case arg.type
-            when :arg, :procarg0
+            when :arg
               default_params << Param.new(var: var, type: type, value: nil, node: arg)
+            when :procarg0
+              var = arg.children[0]
+              if var.is_a?(Symbol)
+                default_params << Param.new(var: var, type: type, value: nil, node: arg)
+              else
+                var = var.children[0]
+                default_params << Param.new(var: var, type: type, value: nil, node: arg)
+              end
             when :optarg
               default_params = trailing_params
               optional_params << Param.new(var: var, type: type, value: arg.children.last, node: arg)

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -325,7 +325,7 @@ module Steep
     def set_up_block_mlhs_params_env: (
       Parser::AST::Node mlhs_node,
       AST::Types::t type,
-      Hash[Symbol, AST::Types::t]
+      Hash[Symbol?, AST::Types::t]
     ) { (Parser::AST::Node error_mlhs_node, AST::Types::t type) -> void } -> void
 
     # Returns a Pair of

--- a/sig/steep/type_inference/block_params.rbs
+++ b/sig/steep/type_inference/block_params.rbs
@@ -37,7 +37,7 @@ module Steep
       # * `node` is the node of the parameter
       #
       class Param
-        attr_reader var: Symbol
+        attr_reader var: Symbol?
 
         attr_reader type: AST::Types::t?
 
@@ -45,7 +45,7 @@ module Steep
 
         attr_reader node: Parser::AST::Node
 
-        def initialize: (var: Symbol, type: AST::Types::t?, value: Parser::AST::Node?, node: Parser::AST::Node) -> void
+        def initialize: (var: Symbol?, type: AST::Types::t?, value: Parser::AST::Node?, node: Parser::AST::Node) -> void
 
         def ==: (untyped other) -> bool
 

--- a/test/block_params_test.rb
+++ b/test/block_params_test.rb
@@ -514,4 +514,29 @@ end
       end
     end
   end
+
+  def test_unnamed
+    with_factory do
+      block_params("proc {|*| }") do |params, args|
+        assert_equal BlockParams::Param.new(var: nil,
+                                            type: nil,
+                                            value: nil,
+                                            node: args[0]),
+                     params.rest_param
+      end
+    end
+  end
+
+  def test_unnamed_multi
+    with_factory do
+      block_params("proc {|(*)| }") do |params, args|
+        param = BlockParams::Param.new(var: nil,
+                                    type: nil,
+                                    value: nil,
+                                    node: args[0])
+        assert_equal [param],
+                     params.leading_params
+      end
+    end
+  end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6120,6 +6120,48 @@ end
     end
   end
 
+  def test_block_param_masgn_with_unnamed
+    with_checker(<<-RBS) do |checker|
+class BlockParamTupleRest
+  def foo: () { ([Integer, String]) -> void } -> void
+end
+    RBS
+      source = parse_ruby(<<-RUBY)
+BlockParamTupleRest.new.foo do |*, **, &|
+  if 1
+  end
+end
+      RUBY
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_typing_error typing, size: 1 do |error,|
+          assert_instance_of Diagnostic::Ruby::FallbackAny, error
+        end
+      end
+    end
+  end
+
+  def test_block_param_masgn_with_unnamed2
+    with_checker(<<-RBS) do |checker|
+class BlockParamTupleRest
+  def foo: () { ([Integer, String]) -> void } -> void
+end
+    RBS
+      source = parse_ruby(<<-RUBY)
+BlockParamTupleRest.new.foo do |(*)|
+  if 1
+  end
+end
+      RUBY
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_typing_error typing, size: 1 do |error,|
+          assert_instance_of Diagnostic::Ruby::FallbackAny, error
+        end
+      end
+    end
+  end
+
   def test_logic_receiver_is_nil
     with_checker(<<-RBS) do |checker|
     RBS


### PR DESCRIPTION
I found two error patterns.
It seems to occur when the block argument is unnamed.

```ruby
m do |*|
  1 if 1
  #=> UnexpectedError: undefined method `start_with?' for nil(NoMethodError)
  #=> 1. /Users/ksss/src/github.com/ksss/steep/lib/steep/type_inference/type_env.rb:316:in `local_variable_name?'
  #=> 2. /Users/ksss/src/github.com/ksss/steep/lib/steep/type_inference/type_env.rb:323:in `local_variable_name!'
  #=> 3. /Users/ksss/src/github.com/ksss/steep/lib/steep/type_inference/type_env.rb:115:in `block in assign_local_variables'
end
```

```ruby
m do |(*)|
  1 if 1
  #=> UnexpectedError: undefined method `start_with?' for nil(NoMethodError)
  #=> 1. /Users/ksss/src/github.com/ksss/steep/lib/steep/type_inference/type_env.rb:316:in `local_variable_name?'
  #=> 2. /Users/ksss/src/github.com/ksss/steep/lib/steep/type_inference/type_env.rb:323:in `local_variable_name!'
  #=> 3. /Users/ksss/src/github.com/ksss/steep/lib/steep/type_inference/type_env.rb:115:in `block in assign_local_variables'
end
```

I fixed it so that there is no error even if the block argument is unnamed.
