### PR TITLE
Abort if subtyping fails to (possible) infinite loop

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -1,6 +1,8 @@
 module Steep
   module Subtyping
     class Check
+      ABORT_LIMIT = ENV.fetch("STEEP_SUBTYPING_ABORT_LIMIT", 50).to_i
+
       attr_reader :builder
       attr_reader :cache
 
@@ -187,6 +189,10 @@ module Steep
       end
 
       def check_type(relation)
+        if assumptions.size > ABORT_LIMIT
+          return Failure(relation, Result::Failure::LoopAbort.new)
+        end
+
         relation.type!
 
         Steep.logger.tagged "#{relation.sub_type} <: #{relation.super_type}" do

--- a/lib/steep/subtyping/result.rb
+++ b/lib/steep/subtyping/result.rb
@@ -269,6 +269,12 @@ module Steep
           end
         end
 
+        class LoopAbort
+          def message
+            "Detected infinite loop with limit of `#{Check::ABORT_LIMIT}`; specify $STEEP_SUBTYPING_ABORT_LIMIT env var to override the limit."
+          end
+        end
+
         attr_reader :error
 
         def initialize(relation, error)

--- a/sig/steep/subtyping/check.rbs
+++ b/sig/steep/subtyping/check.rbs
@@ -1,6 +1,8 @@
 module Steep
   module Subtyping
     class Check
+      ABORT_LIMIT: Integer
+
       attr_reader builder: Interface::Builder
 
       attr_reader cache: Cache

--- a/sig/steep/subtyping/result.rbs
+++ b/sig/steep/subtyping/result.rbs
@@ -81,7 +81,7 @@ module Steep
       class Failure < Base
         type error = MethodMissingError | BlockMismatchError | ParameterMismatchError
                    | UnknownPairError | PolyMethodSubtyping | UnsatisfiedConstraints
-                   | SelfBindingMismatch
+                   | SelfBindingMismatch | LoopAbort
 
         class MethodMissingError
           attr_reader name: untyped
@@ -142,6 +142,10 @@ module Steep
         class SelfBindingMismatch
           def initialize: () -> void
 
+          def message: () -> String
+        end
+
+        class LoopAbort
           def message: () -> String
         end
 

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1828,4 +1828,34 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_string_match
+    run_type_check_test(
+      signatures: {},
+      code: {
+        "a.rb" => <<~RUBY
+          "" =~ ""
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 0
+              end:
+                line: 1
+                character: 8
+            severity: ERROR
+            message: |-
+              Cannot find compatible overloading of method `=~` of type `::String`
+              Method types:
+                def =~: (::Regexp) -> (::Integer | nil)
+                      | [T] (::String::_MatchAgainst[::String, T]) -> T
+            code: Ruby::UnresolvedOverloading
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
Type checking `"" =~ ""` doesn't stop by infinitely recursive subtyping check.

```
# Simplified RBS excerpt

interface _MatchAgainst[T]
  def =~: (String) -> T
end

class String
  def =~: (Regexp) -> Integer?
        | [T] (_MatchAgainst[T]) -> T
end

# Ruby code

"" =~ ""

# Subtyping trace

String <: _MatchAgainst[T_1]                           # T_1 is a fresh type variable
  =~
    [T] (_MatchAgainst[T]) -> T <: (String) -> T_1     # Expand =~ method types
      (_MatchAgainst[T_2]) -> T_2 <: (String) -> T_1   # Expand generics with fresh type variable T_2
        String <: _MatchAgainst[T_2]                   # The first subtyping relationship but with T_2, and continues
        T_2 <: T_1
```

Instead of causing `SystemStackError`, let subtyping check fail with new `LoopAbort` error.