### PR TITLE
Should not include sig/shims on spec.files

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/soutaro/steep/blob/master/CHANGELOG.md"
 
   spec.files         = `git ls-files -z`.split("\x0").reject {|f|
-    f.match(%r{^(test|spec|features|smoke)/})
+    f.match(%r{^(test|spec|features|smoke|sig/shims)/})
   }
 
   spec.bindir        = "exe"


### PR DESCRIPTION
ref: https://github.com/soutaro/steep/issues/1072

Currently, the **parser** and **concurrent-ruby** signatures in `sig/shims` are conflicting with signatures on gem_rbs_collection.
As a stopgap measure, remove `sig/shims` from the distribution file and make it internal.
As a root solution, signatures in `sig/shims` should be merged into gem_rbs_collection.