### PR TITLE
Avoid unnecessary calling `RBS::Location#to_s` on debug log

### DIFF
--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -134,7 +134,7 @@ module Steep
       end
 
       def validate_type(type)
-        Steep.logger.debug "#{Location.to_string type.location}: Validating #{type}..."
+        Steep.logger.debug { "#{Location.to_string type.location}: Validating #{type}..." }
 
         validator.validate_type(type, context: nil)
         validate_type_application(type)


### PR DESCRIPTION
This PR reduces `RBS::Location#to_s` calls.

Currently, this method is called for debug logging but it is unnecessary unless the log level is debug. So I replaced the string literal with a block. 


This change is necessary because I want to make `RBS::Location` slim. I plan to remove `line` and `column` information in this change to reduce memory usage.
This debug logging is the only call of the method during `steep check`. Therefore we can make it slim safely if this method call is removed.


I've confirmed the `RBS::Location#to_s` calls with the following patch for RBS.

```diff
diff --git a/lib/rbs/location_aux.rb b/lib/rbs/location_aux.rb
index 769f91c5..53203d3f 100644
--- a/lib/rbs/location_aux.rb
+++ b/lib/rbs/location_aux.rb
@@ -45,13 +45,13 @@ module RBS
 
     def start_loc
       @start_loc ||= begin
-        _start_loc || buffer.pos_to_loc(start_pos)
+        _start_loc.tap{p caller if _1} || buffer.pos_to_loc(start_pos)
       end
     end
 
     def end_loc
       @end_loc ||= begin
-        _end_loc || buffer.pos_to_loc(end_pos)
+        _end_loc.tap{p caller if _1} || buffer.pos_to_loc(end_pos)
       end
     end
```