### PR TITLE
Support unnamed restarg

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -37,7 +37,7 @@ module Steep
       s + ">"
     end
 
-    SPECIAL_LVAR_NAMES = Set[:_, :__any__, :__skip__]
+    SPECIAL_LVAR_NAMES = Set[nil, :_, :__any__, :__skip__]
 
     include ModuleHelper
 

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1787,6 +1787,37 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  def test_unnamed_restarg
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Foo
+            def foo: (*untyped, **untyped) -> void
+
+            def bar: { (*untyped, **untyped) -> void } -> void
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class Foo
+            def foo(*, **)
+              bar { |*, **| }
+            end
+
+            def bar
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
   def test_rescue_assignment
     run_type_check_test(
       signatures: {


### PR DESCRIPTION
Without this change, the test produces the following diagnostics:

```yaml
diagnostics:
- range:
    start:
      line: 2
      character: 10
    end:
      line: 2
      character: 11
  severity: ERROR
  message: Cannot detect the type of the expression
  code: Ruby::FallbackAny
- range:
    start:
      line: 2
      character: 13
    end:
      line: 2
      character: 15
  severity: ERROR
  message: Cannot detect the type of the expression
  code: Ruby::FallbackAny
- range:
    start:
      line: 3
      character: 11
    end:
      line: 3
      character: 12
  severity: ERROR
  message: Cannot detect the type of the expression
  code: Ruby::FallbackAny
```