### PR TITLE
Fix issue with wildcard expansion in FileLoader

### DIFF
--- a/test/file_loader_test.rb
+++ b/test/file_loader_test.rb
@@ -33,4 +33,34 @@ class FileLoaderTest < Minitest::Test
       assert_empty loader.each_path_in_patterns(pat, ["Rakefile"]).to_a
     end
   end
+
+  def test_each_path_in_patterns_with_glob
+    in_tmpdir do
+      loader = FileLoader.new(base_dir: current_dir)
+
+      (current_dir + "lib/foo/bar").mkpath()
+      (current_dir + "lib/foo/bar/baz.rb").write("")
+      (current_dir + "lib/foo/parser.rb").write("")
+      (current_dir + "lib/foo/bar/index.html.erb").write("")
+
+      pat = Pattern.new(patterns: ["lib/*/bar"], ext: ".rb")
+
+      assert_equal [Pathname("lib/foo/bar/baz.rb")], loader.each_path_in_patterns(pat, []).to_a
+    end
+  end
+
+  def test_each_path_in_patterns_with_glob_and_ext
+    in_tmpdir do
+      loader = FileLoader.new(base_dir: current_dir)
+
+      (current_dir + "lib/foo/bar").mkpath()
+      (current_dir + "lib/foo/bar/baz.rb").write("")
+      (current_dir + "lib/foo/parser.rb").write("")
+      (current_dir + "lib/foo/bar/index.html.erb").write("")
+
+      pat = Pattern.new(patterns: ["lib/*/bar/baz.rb"], ext: ".rb")
+
+      assert_equal [Pathname("lib/foo/bar/baz.rb")], loader.each_path_in_patterns(pat, []).to_a
+    end
+  end
 end


### PR DESCRIPTION
Fixed soutaro/steep#1109

Adjusted processing to apply `Pathname.glob` for wildcard expansion before subsequent processing. 
As a result, eliminated cases where `absolute_path` is neither a file nor a directory, and removed the unnecessary branching logic.