### PR TITLE
Improve wildcard handling in pattern matching for directory paths

### DIFF
--- a/lib/steep/project/pattern.rb
+++ b/lib/steep/project/pattern.rb
@@ -46,10 +46,9 @@ module Steep
 
       def test_string(path, patterns, prefixes)
         string = path.to_s
-        extension = path.extname
 
         patterns.any? {|pat| File.fnmatch(pat, string, File::FNM_PATHNAME) } ||
-          prefixes.any? {|prefix| string.start_with?(prefix) && extension == ext }
+          prefixes.any? {|prefix| File.fnmatch("#{prefix}**/*#{ext}", string, File::FNM_PATHNAME) }
       end
     end
   end

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -13,4 +13,14 @@ class PatternTest < Minitest::Test
     assert_operator pattern, :=~, "app/controllers/admin_controller.rb"
     assert_operator pattern, :=~, "app/controllers/api/v2/accounts_controller.rb"
   end
+
+  def test_pattern_with_glob
+    pattern = Project::Pattern.new(
+      patterns: ["app/models/*/bar"],
+      ext: ".rb"
+    )
+
+    assert_operator pattern, :=~, "app/models/foo/bar/baz.rb"
+    assert_operator pattern, :=~, "app/models/foo/bar/baz/qux.rb"
+  end
 end


### PR DESCRIPTION
Fixed soutaro/steep#1120

Prior to this commit, the `Pattern` class used `String#start_with?` for pattern matching when directory names were specified in the patterns array. 
This method did not support the expansion of wildcards, which led to files that should have been matched by wildcard patterns being omitted from the `steep stats` output. 
By replacing `String#start_with?` with `File.fnmatch`, this commit ensures that wildcards are correctly expanded even when matching directory patterns, thereby resolving the mismatch issue.

The tests added to `pattern_test.rb` confirm that the new pattern matching logic correctly identifies files within directories that match wildcard patterns, ensuring robustness of this fix and preventing future regressions.