### PR TITLE
Handle `$/file/reset` request in interaction worker

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -90,6 +90,12 @@ module Steep
           collect_changes(request)
           queue_job ApplyChangeJob.new
 
+        when "$/file/reset"
+          uri = request[:params][:uri]
+          text = request[:params][:content]
+          reset_change(uri: uri, text: text)
+          queue_job ApplyChangeJob.new
+
         when "textDocument/hover"
           id = request[:id]
 

--- a/test/interaction_worker_test.rb
+++ b/test/interaction_worker_test.rb
@@ -109,6 +109,40 @@ end
     end
   end
 
+  def test_handle_request__file_reset
+    in_tmpdir do
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+      Project::DSL.parse(project, <<EOF)
+target :lib do
+  check "lib"
+  signature "sig"
+end
+EOF
+
+      worker = InteractionWorker.new(project: project, reader: worker_reader, writer: worker_writer)
+
+      worker.handle_request({ method: "initialize", id: 1, params: nil })
+      flush_queue(worker.queue)
+
+      worker.handle_request(
+        {
+          method: "$/file/reset",
+          id: 123,
+          params: {
+            uri: "#{file_scheme}#{current_dir}/lib/hello.rb",
+            content: "1 + true"
+          }
+        }
+      )
+
+      q = flush_queue(worker.queue)
+      assert_equal 1, q.size
+      assert_instance_of InteractionWorker::ApplyChangeJob, q[0]
+
+      refute_empty worker.buffered_changes
+    end
+  end
+
   def test_handle_request_hover
     in_tmpdir do
       project = Project.new(steepfile_path: current_dir + "Steepfile")


### PR DESCRIPTION
The custom LSP request is handled in TypeCheckWorker, but the implementation in InteractionWorker slipped my mind in #936.

The result was confusing while I was testing RBS::Inline gem. The diagnostics was reported because it's done be TypeCheckWorker, but the completion or hover doesn't work. Checking the updated RBS file resumes the interaction worker, because opening the file means the `textDocument/didChange` notifications are sent to language server.