### PR TITLE
Treat `present?` as a special method that guarantees the receiver is not nil

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -720,6 +720,20 @@ module Steep
             end
             end
 
+          when :present?
+            case defined_in
+            when RBS::BuiltinNames::Object.name,
+              AST::Builtin::NilClass.module_name,
+              RBS::BuiltinNames::Kernel.name
+              if member.instance?
+                return method_type.with(
+                  type: method_type.type.with(
+                    return_type: AST::Types::Logic::ReceiverIsNotNil.new(location: method_type.type.return_type.location)
+                  )
+                )
+            end
+            end
+
           when :!
             case defined_in
             when RBS::BuiltinNames::BasicObject.name,

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -6195,6 +6195,41 @@ e + 1
     end
   end
 
+  def test_logic_receiver_is_not_nil
+    with_checker(<<-RBS) do |checker|
+      class Object
+        def present?: () -> bool
+      end
+    RBS
+      source = parse_ruby(<<-RUBY)
+a = [1].first
+return unless a.present?
+a + 1
+
+b = [1].first
+return unless (x = b).present?
+x + 1
+
+c = [1].first
+return unless (y = c.present?)
+c + 1
+
+d = [1].first
+puts "nil!" and return unless d.present?
+d + 1
+
+e = [1].first
+nil or return unless e.present?
+e + 1
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        construction.synthesize(source.node)
+        assert_no_error typing
+      end
+    end
+  end
+
   def test_logic_receiver_is_arg
     with_checker(<<-RBS) do |checker|
     RBS


### PR DESCRIPTION
Fixes https://github.com/soutaro/steep/issues/472

The pull request https://github.com/soutaro/steep/pull/905 attempts to resolve the issue using annotations, but this PR resolves it by treating `present?` as a special method, similar to how Sorbet handles it https://github.com/sorbet/sorbet/blob/718bc64f895abeeff88f56efbc92a3554ffaa4f2/infer/environment.cc#L564-L579