### PR TITLE
Stop to distribute sig dir

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/soutaro/steep/blob/master/CHANGELOG.md"
 
   spec.files         = `git ls-files -z`.split("\x0").reject {|f|
-    f.match(%r{^(test|spec|features|smoke)/})
+    f.match(%r{^(test|spec|features|smoke|sig)/})
   }
 
   spec.bindir        = "exe"


### PR DESCRIPTION
Retry: https://github.com/soutaro/steep/pull/1074
Fix: https://github.com/soutaro/steep/issues/1072

Some signatures in Steep's sig directory conflict with those in gem_rbs_collection, making them difficult to use.
Additionally, code that uses Steep's class/module/interface does not seem to have many use cases.
To resolve this issue, I propose excluding the `sig` directory from the steep gem package.