### PR TITLE
Fix variable untyped hover issue in rescue clause

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2106,6 +2106,7 @@ module Steep
               end
 
               if body
+                resbody_construction.typing.add_context_for_node(body, context: resbody_construction.context)
                 resbody_construction.synthesize(body, hint: hint)
               else
                 Pair.new(constr: body_constr, type: AST::Builtin.nil_type)


### PR DESCRIPTION
When writing `rescue StandardError => e`, `e` should be an instance of the `StandardError` class. 
However, variables declared in rescue clauses would become untyped on hover in some cases.

```ruby
class Hello
  def do_something(x)
    x
  rescue StandardError => e
    e.message # `e` becomes untyped on hover
    e # `e` is StandardError on hover
  end
end
```

This issue is fixed by explicitly updating the context.