### PR TITLE
Fix subtyping issues

### DIFF
--- a/doc/shape.md
+++ b/doc/shape.md
@@ -24,7 +24,9 @@ Shape (_Foo) {
 Note that the `self` type in the example is resolved to `_Foo` during shape calculation.
 
 The shape calculation of an object is straightforward. Calculate a `RBS::Definition` of a class singleton/instance, or an interface, and translate the data structure to a `Shape` object. But there are a few things to consider.
+
 ## Tuple, record, and proc types
+
 The shape of tuple, record, or proc types are based on their base types -- Array, Hash, or Proc classes --, but with specialized method types.
 
 ```
@@ -37,16 +39,22 @@ Shape ([Integer, String]) {
 ```
 
 The specialization is implemented as a part of shape calculation.
+
 ## Special methods
+
 Steep recognizes some special methods for type narrowing, including `#is_a?`, `#===`, `#nil?`, ... These methods are defined with normal RBS syntax, but the method types in shapes are transformed to types using logic types.
 
 The shape calculation inserts the specialized methods with these special methods.
+
 ## `self` types
+
 There are two cases of `self` types to consider during shape calculation.
 
 1. `self` types included in the shape of a type
 2. `self` types included in given types
+
 ### 1. `self` types included in the shape of a type
+
 `self` types may be included in a class or interface definition.
 
 ```rbs
@@ -62,7 +70,9 @@ Shape (_Foo) {
   itself: () -> _Foo
 }
 ```
+
 ### 2. `self` types included in given types
+
 Unlike `self` types included in definitions, `self` types in given types should be preserved.
 
 ```rbs
@@ -100,7 +110,9 @@ end
 ```
 
 We want the type of `foo.get` to be `self`, not `Foo`, to avoid a type error being detected.
+
 ## Shape of `self` types
+
 We also want `self` type if `self` is the type of the shape.
 
 ```rb
@@ -154,7 +166,9 @@ Shape (Foo | Bar) {
 So, the resulting type of `self.foo` where the type of `self` is `Foo | Bar`, would be `Integer | Foo | Bar`. But, actually, it won't be `Foo` because the `self` comes from `Bar`.
 
 This is an incorrect result, but Steep is doing this right now.
+
 ## `class` and `instance` types
+
 The shape calculation provides limited support for `class` and `instance` types.
 
 1. `class`/`instance` types from the definition are resolved
@@ -162,13 +176,17 @@ The shape calculation provides limited support for `class` and `instance` types.
 3. Shape of `class`/`instance` types are resolved to configuration's `class_type` and `instance_type`, and the translated types are used to calculate the shape
 
 It's different from `self` types except case #2. The relationship between `self`/`class`/`instance` is not trivial in Ruby. All of them might be resolved to any type, which means calculating one from another of them is simply impossible.
+
 ## Public methods, private methods
+
 `Shape` objects have a flag of if the shape is for *public* method calls or *private* method calls. Private method call is a form of `foo()` or `self.foo()` -- when the receiver is omitted or `self`. Public method calls are anything else.
 
 The shape calculation starts with *private methods*, and the `Shape#public_shape` method returns another shape that only has *public* methods.
 
 > Note that the private shape calculation is required even on public method calls. This means a possible chance of future optimizations.
+
 ## Lazy method type calculation
+
 We rarely need all of the methods available for an object. If we want to type check a method call, we only need the method type of that method. All other methods can be just ignored.
 
 *Lazy method type calculation* is introduced for that case. Instead of calculating the types of all of the methods, it registers a block that computes the method type.

--- a/rbs_collection.steep.yaml
+++ b/rbs_collection.steep.yaml
@@ -21,3 +21,5 @@ gems:
   - name: csv
   - name: pathname
   - name: securerandom
+  - name: ffi
+    ignore: true

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -28,9 +28,16 @@ module Steep
 
         def upper_bound: (Symbol) -> AST::Types::t?
 
-        private
+        # Validates `self_type` attribute, and raises an error if it's not valid
+        def validate_self_type: () -> void
 
-        def validate: () -> self
+        # Validates `instance_type` attribute, and raises an error if it's not valid
+        def validate_instance_type: () -> void
+
+        # Validates `class_type` attribute, and raises an error if it's not valid
+        def validate_class_type: () -> void
+
+        private
 
         def validate_fvs: (Symbol name, AST::Types::t?) -> void
       end

--- a/sig/steep/signature/validator.rbs
+++ b/sig/steep/signature/validator.rbs
@@ -18,7 +18,7 @@ module Steep
       attr_reader context: Array[[AST::Types::t?, AST::Types::t?, AST::Types::t?]]
 
       def latest_context: -> [AST::Types::t?, AST::Types::t?, AST::Types::t?]
-                        
+
       def push_context: [T] (?self_type: AST::Types::t?, ?class_type: AST::Types::t?, ?instance_type: AST::Types::t?) { () -> T } -> T
 
       def initialize: (checker: Subtyping::Check) -> void
@@ -81,7 +81,7 @@ module Steep
       #
       def validate_one_alias: (RBS::TypeName name, ?RBS::Environment::TypeAliasEntry entry) -> void
 
-      def validate_one_class_decl: (RBS::TypeName) -> void
+      def validate_one_class_decl: (RBS::TypeName, RBS::Environment::ClassEntry | RBS::Environment::ModuleEntry) -> void
 
       def validate_one_class_alias: (RBS::TypeName, RBS::Environment::ClassAliasEntry | RBS::Environment::ModuleAliasEntry) -> void
 

--- a/sig/steep/signature/validator.rbs
+++ b/sig/steep/signature/validator.rbs
@@ -13,6 +13,14 @@ module Steep
 
       @validator: RBS::Validator?
 
+      # Stack of `self_type`, `class_type`, `instance_type` tuple
+      #
+      attr_reader context: Array[[AST::Types::t?, AST::Types::t?, AST::Types::t?]]
+
+      def latest_context: -> [AST::Types::t?, AST::Types::t?, AST::Types::t?]
+                        
+      def push_context: [T] (?self_type: AST::Types::t?, ?class_type: AST::Types::t?, ?instance_type: AST::Types::t?) { () -> T } -> T
+
       def initialize: (checker: Subtyping::Check) -> void
 
       def has_error?: () -> bool
@@ -70,7 +78,7 @@ module Steep
       #
       # 1. Make sure the outer namespace of given `name` exists
       # 2. Make sure the type alias is valid with respect to `RBS::Validator`
-      # 
+      #
       def validate_one_alias: (RBS::TypeName name, ?RBS::Environment::TypeAliasEntry entry) -> void
 
       def validate_one_class_decl: (RBS::TypeName) -> void

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -1156,4 +1156,27 @@ Test: SetValueExtractor[ArraySet]
       end
     end
   end
+
+  def test_validate_type_app__classish_bounded
+    with_checker <<~RBS do |checker|
+        interface _Generic[T < Object]
+        end
+
+        class Foo < BasicObject
+          class User
+            type t1 = _Generic[instance]
+            type t2 = _Generic[class]
+
+            include _Generic[class]
+            extend _Generic[instance]
+          end
+        end
+      RBS
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate
+        assert_predicate validator.each_error.to_a, :empty?
+      end
+    end
+  end
 end


### PR DESCRIPTION
Steep 1.7.0 introduces a new constraint that `self` cannot include `instance` and `class` types, and vice versa. This causes an unexpected type checking failure on FFI as reported in https://github.com/soutaro/steep/issues/1162.

This PR fixes the problem by delaying the constraint checking until the shape of `self` type is needed.

https://github.com/soutaro/steep/issues/916 is also fixed by handling the `self`, `instance`, and `class` types during validation.

Fixes https://github.com/soutaro/steep/issues/1162, https://github.com/soutaro/steep/issues/916.