### PR TITLE
Ignore `#:` annotation on `attr_*` calls

### DIFF
--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -475,6 +475,15 @@ module Steep
               return assertion_node(node, last_comment)
             end
           else
+            if (receiver, name, * = deconstruct_send_node(node))
+              if receiver.nil?
+                if name == :attr_reader || name == :attr_writer || name == :attr_accessor
+                  child_assertions = comments.except(last_line)
+                  node = map_child_node(node) {|child| insert_type_node(child, child_assertions) }
+                  return adjust_location(node)
+                end
+              end
+            end
             child_assertions = comments.except(last_line)
             node = map_child_node(node) {|child| insert_type_node(child, child_assertions) }
             node = adjust_location(node)


### PR DESCRIPTION
This improves the compatibility with `rbs-inline`, where `attr_*` calls may be annotated for the type of the attributes.

Steep now ignores `#:` annotations given to `attr_reader`, `attr_accessor`, and `attr_writer` calls without receivers. If you really need some type annotation to your custom `attr_reader` (likes) calls, you need to add `self.` receiver or surround them with parens.

```rb
class Foo
  # Type declaration for rbs-inline, Steep ignores the annotation
  attr_reader :foo #: String

  # Steep detects the annotation because it's with `self` receiver
  self.attr_reader :foo #: String

  # Steep detects the annotation because of the parens
  (attr_reader :foo) #: String
end
```