### PR TITLE
Support literals for Rational and Complex

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1375,6 +1375,12 @@ module Steep
         when :float
           add_typing(node, type: AST::Builtin::Float.instance_type)
 
+        when :rational
+          add_typing(node, type: AST::Types::Name::Instance.new(name: TypeName("::Rational"), args: []))
+
+        when :complex
+          add_typing(node, type: AST::Types::Name::Instance.new(name: TypeName("::Complex"), args: []))
+
         when :nil
           add_typing(node, type: AST::Builtin.nil_type)
 

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -10864,4 +10864,25 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       end
     end
   end
+
+  def test_rational_and_complex_literal
+    with_checker(<<~RBS) do |checker|
+      RBS
+      source = parse_ruby(<<~RUBY)
+        r = 1r
+        c = 1i
+        rc = 1ri
+      RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        # type, _, context = construction.synthesize(source.node)
+        pair = construction.synthesize(source.node)
+
+        assert_equal parse_type("::Rational"), pair.context.type_env[:r]
+        assert_equal parse_type("::Complex"), pair.context.type_env[:c]
+        assert_equal parse_type("::Complex"), pair.context.type_env[:rc]
+        assert_no_error typing
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, steep does not support the syntax for `1r`, `1i`  and `1ri`, and they default to `untyped` type.
In this PR, I have made it possible to interpret `1r` as `Rational`, `1i` as `Complex` and `1ri` as `Complex`.