### PR TITLE
Fix shape calculation error

### DIFF
--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -725,7 +725,7 @@ module Steep
       end
 
       def keyword_argument_items_for_method(call_node:, send_node:, position:, prefix:, items:)
-        receiver_node, method_name, argument_nodes = deconstruct_send_node!(send_node)
+        _receiver_node, _method_name, argument_nodes = deconstruct_send_node!(send_node)
 
         call = typing.call_of(node: call_node)
 
@@ -733,6 +733,7 @@ module Steep
         when TypeInference::MethodCall::Typed, TypeInference::MethodCall::Error
           context = typing.context_at(line: position.line, column: position.column)
           type = call.receiver_type
+          type = type.subst(Interface::Substitution.build([], self_type: context.self_type, module_type: context.module_context&.module_type, instance_type: context.module_context&.instance_type))
 
           config = Interface::Builder::Config.new(self_type: type, variable_bounds: context.variable_context.upper_bounds)
           if shape = subtyping.builder.shape(type, config)

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -650,4 +650,15 @@ end
       end
     end
   end
+
+  def test_self_receiver_call_type
+    with_checker do
+      CompletionProvider.new(source_text: <<-EOR, path: Pathname("foo.rb"), subtyping: checker).tap do |provider|
+puts i
+      EOR
+
+        provider.run(line: 1, column: 6) # Assert nothing raised
+      end
+    end
+  end
 end


### PR DESCRIPTION
<img width="653" alt="スクリーンショット 2024-08-01 17 27 29" src="https://github.com/user-attachments/assets/78114902-2c82-42c3-ae29-a460de135fcf">

The error is caused by calculating the type of method call, where the receiver is `self`. Resolving the `self`-ish types beforehand fixes the problem.