### PR TITLE
Load files in main process

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -161,7 +161,11 @@ module Steep
   end
 
   def self.new_logger(output, prev_level)
-    ActiveSupport::TaggedLogging.new(Logger.new(output)).tap do |logger|
+    logger = Logger.new(output)
+    logger.formatter = proc do |severity, datetime, progname, msg|
+      "#{datetime.strftime('%Y-%m-%d %H:%M:%S')}: #{severity}: #{msg}\n"
+    end
+    ActiveSupport::TaggedLogging.new(logger).tap do |logger|
       logger.push_tags "Steep #{VERSION}"
       logger.level = prev_level || Logger::ERROR
     end

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -15,6 +15,7 @@ require "stringio"
 require 'uri'
 require "yaml"
 require "securerandom"
+require "base64"
 
 require "concurrent/utility/processor_counter"
 require "terminal-table"

--- a/lib/steep/server/change_buffer.rb
+++ b/lib/steep/server/change_buffer.rb
@@ -28,6 +28,9 @@ module Steep
         Steep.logger.tagged "#load_files" do
           push_buffer do |changes|
             input.each do |filename, content|
+              if content.is_a?(Hash)
+                content = Base64.decode64(content[:text]).force_encoding(Encoding::UTF_8)
+              end
               changes[Pathname(filename.to_s)] = [Services::ContentChange.new(text: content)]
             end
           end

--- a/lib/steep/server/change_buffer.rb
+++ b/lib/steep/server/change_buffer.rb
@@ -24,16 +24,11 @@ module Steep
         end
       end
 
-      def load_files(project:, commandline_args:)
+      def load_files(input)
         Steep.logger.tagged "#load_files" do
           push_buffer do |changes|
-            loader = Services::FileLoader.new(base_dir: project.base_dir)
-
-            Steep.measure "load changes from disk" do
-              project.targets.each do |target|
-                loader.load_changes(target.source_pattern, commandline_args, changes: changes)
-                loader.load_changes(target.signature_pattern, changes: changes)
-              end
+            input.each do |filename, content|
+              changes[Pathname(filename.to_s)] = [Services::ContentChange.new(text: content)]
             end
           end
         end

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -82,12 +82,15 @@ module Steep
       def handle_request(request)
         case request[:method]
         when "initialize"
-          load_files(project: project, commandline_args: [])
-          queue_job ApplyChangeJob.new
           writer.write({ id: request[:id], result: nil })
 
         when "textDocument/didChange"
           collect_changes(request)
+          queue_job ApplyChangeJob.new
+
+        when "$/file/load"
+          input = request[:params][:content]
+          load_files(input)
           queue_job ApplyChangeJob.new
 
         when "$/file/reset"

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -380,7 +380,7 @@ module Steep
         include MessageUtils
       end
 
-      SendMessageJob = _ = Struct.new(:dest, :message, keyword_init: true) do
+      class SendMessageJob < Struct.new(:dest, :message, keyword_init: true)
         # @implements SendMessageJob
 
         def self.to_worker(worker, message:)

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -572,6 +572,14 @@ module Steep
 
             Steep.measure("Load files from disk...") do
               controller.load(command_line_args: commandline_args) do |input|
+                input.transform_values! do |content|
+                  content.is_a?(String) or raise
+                  if content.valid_encoding?
+                    content
+                  else
+                    { text: Base64.encode64(content), binary: true }
+                  end
+                end
                 broadcast_notification({ method: "$/file/load", params: { content: input } })
               end
             end

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -11,9 +11,7 @@ module Steep
       TypeCheckCodeJob = _ = Struct.new(:guid, :path, keyword_init: true)
       ValidateAppSignatureJob = _ = Struct.new(:guid, :path, keyword_init: true)
       ValidateLibrarySignatureJob = _ = Struct.new(:guid, :path, keyword_init: true)
-      GotoJob = _ = Struct.new(:id, :kind, :params, keyword_init: true) do
-        # @implements GotoJob
-
+      class GotoJob < Struct.new(:id, :kind, :params, keyword_init: true)
         def self.implementation(id:, params:)
           new(
             kind: :implementation,

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -66,11 +66,14 @@ module Steep
       def handle_request(request)
         case request[:method]
         when "initialize"
-          load_files(project: project, commandline_args: commandline_args)
           writer.write({ id: request[:id], result: nil})
 
         when "textDocument/didChange"
           collect_changes(request)
+
+        when "$/file/load"
+          input = request[:params][:content]
+          load_files(input)
 
         when "$/file/reset"
           uri = request[:params][:uri]

--- a/rbs_collection.steep.yaml
+++ b/rbs_collection.steep.yaml
@@ -23,3 +23,4 @@ gems:
   - name: securerandom
   - name: ffi
     ignore: true
+  - name: base64

--- a/sig/steep/server/change_buffer.rbs
+++ b/sig/steep/server/change_buffer.rbs
@@ -22,9 +22,11 @@ module Steep
       def pop_buffer: [A] () { (changes) -> A } -> A
                     | () -> changes
 
+      type content = String | { text: String, binary: true }
+
       # Load files from `project` to `buffered_changes`
       #
-      def load_files: (Hash[String, String] input) -> void
+      def load_files: (Hash[String, content] input) -> void
 
       # Load changes from a request with `DidChangeTextDocumentParams` into `buffered_changes`
       #

--- a/sig/steep/server/change_buffer.rbs
+++ b/sig/steep/server/change_buffer.rbs
@@ -24,7 +24,7 @@ module Steep
 
       # Load files from `project` to `buffered_changes`
       #
-      def load_files: (project: Project, commandline_args: Array[String]) -> void
+      def load_files: (Hash[String, String] input) -> void
 
       # Load changes from a request with `DidChangeTextDocumentParams` into `buffered_changes`
       #

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -110,7 +110,7 @@ module Steep
 
         def initialize: (project: Project) -> void
 
-        def load: (command_line_args: Array[String]) -> void
+        def load: (command_line_args: Array[String]) { (Hash[String, String]) -> void } -> void
 
         def push_changes: (Pathname path) -> void
 

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -213,7 +213,7 @@ module Steep
 
         attr_reader message: untyped
 
-        def initialize: (dest: WorkerProcess | :client, message: untyped) -> void
+        def self.new: (dest: WorkerProcess | :client, message: untyped) -> instance
 
         def self.to_worker: (WorkerProcess, message: untyped) -> SendMessageJob
 

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -110,7 +110,7 @@ module Steep
 
         def initialize: (project: Project) -> void
 
-        def load: (command_line_args: Array[String]) { (Hash[String, String]) -> void } -> void
+        def load: (command_line_args: Array[String]) { (Hash[String, ChangeBuffer::content]) -> void } -> void
 
         def push_changes: (Pathname path) -> void
 

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -82,7 +82,7 @@ module Steep
 
         attr_reader params: params
 
-        def initialize: (id: String, params: params, kind: kind) -> void
+        def self.new: (id: String, params: params, kind: kind) -> instance
 
         def self.implementation: (id: String, params: params) -> GotoJob
 

--- a/test/interaction_worker_test.rb
+++ b/test/interaction_worker_test.rb
@@ -53,6 +53,7 @@ EOF
       worker = InteractionWorker.new(project: project, reader: worker_reader, writer: worker_writer)
 
       worker.handle_request({ method: "initialize", id: 1, params: nil })
+      worker.handle_request({ method: "$/file/load", params: { content: {} } })
 
       q = flush_queue(worker.queue)
       assert_equal 1, q.size

--- a/test/master_type_check_controller_test.rb
+++ b/test/master_type_check_controller_test.rb
@@ -104,7 +104,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
 
       controller.target_paths[0].tap do |paths|
         assert_equal Set[current_dir + "lib/customer.rb"], paths.code_paths
@@ -137,7 +137,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
       controller.push_changes(current_dir + "lib/customer.rb")
@@ -177,7 +177,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
       controller.update_priority(open: current_dir + "lib/customer.rb")
@@ -213,7 +213,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
       assert_nil controller.make_request()
@@ -241,7 +241,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
       controller.update_priority(open: current_dir + "lib/customer.rb")
@@ -278,7 +278,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
       controller.update_priority(open: current_dir + "lib/customer.rb")
@@ -319,7 +319,7 @@ end
       Project::DSL.parse(project, steepfile.read)
 
       controller = Server::Master::TypeCheckController.new(project: project)
-      controller.load(command_line_args: [])
+      controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
       controller.update_priority(open: current_dir + "lib/customer.rb")

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -186,7 +186,6 @@ class TypeCheckWorkerTest < Minitest::Test
           reader: worker_reader,
           writer: worker_writer
         )
-        worker.load_files(project: worker.project, commandline_args: [])
 
         worker.handle_request(
           {
@@ -250,7 +249,6 @@ class TypeCheckWorkerTest < Minitest::Test
           reader: worker_reader,
           writer: worker_writer
         )
-        worker.load_files(project: worker.project, commandline_args: [])
 
         changes = {}
         changes[Pathname("lib/hello.rb")] = [Services::ContentChange.string(<<~RUBY)]
@@ -298,7 +296,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, "guid")
 
         {}.tap do |changes|
@@ -349,7 +346,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, nil)
 
         {}.tap do |changes|
@@ -396,7 +392,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, "guid")
 
         {}.tap do |changes|
@@ -450,7 +445,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, nil)
 
         {}.tap do |changes|
@@ -498,7 +492,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, "guid")
 
         {}.tap do |changes|
@@ -557,7 +550,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, "guid")
 
         {}.tap do |changes|
@@ -619,7 +611,6 @@ class TypeCheckWorkerTest < Minitest::Test
           writer: worker_writer
         )
 
-        worker.load_files(project: worker.project, commandline_args: [])
         worker.instance_variable_set(:@current_type_check_guid, nil)
 
         {}.tap do |changes|
@@ -682,35 +673,6 @@ RBS
         assert_equal "#{file_scheme}#{current_dir}/sig/foo.rbs", symbol.location[:uri].to_s
         assert_equal "NewClassName", symbol.container_name
       end
-    end
-  end
-
-  def test_loading_files_with_args
-    in_tmpdir do
-      project = Project.new(steepfile_path: current_dir + "Steepfile")
-      Project::DSL.parse(project, <<EOF)
-target :lib do
-  check "lib"
-  signature "sig"
-end
-EOF
-
-      (current_dir + "lib").mkdir
-      (current_dir + "lib/foo.rb").write("")
-      (current_dir + "lib/bar.rb").write("")
-
-      worker = Server::TypeCheckWorker.new(
-        project: project,
-        assignment: assignment,
-        commandline_args: [],
-        reader: worker_reader,
-        writer: worker_writer
-      )
-
-      worker.load_files(project: worker.project, commandline_args: ["lib/foo.rb"])
-      worker.service.update(changes: worker.pop_buffer) {}
-
-      assert_equal [Pathname("lib/foo.rb")], worker.service.source_files.keys
     end
   end
 


### PR DESCRIPTION
Loading Ruby scripts and app signature files in each worker processes causes busy disk IO. Loading all of the files in main process and send them with custom LSP events would improve the busy disk IO and make it faster.