### PR TITLE
Print `loading project` message via LSP

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -163,7 +163,7 @@ module Steep
   def self.new_logger(output, prev_level)
     logger = Logger.new(output)
     logger.formatter = proc do |severity, datetime, progname, msg|
-      "#{datetime.strftime('%Y-%m-%d %H:%M:%S')}: #{severity}: #{msg}\n"
+      "#{datetime.strftime('%Y-%m-%d %H:%M:%S.%L')}: #{severity}: #{msg}\n"
     end
     ActiveSupport::TaggedLogging.new(logger).tap do |logger|
       logger.push_tags "Steep #{VERSION}"

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -114,6 +114,7 @@ require "steep/services/stats_calculator"
 require "steep/services/file_loader"
 require "steep/services/goto_service"
 
+require "steep/server/work_done_progress"
 require "steep/server/delay_queue"
 require "steep/server/lsp_formatter"
 require "steep/server/change_buffer"

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -61,7 +61,7 @@ module Steep
 
         Steep.logger.info { "Initializing server" }
         initialize_id = request_id()
-        client_writer.write({ method: :initialize, id: initialize_id, params: {} })
+        client_writer.write({ method: :initialize, id: initialize_id, params: DEFAULT_CLI_LSP_INITIALIZE_PARAMS })
         wait_for_response_id(reader: client_reader, id: initialize_id)
 
         request_guid = SecureRandom.uuid

--- a/lib/steep/drivers/utils/driver_helper.rb
+++ b/lib/steep/drivers/utils/driver_helper.rb
@@ -83,6 +83,14 @@ module Steep
             severity <= LanguageServer::Protocol::Constant::DiagnosticSeverity::INFORMATION
           end
         end
+
+        (DEFAULT_CLI_LSP_INITIALIZE_PARAMS = {
+          capabilities: {
+            window: {
+              workDoneProgress: true
+            }
+          }
+        }).freeze
       end
     end
   end

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -59,7 +59,7 @@ module Steep
         end
 
         initialize_id = request_id()
-        client_writer.write(method: "initialize", id: initialize_id)
+        client_writer.write(method: "initialize", id: initialize_id, params: DEFAULT_CLI_LSP_INITIALIZE_PARAMS)
         wait_for_response_id(reader: client_reader, id: initialize_id)
 
         Steep.logger.info "Watching #{dirs.join(", ")}..."

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -55,12 +55,15 @@ module Steep
         super(project: project, reader: reader, writer: writer)
 
         @assignment = assignment
-        @service = Services::TypeCheckService.new(project: project)
         @buffered_changes = {}
         @mutex = Mutex.new()
         @queue = Queue.new
         @commandline_args = commandline_args
         @current_type_check_guid = nil
+      end
+
+      def service
+        @service ||= Services::TypeCheckService.new(project: project)
       end
 
       def handle_request(request)

--- a/lib/steep/server/work_done_progress.rb
+++ b/lib/steep/server/work_done_progress.rb
@@ -1,0 +1,64 @@
+module Steep
+  module Server
+    class WorkDoneProgress
+      attr_reader :sender, :guid, :percentage
+
+      def initialize(guid, &block)
+        @sender = block
+        @guid = guid
+        @percentage = 0
+      end
+
+      def begin(title, message = nil, request_id:)
+        sender.call(
+          {
+            id: request_id,
+            method: "window/workDoneProgress/create",
+            params: { token: guid }
+          }
+        )
+
+        value = { kind: "begin", cancellable: false, title: title, percentage: percentage }
+        value[:message] = message if message
+
+        sender.call(
+          {
+            method: "$/progress",
+            params: { token: guid, value: value }
+          }
+        )
+
+        self
+      end
+
+      def report(percentage, message = nil)
+        @percentage = percentage
+        value = { kind: "report", percentage: percentage }
+        value[:message] = message if message
+
+        sender.call(
+          {
+            method: "$/progress",
+            params: { token: guid, value: value }
+          }
+        )
+
+        self
+      end
+
+      def end(message = nil)
+        value = { kind: "end" }
+        value[:message] = message if message
+
+        sender.call(
+          {
+            method: "$/progress",
+            params: { token: guid, value: value }
+          }
+        )
+
+        self
+      end
+    end
+  end
+end

--- a/sig/steep/drivers/utils/driver_helper.rbs
+++ b/sig/steep/drivers/utils/driver_helper.rbs
@@ -19,6 +19,8 @@ module Steep
         def wait_for_message: (reader: Reader, ?unknown_messages: unknown_message_action) { (untyped) -> bool } -> untyped
 
         def keep_diagnostic?: (untyped diagnostic, severity_level: Diagnostic::LSPFormatter::severity) -> bool
+
+        DEFAULT_CLI_LSP_INITIALIZE_PARAMS: Hash[Symbol, untyped]
       end
     end
   end

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -6,6 +6,8 @@ module Steep
       class TypeCheckRequest
         attr_reader guid: String
 
+        attr_reader work_done_progress: WorkDoneProgress
+
         attr_reader library_paths: Set[Pathname]
 
         attr_reader signature_paths: Set[Pathname]
@@ -16,7 +18,7 @@ module Steep
 
         attr_reader checked_paths: Set[Pathname]
 
-        def initialize: (guid: String) -> void
+        def initialize: (guid: String, progress: WorkDoneProgress) -> void
 
         def uri: (Pathname path) -> URI::File
 
@@ -52,6 +54,7 @@ module Steep
       # controller.update_priority(open: file_path)  # Remember that an editor opens the path
       # controller.make_request(...)                 # Make an instance of TypeCheckRequest that contains list of all paths to type check
       # ```
+      #
       class TypeCheckController
         attr_reader project: Project
 
@@ -117,7 +120,17 @@ module Steep
         def update_priority: (open: Pathname) -> void
                            | (close: Pathname) -> void
 
-        def make_request: (?guid: String, ?last_request: TypeCheckRequest?, ?include_unchanged: bool) -> TypeCheckRequest?
+        # Returns a TypeCheckRequest that contains all paths to be type checked
+        #
+        # This method also resets the controller status by removing everything from `changed_paths`.
+        #
+        # * If `last_request:` is given, the remaining paths are also included in the new request.
+        # * If `include_unchanged` is `true`, all paths are included in the new request.
+        # * `progress:` is a `WorkDoneProgress` object to report the progress of the type checking.
+        #
+        # Returns `nil` when no type checking is needed.
+        #
+        def make_request: (?guid: String, ?last_request: TypeCheckRequest?, ?include_unchanged: bool, progress: WorkDoneProgress) -> TypeCheckRequest?
       end
 
       type lsp_notification = { method: String, params: untyped }
@@ -260,7 +273,7 @@ module Steep
 
       attr_reader result_controller: ResultController
 
-      attr_reader initialize_params: untyped
+      attr_reader initialize_params: Hash[Symbol, untyped]?
 
       attr_accessor typecheck_automatically: bool
 
@@ -291,15 +304,22 @@ module Steep
 
       def pathname: (String uri) -> Pathname?
 
-      def work_done_progress_supported?: () -> bool
+      def assign_initialize_params: (untyped) -> void
 
+      # Returns `true` if `DidChangeWatchedFiles` is supported by the client based on the `initialize` params
+      #
       def file_system_watcher_supported?: () -> bool
+
+      # Returns `true` if work done progress is supported by the client based on the `initialize` params
+      #
+      def work_done_progress_supported?: () -> bool
 
       def process_message_from_client: (untyped message) -> void
 
       def process_message_from_worker: (untyped message, worker: WorkerProcess) -> void
 
-      def start_type_check: (TypeCheckRequest request, last_request: TypeCheckRequest?, start_progress: bool) -> void
+      def start_type_check: (last_request: TypeCheckRequest?, progress: WorkDoneProgress, ?include_unchanged: bool, ?report_progress_threshold: Integer) -> void
+                          | (request: TypeCheckRequest, last_request: TypeCheckRequest?, ?report_progress_threshold: Integer) -> void
 
       def on_type_check_update: (guid: String, path: Pathname) -> void
 
@@ -314,6 +334,8 @@ module Steep
       def group_request: () { (GroupHandler) -> void } -> GroupHandler
 
       def enqueue_write_job: (SendMessageJob job) -> void
+
+      def work_done_progress: (String) -> WorkDoneProgress
     end
   end
 end

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -234,7 +234,25 @@ module Steep
 
       attr_reader typecheck_workers: Array[WorkerProcess]
 
+      # Queue for processing incoming jobs and postpone a work
+      #
+      # ```rb
+      # # Notify the *work/main* thread a message is arriving from a worker or client
+      # job_queue << ReceiveMessageJob.new(source: interaction_worker, message: message)
+      # ```
+      #
+      # ```rb
+      # job_queue.push(
+      #   -> do
+      #     puts "Doing something on the *work/main* thread"
+      #   end
+      # )
+      # ```
       attr_reader job_queue: Thread::Queue
+
+      # Queue for writing messages to the client and the workers
+      #
+      attr_reader write_queue: Thread::SizedQueue
 
       attr_reader current_type_check_request: TypeCheckRequest?
 
@@ -294,6 +312,8 @@ module Steep
       def send_request: (method: String, worker: WorkerProcess, ?id: String, ?params: untyped?) ?{ (ResultHandler) -> void } -> ResultHandler
 
       def group_request: () { (GroupHandler) -> void } -> GroupHandler
+
+      def enqueue_write_job: (SendMessageJob job) -> void
     end
   end
 end

--- a/sig/steep/server/work_done_progress.rbs
+++ b/sig/steep/server/work_done_progress.rbs
@@ -1,0 +1,19 @@
+module Steep
+  module Server
+    class WorkDoneProgress
+      attr_reader sender: ^(untyped message) -> void
+
+      attr_reader guid: String
+
+      attr_reader percentage: Integer
+
+      def initialize: (String guid) { (untyped message) -> void } -> void
+
+      def begin: (String title, ?String? message, request_id: String) -> self
+
+      def report: (Integer percentage, ?String? message) -> self
+
+      def end: (?String? message) -> self
+    end
+  end
+end

--- a/test/lsp_double.rb
+++ b/test/lsp_double.rb
@@ -53,7 +53,7 @@ class LSPDouble
       end
     end
 
-    send_request(id: next_request_id, method: "initialize") { }
+    send_request(id: next_request_id, method: "initialize", params: {}) { }
     send_notification(method: "initialized", params: {})
 
     if block_given?

--- a/test/master_type_check_controller_test.rb
+++ b/test/master_type_check_controller_test.rb
@@ -7,6 +7,7 @@ class MasterTypeCheckControllerTest < Minitest::Test
 
   include Steep
   TypeCheckController = Server::Master::TypeCheckController
+  WorkDoneProgress = Server::WorkDoneProgress
 
   def dirs
     @dirs ||= []
@@ -216,7 +217,7 @@ end
       controller.load(command_line_args: []) {}
       controller.changed_paths.clear()
 
-      assert_nil controller.make_request()
+      assert_nil controller.make_request(progress: WorkDoneProgress.new("guid") {})
     end
   end
 
@@ -247,7 +248,7 @@ end
       controller.update_priority(open: current_dir + "lib/customer.rb")
       controller.push_changes(current_dir + "sig/customer.rbs")
 
-      request = controller.make_request()
+      request = controller.make_request(progress: WorkDoneProgress.new("guid") {})
       assert_equal Set[current_dir + "sig/customer.rbs"], request.signature_paths
       assert_equal Set[current_dir + "lib/customer.rb"], request.code_paths
       assert_equal Set[current_dir + "lib/customer.rb"], request.priority_paths
@@ -284,7 +285,7 @@ end
       controller.update_priority(open: current_dir + "lib/customer.rb")
       controller.push_changes(current_dir + "lib/customer.rb")
 
-      request = controller.make_request()
+      request = controller.make_request(progress: WorkDoneProgress.new("guid") {})
       assert_equal Set[], request.signature_paths
       assert_equal Set[current_dir + "lib/customer.rb"], request.code_paths
       assert_equal Set[current_dir + "lib/customer.rb"], request.priority_paths
@@ -325,12 +326,12 @@ end
       controller.update_priority(open: current_dir + "lib/customer.rb")
       controller.push_changes(current_dir + "lib/customer.rb")
 
-      last_request = Server::Master::TypeCheckRequest.new(guid: "last_guid")
+      last_request = Server::Master::TypeCheckRequest.new(guid: "last_guid", progress: WorkDoneProgress.new("guid") {})
       last_request.code_paths << current_dir + "lib/account.rb"
       last_request.signature_paths << current_dir + "sig/account.rbs"
       last_request.library_paths << RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "integer.rbs"
 
-      request = controller.make_request(last_request: last_request)
+      request = controller.make_request(last_request: last_request, progress: WorkDoneProgress.new("guid") {})
       assert_equal Set[current_dir + "sig/account.rbs"], request.signature_paths
       assert_equal Set[current_dir + "lib/customer.rb", current_dir + "lib/account.rb"], request.code_paths
       assert_equal Set[current_dir + "lib/customer.rb"], request.priority_paths

--- a/test/master_type_check_request_test.rb
+++ b/test/master_type_check_request_test.rb
@@ -12,12 +12,12 @@ class MasterTypeCheckRequestTest < Minitest::Test
   end
 
   def test_request
-    Server::Master::TypeCheckRequest.new(guid: "guid")
+    Server::Master::TypeCheckRequest.new(guid: "guid", progress: Server::WorkDoneProgress.new("guid"))
   end
 
   def test_as_json_all
     in_tmpdir do
-      request = Server::Master::TypeCheckRequest.new(guid: "guid")
+      request = Server::Master::TypeCheckRequest.new(guid: "guid", progress: Server::WorkDoneProgress.new("guid"))
 
       request.library_paths << (RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs")
       request.signature_paths << (current_dir + "sig/user.rbs")
@@ -40,7 +40,7 @@ class MasterTypeCheckRequestTest < Minitest::Test
 
   def test_as_json_none
     in_tmpdir do
-      request = Server::Master::TypeCheckRequest.new(guid: "guid")
+      request = Server::Master::TypeCheckRequest.new(guid: "guid", progress: Server::WorkDoneProgress.new("guid"))
 
       request.library_paths << (RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs")
       request.signature_paths << (current_dir + "sig/user.rbs")
@@ -63,7 +63,7 @@ class MasterTypeCheckRequestTest < Minitest::Test
 
   def test_progress
     in_tmpdir do
-      request = Server::Master::TypeCheckRequest.new(guid: "guid")
+      request = Server::Master::TypeCheckRequest.new(guid: "guid", progress: Server::WorkDoneProgress.new("guid"))
       request.library_paths << (RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs")
       request.signature_paths << (current_dir + "sig/user.rbs")
       request.code_paths << (current_dir + "lib/user.rb")


### PR DESCRIPTION
Loading bigger project takes seconds, and the language server blocks while scanning all of the files. This PR shows a progress message with `loading project` to let the users know what is happening.