### PR TITLE
No `timeout: nil`

### DIFF
--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -1025,7 +1025,7 @@ module Steep
 
       def enqueue_write_job(job)
         Steep.logger.info { "Write_queue has #{write_queue.size} items"}
-        write_queue.push(job, timeout: nil)
+        write_queue.push(job) # steep:ignore InsufficientKeywordArguments
       end
 
       def work_done_progress(guid)


### PR DESCRIPTION
Test fails with `ThreadError` on `#push` with ruby-3.0 and ruby-3.1.

```
/home/runner/work/steep/steep/lib/steep/server/master.rb:1028:in `push': queue full (ThreadError)
```

This is because the `timeout:` keyword arg is introduced at Ruby 3.2, so the `push(object, timeout: nil)` is equivalent to `push(object, true)` which means raising error immediately when queue is full.

Deleting `timeout: nil` would solve the problem.