### PR TITLE
Revert implicit generic upper bound

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -50,7 +50,7 @@ module Steep
         end
 
         def upper_bound(a)
-          variable_bounds.fetch(a, Interface::TypeParam::IMPLICIT_UPPER_BOUND)
+          variable_bounds.fetch(a, nil)
         end
       end
 

--- a/lib/steep/interface/type_param.rb
+++ b/lib/steep/interface/type_param.rb
@@ -1,8 +1,6 @@
 module Steep
   module Interface
     class TypeParam
-      IMPLICIT_UPPER_BOUND = AST::Builtin.optional(AST::Builtin::Object.instance_type)
-      
       attr_reader :name
       attr_reader :upper_bound
       attr_reader :variance

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -331,23 +331,25 @@ module Steep
           end
 
         when relation.super_type.is_a?(AST::Types::Var) && constraints.unknown?(relation.super_type.name)
-          ub = variable_upper_bound(relation.super_type.name) || Interface::TypeParam::IMPLICIT_UPPER_BOUND
-
-          Expand(relation) do
-            check_type(Relation.new(sub_type: relation.sub_type, super_type: ub))
-          end.tap do |result|
-            if result.success?
-              constraints.add(relation.super_type.name, sub_type: relation.sub_type)
+          if ub = variable_upper_bound(relation.super_type.name)
+            Expand(relation) do
+              check_type(Relation.new(sub_type: relation.sub_type, super_type: ub))
+            end.tap do |result|
+              if result.success?
+                constraints.add(relation.super_type.name, sub_type: relation.sub_type)
+              end
             end
+          else
+            constraints.add(relation.super_type.name, sub_type: relation.sub_type)
+            Success(relation)
           end
 
         when relation.sub_type.is_a?(AST::Types::Var) && constraints.unknown?(relation.sub_type.name)
           constraints.add(relation.sub_type.name, super_type: relation.super_type)
           Success(relation)
 
-        when relation.sub_type.is_a?(AST::Types::Var)
+        when relation.sub_type.is_a?(AST::Types::Var) && ub = variable_upper_bound(relation.sub_type.name)
           Expand(relation) do
-            ub = variable_upper_bound(relation.sub_type.name) || Interface::TypeParam::IMPLICIT_UPPER_BOUND
             check_type(Relation.new(sub_type: ub, super_type: relation.super_type))
           end
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3848,17 +3848,21 @@ module Steep
 
           type_args.each_with_index do |type, index|
             param = method_type.type_params[index]
-            upper_bound = param.upper_bound || Interface::TypeParam::IMPLICIT_UPPER_BOUND
-            if result = no_subtyping?(sub_type: type.value, super_type: upper_bound)
-              args_ << AST::Builtin.any_type
-              constr.typing.add_error(
-                Diagnostic::Ruby::TypeArgumentMismatchError.new(
-                  type_arg: type.value,
-                  type_param: param,
-                  result: result,
-                  location: type.location
+
+            if upper_bound = param.upper_bound
+              if result = no_subtyping?(sub_type: type.value, super_type: upper_bound)
+                args_ << AST::Builtin.any_type
+                constr.typing.add_error(
+                  Diagnostic::Ruby::TypeArgumentMismatchError.new(
+                    type_arg: type.value,
+                    type_param: param,
+                    result: result,
+                    location: type.location
+                  )
                 )
-              )
+              else
+                args_ << type.value
+              end
             else
               args_ << type.value
             end

--- a/sig/steep/interface/type_param.rbs
+++ b/sig/steep/interface/type_param.rbs
@@ -1,12 +1,6 @@
 module Steep
   module Interface
     class TypeParam
-      # Implicit upper bound given to unqualified generic parameter
-      #
-      # It's `Object?` currently.
-      # 
-      IMPLICIT_UPPER_BOUND: AST::Types::t
-
       type loc = RBS::Location[untyped, untyped]
 
       type variance = RBS::AST::TypeParam::variance

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2189,36 +2189,6 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
-  def test_generics_upperbound_implicitly_object
-    run_type_check_test(
-      signatures: {
-        "a.rbs" => <<~RBS
-          class Foo
-            def foo: [X] (X) -> void
-          end
-        RBS
-      },
-      code: {
-        "a.rb" => <<~RUBY
-          class Foo
-            def foo(x)
-              x.nil?
-            end
-          end
-
-          foo = Foo.new
-          foo.foo("")
-          foo.foo(NilClass.new)
-        RUBY
-      },
-      expectations: <<~YAML
-        ---
-        - file: a.rb
-          diagnostics: []
-      YAML
-    )
-  end
-
   def test_generics_upperbound_default
     run_type_check_test(
       signatures: {


### PR DESCRIPTION
Found that the implicit upper bound causes issues with `void` and interface types. 😢 