### PR TITLE
Support optional keys in record types

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -599,6 +599,10 @@ module Steep
             overloads: record.elements.map do |key_value, value_type|
               key_type = AST::Types::Literal.new(value: key_value)
 
+              if record.optional?(key_value)
+                value_type = AST::Builtin.optional(value_type)
+              end
+
               Shape::MethodOverload.new(
                 MethodType.new(
                   type_params: [],

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -497,13 +497,19 @@ module Steep
         when relation.sub_type.is_a?(AST::Types::Record) && relation.super_type.is_a?(AST::Types::Record)
           All(relation) do |result|
             relation.super_type.elements.each_key do |key|
-              rel = Relation.new(
-                sub_type: relation.sub_type.elements[key] || AST::Builtin.nil_type,
-                super_type: relation.super_type.elements[key]
-              )
+              super_element_type = relation.super_type.elements[key]
 
-              result.add(rel) do
-                check_type(rel)
+              if relation.sub_type.elements.key?(key)
+                sub_element_type = relation.sub_type.elements[key]
+              else
+                if relation.super_type.required?(key)
+                  sub_element_type = AST::Builtin.nil_type
+                end
+              end
+
+              if sub_element_type
+                rel = Relation.new(sub_type: sub_element_type, super_type: super_element_type)
+                result.add(rel) { check_type(rel) }
               end
             end
           end

--- a/lib/steep/subtyping/constraints.rb
+++ b/lib/steep/subtyping/constraints.rb
@@ -174,9 +174,7 @@ module Steep
             types: type.types.map {|ty| eliminate_variable(ty, to: AST::Builtin.any_type) }
           )
         when AST::Types::Record
-          AST::Types::Record.new(
-            elements: type.elements.transform_values {|ty| eliminate_variable(ty, to: AST::Builtin.any_type) }
-          )
+          type.map_type { eliminate_variable(_1, to: AST::Builtin.any_type) }
         when AST::Types::Proc
           type.map_type {|ty| eliminate_variable(ty, to: AST::Builtin.any_type) }
         else

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -4962,7 +4962,7 @@ module Steep
       each_child_node(hash_node) do |child|
         if child.type == :pair
           case child.children[0].type
-          when :sym, :str, :int
+          when :sym
             key_node = child.children[0] #: Parser::AST::Node
             value_node = child.children[1] #: Parser::AST::Node
 
@@ -4991,7 +4991,7 @@ module Steep
         end
       end
 
-      type = AST::Types::Record.new(elements: elems)
+      type = AST::Types::Record.new(elements: elems, required_keys: record_type&.required_keys || Set.new(elems.keys))
       constr.add_typing(hash_node, type: type)
     end
 

--- a/lib/steep/type_inference/send_args.rb
+++ b/lib/steep/type_inference/send_args.rb
@@ -656,7 +656,7 @@ module Steep
                       errors << ts
                     when Array
                       pairs = keys.zip(ts) #: Array[[Symbol, AST::Types::t]]
-                      record = AST::Types::Record.new(elements: Hash[pairs])
+                      record = AST::Types::Record.new(elements: Hash[pairs], required_keys: Set.new(keys))
                       yield KeywordArgs::ArgTypePairs.new(pairs: [[a.node, record]])
                     end
                   else

--- a/sig/steep/ast/types/record.rbs
+++ b/sig/steep/ast/types/record.rbs
@@ -6,7 +6,9 @@ module Steep
 
         attr_reader elements: Hash[key, t]
 
-        def initialize: (elements: Hash[key, t]) -> void
+        attr_reader required_keys: Set[key]
+
+        def initialize: (elements: Hash[key, t], required_keys: Set[key]) -> void
 
         def ==: (untyped other) -> bool
 
@@ -29,6 +31,10 @@ module Steep
         def map_type: () { (t) -> t } -> Record
 
         def level: () -> Array[Integer]
+
+        def required?: (key) -> bool
+
+        def optional?: (key) -> bool
       end
     end
   end

--- a/smoke/hash/test_expectations.yml
+++ b/smoke/hash/test_expectations.yml
@@ -61,8 +61,8 @@
         character: 66
     severity: ERROR
     message: |-
-      Cannot assign a value of type `{ :email => ::String, :id => ::String, :name => ::String }` to a variable of type `{ :id => ::Integer, :name => ::String }`
-        { :email => ::String, :id => ::String, :name => ::String } <: { :id => ::Integer, :name => ::String }
+      Cannot assign a value of type `{ ?:email => ::String, :id => ::String, :name => ::String }` to a variable of type `{ :id => ::Integer, :name => ::String }`
+        { ?:email => ::String, :id => ::String, :name => ::String } <: { :id => ::Integer, :name => ::String }
           ::String <: ::Integer
             ::Object <: ::Integer
               ::BasicObject <: ::Integer


### PR DESCRIPTION
The semantics of optional keys in record in Steep is *the hash may not have any value associated with the optional key*.

So, 

1. Assigning a hash without the optional key is allowed -- `{ id: 123 } #: { id: Integer, ?name: String }`
2. Having incompatible type with the optional key is prohibited (but, it causes unsoundness...)
3. The `#[]` operator of the record type returns an optional type, `#fetch` returns non-optional type (if the value type is not an optional)