### PR TITLE
Add special path for `Kernel#class` method

### DIFF
--- a/lib/steep/ast/builtin.rb
+++ b/lib/steep/ast/builtin.rb
@@ -65,6 +65,7 @@ module Steep
       Regexp = Type.new("::Regexp")
       NilClass = Type.new("::NilClass")
       Proc = Type.new("::Proc")
+      Kernel = Type.new("::Kernel")
 
       def self.nil_type
         AST::Types::Nil.instance

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2657,34 +2657,11 @@ module Steep
     def synthesize_sendish(node, hint:, tapp:)
       case node.type
       when :send
-        yield_self do
-          if self_class?(node)
-            module_type = expand_alias(module_context.module_type)
-            type = if module_type.is_a?(AST::Types::Name::Singleton)
-                     AST::Types::Name::Singleton.new(name: module_type.name)
-                   else
-                     module_type
-                   end
-
-            add_typing(node, type: type)
-          else
-            type_send(node, send_node: node, block_params: nil, block_body: nil, tapp: tapp, hint: hint)
-          end
-        end
+        type_send(node, send_node: node, block_params: nil, block_body: nil, tapp: tapp, hint: hint)
       when :csend
         yield_self do
           send_type, constr =
-            if self_class?(node)
-              module_type = expand_alias(module_context.module_type)
-              type = if module_type.is_a?(AST::Types::Name::Singleton)
-                       AST::Types::Name::Singleton.new(name: module_type.name)
-                     else
-                       module_type
-                     end
-              add_typing(node, type: type).to_ary
-            else
-              type_send(node, send_node: node, block_params: nil, block_body: nil, unwrap: true, tapp: tapp, hint: hint).to_ary
-            end
+            type_send(node, send_node: node, block_params: nil, block_body: nil, unwrap: true, tapp: tapp, hint: hint).to_ary
 
           constr
             .update_type_env { context.type_env.join(constr.context.type_env, context.type_env) }
@@ -4685,10 +4662,6 @@ module Steep
       end
 
       add_typing node, type: AST::Builtin.any_type
-    end
-
-    def self_class?(node)
-      node.type == :send && node.children[0]&.type == :self && node.children[1] == :class
     end
 
     def namespace_module?(node)

--- a/sig/steep/ast/builtin.rbs
+++ b/sig/steep/ast/builtin.rbs
@@ -49,6 +49,8 @@ module Steep
 
       Proc: Type
 
+      Kernel: Type
+
       def self.nil_type: () -> Types::Nil
 
       def self.any_type: () -> Types::Any

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -110,6 +110,8 @@ module Steep
 
       def replace_primitive_method: (method_name, RBS::Definition::Method::TypeDef, MethodType) -> MethodType
 
+      def replace_kernel_class: (method_name, RBS::Definition::Method::TypeDef, MethodType) { () -> AST::Types::t } -> MethodType
+
       @subtyping: Subtyping::Check?
 
       def subtyping: () -> Subtyping::Check

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -393,9 +393,6 @@ module Steep
 
     def fallback_to_any: (Parser::AST::Node node) ?{ () -> Diagnostic::Ruby::Base } -> Pair
 
-    # Return `true` if `node` is `self.class`
-    def self_class?: (Parser::AST::Node node) -> bool
-
     # Returns `true` if the given `node` is a `class` or `module` declaration that only contains module/class definitions
     #
     def namespace_module?: (Parser::AST::Node node) -> bool

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2349,13 +2349,34 @@ class TypeCheckTest < Minitest::Test
       },
       code: {
         "a.rb" => <<~RUBY
-          Foo.new(1).class.new(2)
+          Foo.new(1).class.fooo
+          Foo.class.barr
         RUBY
       },
       expectations: <<~YAML
         ---
         - file: a.rb
-          diagnostics: []
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 17
+              end:
+                line: 1
+                character: 21
+            severity: ERROR
+            message: Type `singleton(::Foo)` does not have method `fooo`
+            code: Ruby::NoMethod
+          - range:
+              start:
+                line: 2
+                character: 10
+              end:
+                line: 2
+                character: 14
+            severity: ERROR
+            message: Type `::Class` does not have method `barr`
+            code: Ruby::NoMethod
       YAML
     )
   end


### PR DESCRIPTION
It cannot be written with `class` and other ways in RBS.

Related to https://github.com/ruby/rbs/pull/2020