### PR TITLE
Update filename example in initial Steepfile

### DIFF
--- a/lib/steep/drivers/init.rb
+++ b/lib/steep/drivers/init.rb
@@ -14,7 +14,7 @@ module Steep
       #   signature "sig"
       #
       #   check "lib"                       # Directory name
-      #   check "Gemfile"                   # File name
+      #   check "path/to/source.rb"         # File name
       #   check "app/models/**/*.rb"        # Glob
       #   # ignore "lib/templates/*.rb"
       #


### PR DESCRIPTION
As far as I know, Steep does not support type checking Gemfile. Therefore it's not good to use `Gemfile` as an example for specifying specific file.

This replaces it with actual .rb file case.


As a trial, I uncommented the line and tried to check `Gemfile`. But I got the following errors:

```
tkomiya@tarf> bundle exec steep check                                                                                                                                      ~/work/tmp/tmptmp
# Type checking files:

...................................................................F................

Gemfile:3:0: [error] Type `::Object` does not have method `source`
│ Diagnostic ID: Ruby::NoMethod
│
└ source "https://rubygems.org"
  ~~~~~~

Gemfile:5:0: [error] Type `::Object` does not have method `gem`
│ Diagnostic ID: Ruby::NoMethod
│
└ gem "steep", require: false
  ~~~

Detected 2 problems from 1 file
```