### PR TITLE
Fix LSP workers crash on file removal

### DIFF
--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -97,7 +97,7 @@ module Steep
         when CustomMethods::FileReset::METHOD
           params = request[:params] #: CustomMethods::FileReset::params
           uri = params[:uri]
-          text = params[:content]
+          text = params[:content] || ""
           reset_change(uri: uri, text: text)
           queue_job ApplyChangeJob.new
 

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -81,7 +81,7 @@ module Steep
         when CustomMethods::FileReset::METHOD
           params = request[:params] #: CustomMethods::FileReset::params
           uri = params[:uri]
-          text = params[:content]
+          text = params[:content] || ""
           reset_change(uri: uri, text: text)
 
         when "workspace/symbol"


### PR DESCRIPTION
When a file is removed, VSCode sends a `$/file/reset` request where the content field is nil.

For example, the following request is sent from VSCode:

```
[Steep 1.7.1] [interaction:interaction] [frontend] request={:method=>"$/file/reset", :params=>{:uri=>"file:///Users/tkomiya/work/tmp/tmp/sig/app.rbs", :content=>nil}, :jsonrpc=>"2.0"}
```

This update adds fallbacks to an empty string when the content is nil.

Closes #1236