### PR TITLE
Fix record shape

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -586,7 +586,7 @@ module Steep
 
       def record_shape(record)
         all_key_type = AST::Types::Union.build(
-          types: record.elements.each_key.map {|value| AST::Types::Literal.new(value: value) }
+          types: record.elements.each_key.map {|value| AST::Types::Literal.new(value: value).back_type }
         )
         all_value_type = AST::Types::Union.build(types: record.elements.values)
         hash_type = AST::Builtin::Hash.instance_type(all_key_type, all_value_type)

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -337,7 +337,7 @@ end
 
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:id) -> ::Integer"))
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name) -> ::String"))
-        assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name | :id) -> (::String | ::Integer)"))
+        assert_includes(shape.methods[:[]].method_types, parse_method_type("(::Symbol) -> (::String | ::Integer)"))
 
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:id, ::Integer) -> ::Integer"))
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:name, ::String) -> ::String"))
@@ -346,8 +346,8 @@ end
         assert_includes(shape.methods[:fetch].method_types, parse_method_type("(:name) -> ::String"))
         assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id, T) -> (::Integer | T)"))
         assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name, T) -> (::String | T)"))
-        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id) { (:id | :name) -> T } -> (::Integer | T)"))
-        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name) { (:id | :name) -> T } -> (::String | T)"))
+        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id) { (::Symbol) -> T } -> (::Integer | T)"))
+        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name) { (::Symbol) -> T } -> (::String | T)"))
       end
 
       builder.shape(parse_type("{ id: ::Integer, name: self }"), config).tap do |shape|
@@ -355,7 +355,7 @@ end
 
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:id) -> ::Integer"))
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name) -> self"))
-        assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name | :id) -> (self | ::Integer)"))
+        assert_includes(shape.methods[:[]].method_types, parse_method_type("(::Symbol) -> (self | ::Integer)"))
 
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:id, ::Integer) -> ::Integer"))
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:name, self) -> self"))
@@ -364,8 +364,8 @@ end
         assert_includes(shape.methods[:fetch].method_types, parse_method_type("(:name) -> self"))
         assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id, T) -> (::Integer | T)"))
         assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name, T) -> (self | T)"))
-        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id) { (:id | :name) -> T } -> (::Integer | T)"))
-        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name) { (:id | :name) -> T } -> (self | T)"))
+        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:id) { (::Symbol) -> T } -> (::Integer | T)"))
+        assert_includes(shape.methods[:fetch].method_types, parse_method_type("[T] (:name) { (::Symbol) -> T } -> (self | T)"))
       end
     end
   end


### PR DESCRIPTION
Add a default overloading with the *backtype* of the keys, instead of the union of the key types.

```rb
hash = { id: 123, name: "foo" } #: { id: Integer, name: String }
hash[:id]              # => Integer
hash[:name]            # => String
hash["id".to_sym]      # => Integer | String, not a type error
```

This is more consistent with tuple types.