### PR TITLE
Support &method(:name) call for block_pass

### DIFF
--- a/lib/steep/ast/builtin.rb
+++ b/lib/steep/ast/builtin.rb
@@ -66,6 +66,7 @@ module Steep
       NilClass = Type.new("::NilClass")
       Proc = Type.new("::Proc")
       Kernel = Type.new("::Kernel")
+      Method = Type.new("::Method")
 
       def self.nil_type
         AST::Types::Nil.instance

--- a/lib/steep/interface/function.rb
+++ b/lib/steep/interface/function.rb
@@ -1057,6 +1057,19 @@ module Steep
         )
       end
 
+      def accept_one_arg?
+        return false unless params
+        return false unless params.keyword_params.requireds.empty?
+        head = params.positional_params or return false
+
+        case head.head
+        when Params::PositionalParams::Required
+          !head.tail.is_a?(Params::PositionalParams::Required)
+        else
+          true
+        end
+      end
+
       def to_s
         if params
           "#{params} -> #{return_type}"

--- a/lib/steep/interface/method_type.rb
+++ b/lib/steep/interface/method_type.rb
@@ -320,6 +320,11 @@ module Steep
           block: block
         )
       end
+
+      def accept_one_arg?
+        return false if block && block.required?
+        type.accept_one_arg?
+      end
     end
   end
 end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2401,8 +2401,8 @@ module Steep
             if value_node
               type, constr = synthesize(value_node, hint: hint)
 
-              if hint.is_a?(AST::Types::Proc) && value_node.type == :send && value_node.children[1] == :method && type.is_a?(AST::Types::Name::Instance) && type.name.to_s == '::Method'
-                method_name = value_node.children[2].children[0]
+              if hint.is_a?(AST::Types::Proc) && value_node.type == :send && value_node.children[1] == :method && AST::Builtin::Method.instance_type?(type)
+                method_name = value_node.children[2].children[0] #: Symbol
                 if method = calculate_interface(AST::Types::Self.instance, private: true)&.methods&.[](method_name)
                   # TODO: select appropriate method type from `method.method_types`.
                   type = AST::Types::Proc.new(

--- a/sig/steep/ast/builtin.rbs
+++ b/sig/steep/ast/builtin.rbs
@@ -51,6 +51,8 @@ module Steep
 
       Kernel: Type
 
+      Method: Type
+
       def self.nil_type: () -> Types::Nil
 
       def self.any_type: () -> Types::Any

--- a/sig/steep/interface/function.rbs
+++ b/sig/steep/interface/function.rbs
@@ -263,6 +263,17 @@ module Steep
 
       def with: (?params: Params?, ?return_type: AST::Types::t) -> Function
 
+      # Returns true if the type accept one argument
+      #
+      # ```rbs
+      # (String) -> bool            # true
+      # (String, ?untyped) -> bool  # true
+      # (*untyped) -> bool          # true
+      # (String, untyped) -> bool   # false
+      # () -> bool                  # false
+      # ```
+      def accept_one_arg?: () -> bool
+
       def to_s: () -> ::String
 
       def closed?: () -> bool

--- a/sig/steep/interface/method_type.rbs
+++ b/sig/steep/interface/method_type.rbs
@@ -98,6 +98,10 @@ module Steep
       # * Ignores all type parameters.
       #
       def &: (MethodType other) -> MethodType?
+
+      # Returns true if the method accepts one argument, no keyword arguments, and no block
+      # 
+      def accept_one_arg?: () -> bool
     end
   end
 end


### PR DESCRIPTION
Pass `&method(:name)` to the block argument on method call is usually used, and well-known idiom in Ruby.  Therefore it is valuable to support the idiom on type check.

This gives a special treatment to it to support type checking.