### PR TITLE
Fix untyped hash typing

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1434,10 +1434,10 @@ module Steep
               case hint
               when AST::Types::Any, AST::Types::Top, AST::Types::Void
                 # ok
-              when hint == pair.type
-                # ok
               else
-                pair.constr.typing.add_error Diagnostic::Ruby::FallbackAny.new(node: node)
+                unless hint == pair.type
+                  pair.constr.typing.add_error Diagnostic::Ruby::FallbackAny.new(node: node)
+                end
               end
             end
           end
@@ -5054,7 +5054,7 @@ module Steep
           if (type_, constr = yield(type, constr))
             constr.check_relation(sub_type: type_, super_type: type).then do
               constr = constr.save_typing
-              return Pair.new(type: type, constr: constr)
+              return Pair.new(type: type_, constr: constr)
             end
           end
         end

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -501,7 +501,7 @@ module Steep
     #
     def type_hash: (Parser::AST::Node hash_node, hint: AST::Types::t?) -> Pair
 
-    # Returns the first one from elements of `types` that returns a type `t` where `t <: hint`.
+    # Yield each member included in `types` and returns the first one where the type `<:` hint
     #
     def pick_one_of: (Array[AST::Types::t] types) { (AST::Types::t hint, TypeConstruction) -> Pair? } -> Pair?
 

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2464,4 +2464,23 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_untyped_hash
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          { foo: 1} #: Hash[untyped, untyped] | String
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
Having a hint of union type with `Hash[untyped, untyped]` caused unexpected `FallbackAny` diagnostics.

```rbs
# Assume `joins` has `*String | Symbol | Hash[untyped, untyped]` type
Account.joins(group: :category)    # => The argument has `FallbackAny` diagnostic
```

This PR fixes the problem.