### PR TITLE
Handle file deletion notification

### DIFF
--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -472,10 +472,9 @@ module Steep
               controller.push_changes(path)
 
               case type
-              when 1, 2
+              when LSP::Constant::FileChangeType::CREATED, LSP::Constant::FileChangeType::CHANGED
                 content = path.read
-              when 4
-                # Deleted
+              when LSP::Constant::FileChangeType::DELETED
                 content = ""
               end
 

--- a/sig/shims/language-server_protocol.rbs
+++ b/sig/shims/language-server_protocol.rbs
@@ -142,6 +142,14 @@ module LanguageServer
       end
 
       TextDocumentSyncKind: __todo__
+
+      module FileChangeType
+        CREATED: 1
+        CHANGED: 2
+        DELETED: 3
+
+        type t = 1 | 2 | 3
+      end
     end
 
     module Interface


### PR DESCRIPTION
The `DELETED` notification is `3`, not `4`, and caused unexpected `nil` content sent to workers.

Closes #1236 #1237 