### PR TITLE
Install rbs collection automatically

### DIFF
--- a/sig/steep/drivers/utils/driver_helper.rbs
+++ b/sig/steep/drivers/utils/driver_helper.rbs
@@ -6,7 +6,12 @@ module Steep
       module DriverHelper
         attr_accessor steepfile: Pathname?
 
+        # `true` to install rbs collection automatically
+        attr_accessor disable_install_collection: bool
+
         def load_config: (?path: Pathname) -> Project
+
+        def install_collection: (Project::Target, Pathname config_path) -> void
 
         def request_id: () -> String
 

--- a/test/driver_helper_test.rb
+++ b/test/driver_helper_test.rb
@@ -12,6 +12,8 @@ class DriverHelperTest < Minitest::Test
   def setup
     @log_output = Steep.log_output
     Steep.log_output = StringIO.new
+    @prev_level = Steep.ui_logger.level
+    Steep.ui_logger.level = Logger::DEBUG
 
     super
   end
@@ -20,6 +22,7 @@ class DriverHelperTest < Minitest::Test
     super
 
     Steep.log_output = @log_output
+    Steep.ui_logger.level = @prev_level
   end
 
   class Test
@@ -63,7 +66,7 @@ class DriverHelperTest < Minitest::Test
       RUBY
 
       Test.new.load_config(path: path)
-      assert_match /rbs-collection setup is broken/, Steep.log_output.string
+      assert_match /rbs-collection configuration is missing/, Steep.log_output.string
     end
   end
 
@@ -94,11 +97,12 @@ class DriverHelperTest < Minitest::Test
       current_dir.join("test.lock.yaml").write("[")
 
       Test.new.load_config(path: path)
-      assert_match /rbs collection install/, Steep.log_output.string
+      assert_match /rbs-collection setup is broken:/, Steep.log_output.string
+      assert_match /syntax error/, Steep.log_output.string
     end
   end
 
-  def test_load_config_error__collection_not_installed
+  def test_load_config__install_from_lockfile
     in_tmpdir do
       path = current_dir.join("Steepfile")
       path.write(<<~RUBY)
@@ -115,14 +119,109 @@ class DriverHelperTest < Minitest::Test
 
         # A directory to install the downloaded RBSs
         path: .gem_rbs_collection
+
+        gems:
+          - name: activesupport
       YAML
       current_dir.join("test.lock.yaml").write(<<~YAML)
         path: .gem_rbs_collection
-        gems: []
+        gems:
+        - name: activesupport
+          version: '7.0'
+          source:
+            type: git
+            name: ruby/gem_rbs_collection
+            revision: c42c09528dd99252db98f0744181a6de54ec2f55
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            repo_dir: gems
       YAML
 
       Test.new.load_config(path: path)
+
+      assert_match /Installing RBS files for collection: /, Steep.log_output.string
+    end
+  end
+
+  def test_load_config__install_from_lockfile__disabled
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          collection_config "test.yaml"
+        end
+      RUBY
+      current_dir.join("test.yaml").write(<<~YAML)
+        sources:
+          - name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: c42c09528dd99252db98f0744181a6de54ec2f55
+            repo_dir: gems
+
+        # A directory to install the downloaded RBSs
+        path: .gem_rbs_collection
+
+        gems:
+          - name: activesupport
+      YAML
+      current_dir.join("test.lock.yaml").write(<<~YAML)
+        path: .gem_rbs_collection
+        gems:
+        - name: activesupport
+          version: '7.0'
+          source:
+            type: git
+            name: ruby/gem_rbs_collection
+            revision: c42c09528dd99252db98f0744181a6de54ec2f55
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            repo_dir: gems
+      YAML
+
+      test = Test.new
+      test.disable_install_collection = true
+      test.load_config(path: path)
+
       assert_match /rbs collection install/, Steep.log_output.string
+    end
+  end
+
+  def test_load_config__install_from_lockfile__failure
+    in_tmpdir do
+      path = current_dir.join("Steepfile")
+      path.write(<<~RUBY)
+        target :app do
+          collection_config "test.yaml"
+        end
+      RUBY
+      current_dir.join("test.yaml").write(<<~YAML)
+        sources:
+          - name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: c42c09528dd99252db98f0744181a6de54ec2f55
+            repo_dir: gems
+
+        # A directory to install the downloaded RBSs
+        path: .gem_rbs_collection
+
+        gems:
+          - name: activesupport
+      YAML
+      current_dir.join("test.lock.yaml").write(<<~YAML)
+        path: .gem_rbs_collection
+        gems:
+        - name: activesupport
+          version: '7.0'
+          source:
+            type: git
+            name: ruby/gem_rbs_collection
+            revision: NO_SUCH_REVISION
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            repo_dir: gems
+      YAML
+
+      test = Test.new
+      test.load_config(path: path)
+
+      assert_match /Failed to set up RBS collection:/, Steep.log_output.string
     end
   end
 end


### PR DESCRIPTION
#1344 

It runs `rbs collection --frozen` (equivalent) if

* Collection lock file is generated, and
* RBS files are missing