### PR TITLE
Delete `target` from `--validate` option

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -138,31 +138,22 @@ module Steep
             command.type_check_code = v ? true : false
           end
 
-          opts.on("--validate=OPTION", ["skip", "group", "target", "project", "library"], "Validation levels of signatures (default: group, options: skip,group,target,project,library)") do |level|
+          opts.on("--validate=OPTION", ["skip", "group", "project", "library"], "Validation levels of signatures (default: group, options: skip,group,project,library)") do |level|
             case level
             when "skip"
               command.validate_group_signatures = false
-              command.validate_target_signatures = false
               command.validate_project_signatures = false
               command.validate_library_signatures = false
             when "group"
               command.validate_group_signatures = true
-              command.validate_target_signatures = false
-              command.validate_project_signatures = false
-              command.validate_library_signatures = false
-            when "target"
-              command.validate_group_signatures = true
-              command.validate_target_signatures = true
               command.validate_project_signatures = false
               command.validate_library_signatures = false
             when "project"
               command.validate_group_signatures = true
-              command.validate_target_signatures = true
               command.validate_project_signatures = true
               command.validate_library_signatures = false
             when "library"
               command.validate_group_signatures = true
-              command.validate_target_signatures = true
               command.validate_project_signatures = true
               command.validate_library_signatures = true
             end

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -14,7 +14,6 @@ module Steep
       attr_reader :active_group_names
       attr_accessor :type_check_code
       attr_accessor :validate_group_signatures
-      attr_accessor :validate_target_signatures
       attr_accessor :validate_project_signatures
       attr_accessor :validate_library_signatures
 
@@ -29,7 +28,6 @@ module Steep
         @active_group_names = []
         @type_check_code = true
         @validate_group_signatures = true
-        @validate_target_signatures = false
         @validate_project_signatures = false
         @validate_library_signatures = false
       end
@@ -217,17 +215,15 @@ module Steep
             params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end
-        if validate_target_signatures
-          if group.is_a?(Project::Group)
-            files.each_target_signature_path(target, group) do |path|
-              params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
-            end
-          end
-        end
         if validate_project_signatures
           files.each_project_signature_path(target) do |path|
             if path_target = files.signature_path_target(path)
               params[:signature_paths] << [path_target.name.to_s, target.project.absolute_path(path).to_s]
+            end
+          end
+          if group.is_a?(Project::Group)
+            files.each_target_signature_path(target, group) do |path|
+              params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
             end
           end
         end

--- a/sig/steep/drivers/check.rbs
+++ b/sig/steep/drivers/check.rbs
@@ -23,8 +23,6 @@ module Steep
 
       attr_accessor validate_group_signatures: bool
 
-      attr_accessor validate_target_signatures: bool
-
       attr_accessor validate_project_signatures: bool
 
       attr_accessor validate_library_signatures: bool


### PR DESCRIPTION
`target` for `--validate` option doesn't make sense because the library configuration is shared among groups in a target. So, specifying every groups in a target validates correctly.