### PR TITLE
Expand `array(splat(expr` node

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -4763,6 +4763,15 @@ module Steep
 
     def try_tuple_type!(node, hint: nil)
       if node.type == :array
+        if node.children.size == 1 && node.children[0]&.type == :splat
+          # Skip the array construct
+          splat_node = node.children[0] or raise
+          splat_value = splat_node.children[0] or raise
+
+          type, constr = try_tuple_type!(splat_value, hint: hint)
+          _, constr = constr.add_typing(splat_node, type: AST::Types::Any.instance)
+          return constr.add_typing(node, type: type)
+        end
         if hint.nil? || hint.is_a?(AST::Types::Tuple)
           typing.new_child() do |child_typing|
             if pair = with_new_typing(child_typing).try_tuple_type(node, hint)

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2538,4 +2538,45 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_masgn_splat
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          array = %w(a b c)
+          a, b = *//.match('hoge')
+
+          a.ffffff
+          b.ffffff
+        RUBY
+      },
+      expectations: <<~YAML
+      ---
+      - file: a.rb
+        diagnostics:
+        - range:
+            start:
+              line: 4
+              character: 2
+            end:
+              line: 4
+              character: 8
+          severity: ERROR
+          message: Type `(::String | nil)` does not have method `ffffff`
+          code: Ruby::NoMethod
+        - range:
+            start:
+              line: 5
+              character: 2
+            end:
+              line: 5
+              character: 8
+          severity: ERROR
+          message: Type `(::String | nil)` does not have method `ffffff`
+          code: Ruby::NoMethod
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
This happens with `*node` node, at masgn right hand side.

```rb
a, b = *regexp.match("foo")     # The expected type of a and b is `String?`, but was `String | [] | nil`
```