### PR TITLE
Update example to not use `^` as a hash function

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ class Email
   end
 
   def hash
-    self.class.hash ^ address.hash
+    [self.class, address].hash
   end
 end
 
@@ -144,7 +144,7 @@ class Phone
   end
 
   def hash
-    self.class.hash ^ country.hash ^ number.hash
+    [self.class, country, number].hash
   end
 end
 ```


### PR DESCRIPTION
XOR is not a good hash function, and this example might give people the wrong idea.

Better to just outsource to the built-in Hash function used by `Array`. It's more idiomatic, and will lead to less collisions.