### PR TITLE
Stop accumulating diagnostics

### DIFF
--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -141,8 +141,6 @@ module Steep
 
       attr_reader current_type_check_request: TypeCheckController::Request?
 
-      attr_reader current_diagnostics: Hash[Pathname, Array[LSPDiagnostic::json]]
-
       attr_reader controller: TypeCheckController
 
       attr_reader result_controller: ResultController


### PR DESCRIPTION
Because we assume each file belongs to a target, we don't have to accumulate the diagnostics, but just forwarding to the client works.