### PR TITLE
Introduces a new `target.*` syntax for everything in the target

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -128,10 +128,17 @@ module Steep
           end
 
           opts.on("--group=GROUP", "Specify target/group name to type check") do |arg|
-            # @type var group: String
+            # @type var arg: String
             target, group = arg.split(".")
             target or raise
-            command.active_group_names << [target.to_sym, group&.to_sym]
+            case group
+            when "*"
+              command.active_group_names << [target.to_sym, true]
+            when nil
+              command.active_group_names << [target.to_sym, nil]
+            else
+              command.active_group_names << [target.to_sym, group.to_sym]
+            end
           end
 
           opts.on("--[no-]type-check", "Type check Ruby code") do |v|

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -38,12 +38,12 @@ module Steep
         case group
         when Project::Target
           active_group_names.any? {|target_name, group_name|
-            target_name == group.name && group_name == nil
+            target_name == group.name && (group_name == nil || group_name == true)
           }
         when Project::Group
           active_group_names.any? {|target_name, group_name|
             target_name == group.target.name &&
-              (group_name == group.name || group_name.nil?)
+              (group_name == group.name || group_name == true)
           }
         end
       end
@@ -206,7 +206,7 @@ module Steep
 
       def load_files(files, target, group, params:)
         if type_check_code
-          files.each_group_source_path(group) do |path|
+          files.each_group_source_path(group, true) do |path|
             params[:code_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end

--- a/lib/steep/server/type_check_controller.rb
+++ b/lib/steep/server/type_check_controller.rb
@@ -266,7 +266,7 @@ module Steep
               request.code_paths << [target_group.name, path]
             end
           else
-            group_set = groups.map do |group_name|
+            group_set = groups.filter_map do |group_name|
               target_name, group_name = group_name.split(".", 2)
               target_name or raise
 
@@ -280,7 +280,7 @@ module Steep
               else
                 project.targets.find {|target| target.name == target_name }
               end
-            end.compact.to_set
+            end.to_set
 
             files.signature_paths.each do |path, target_group|
               if group_set.include?(target_group)

--- a/sig/steep/drivers/check.rbs
+++ b/sig/steep/drivers/check.rbs
@@ -17,7 +17,7 @@ module Steep
 
       attr_reader jobs_option: Utils::JobsOption
 
-      attr_reader active_group_names: Array[[Symbol, Symbol?]]
+      attr_reader active_group_names: Array[[Symbol, Symbol | true | nil]]
 
       attr_accessor type_check_code: bool
 


### PR DESCRIPTION
The semantics of `target` is changed in `steep check` command, which is aligned to `Type check groups` command in LSP.

- The `target` syntax means files that belongs to the target directly, not to the groups in the target
- The `target.* syntax means all files under the target

