### PR TITLE
Make `implicitly-returns-nil` opt-in

### DIFF
--- a/lib/steep/drivers/annotations.rb
+++ b/lib/steep/drivers/annotations.rb
@@ -21,7 +21,7 @@ module Steep
 
         project.targets.each do |target|
           Steep.logger.tagged "target=#{target.name}" do
-            service = Services::SignatureService.load_from(target.new_env_loader())
+            service = Services::SignatureService.load_from(target.new_env_loader(), implicitly_returns_nil: target.implicitly_returns_nil)
 
             sigs = loader.load_changes(target.signature_pattern, changes: {})
             service.update(sigs)

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -54,13 +54,14 @@ module Steep
         end
       end
 
-      attr_reader :factory, :object_shape_cache, :union_shape_cache, :singleton_shape_cache
+      attr_reader :factory, :object_shape_cache, :union_shape_cache, :singleton_shape_cache, :implicitly_returns_nil
 
-      def initialize(factory)
+      def initialize(factory, implicitly_returns_nil:)
         @factory = factory
         @object_shape_cache = {}
         @union_shape_cache = {}
         @singleton_shape_cache = {}
+        @implicitly_returns_nil = implicitly_returns_nil
       end
 
       def shape(type, config)
@@ -826,6 +827,8 @@ module Steep
       end
 
       def add_implicitly_returns_nil(annotations, method_type)
+        return method_type unless implicitly_returns_nil
+        
         if annotations.find { _1.string == "implicitly-returns-nil" }
           return_type = method_type.type.return_type
           method_type = method_type.with(

--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -119,6 +119,7 @@ module Steep
         attr_reader :project
         attr_reader :unreferenced
         attr_reader :groups
+        attr_reader :implicitly_returns_nil
 
         def initialize(name, project:)
           @name = name
@@ -127,6 +128,7 @@ module Steep
           @project = project
           @collection_config_path = collection_config_path
           @unreferenced = false
+          @implicitly_returns_nil = false
           @groups = []
         end
 
@@ -144,11 +146,16 @@ module Steep
           @project = other.project
           @collection_config_path = other.collection_config_path
           @unreferenced = other.unreferenced
+          @implicitly_returns_nil = other.implicitly_returns_nil
           @groups = other.groups.dup
         end
 
         def unreferenced!(value = true)
           @unreferenced = value
+        end
+
+        def implicitly_returns_nil!(value = true)
+          @implicitly_returns_nil = value
         end
 
         def configure_code_diagnostics(hash = nil)
@@ -245,7 +252,8 @@ module Steep
           options: dsl.library_configured? ? dsl.to_library_options : nil,
           code_diagnostics_config: dsl.code_diagnostics_config,
           project: project,
-          unreferenced: dsl.unreferenced
+          unreferenced: dsl.unreferenced,
+          implicitly_returns_nil: dsl.implicitly_returns_nil
         )
 
         dsl.groups.each do

--- a/lib/steep/project/target.rb
+++ b/lib/steep/project/target.rb
@@ -10,8 +10,9 @@ module Steep
       attr_reader :project
       attr_reader :unreferenced
       attr_reader :groups
+      attr_reader :implicitly_returns_nil
 
-      def initialize(name:, options:, source_pattern:, signature_pattern:, code_diagnostics_config:, project:, unreferenced:)
+      def initialize(name:, options:, source_pattern:, signature_pattern:, code_diagnostics_config:, project:, unreferenced:, implicitly_returns_nil:)
         @name = name
         @target_options = options
         @source_pattern = source_pattern
@@ -20,6 +21,7 @@ module Steep
         @project = project
         @unreferenced = unreferenced
         @groups = []
+        @implicitly_returns_nil = implicitly_returns_nil
       end
 
       def options

--- a/lib/steep/server/type_check_controller.rb
+++ b/lib/steep/server/type_check_controller.rb
@@ -185,7 +185,7 @@ module Steep
         loader = Services::FileLoader.new(base_dir: project.base_dir)
 
         project.targets.each do |target|
-          signature_service = Services::SignatureService.load_from(target.new_env_loader())
+          signature_service = Services::SignatureService.load_from(target.new_env_loader(), implicitly_returns_nil: target.implicitly_returns_nil)
           files.add_library_path(target, *signature_service.env_rbs_paths.to_a)
         end
 

--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -82,7 +82,7 @@ module Steep
         @source_files = {}
         @signature_services = project.targets.each.with_object({}) do |target, hash| #$ Hash[Symbol, SignatureService]
           loader = Project::Target.construct_env_loader(options: target.options, project: project)
-          hash[target.name] = SignatureService.load_from(loader)
+          hash[target.name] = SignatureService.load_from(loader, implicitly_returns_nil: target.implicitly_returns_nil)
         end
         @signature_validation_diagnostics = project.targets.each.with_object({}) do |target, hash| #$ Hash[Symbol, Hash[Pathname, Array[Diagnostic::Signature::Base]]]
           hash[target.name] = {}

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -51,7 +51,9 @@ module Steep
 
       attr_reader singleton_shape_cache: Hash[TypeName, Shape?]
 
-      def initialize: (AST::Types::Factory) -> void
+      attr_reader implicitly_returns_nil: bool
+
+      def initialize: (AST::Types::Factory, implicitly_returns_nil: bool) -> void
 
       # Returns a shape of given type with respect to Config
       #

--- a/sig/steep/project/dsl.rbs
+++ b/sig/steep/project/dsl.rbs
@@ -79,6 +79,8 @@ module Steep
 
         attr_reader groups: Array[GroupDSL]
 
+        attr_reader implicitly_returns_nil: bool
+
         include LibraryOptions
 
         include WithPattern
@@ -94,6 +96,10 @@ module Steep
         # Use this for test targets so that editing files in this target doesn't involve type checking other targets.
         #
         def unreferenced!: (?bool) -> void
+
+        # Mark the target implicitly returns nil
+        #
+        def implicitly_returns_nil!: (?bool) -> void
 
         # Configuration of Ruby code diagnostics
         #

--- a/sig/steep/project/target.rbs
+++ b/sig/steep/project/target.rbs
@@ -11,13 +11,26 @@ module Steep
 
       attr_reader code_diagnostics_config: untyped
 
+      # Whether this target is returns optional type if `implicitly-returns-nil` annotation is given
+      #
+      attr_reader implicitly_returns_nil: bool
+
       attr_reader project: Project
 
       attr_reader unreferenced: bool
 
       attr_reader groups: Array[Group]
 
-      def initialize: (name: Symbol, options: Options?, source_pattern: Pattern, signature_pattern: Pattern, code_diagnostics_config: untyped, project: Project, unreferenced: bool) -> void
+      def initialize: (
+        name: Symbol,
+        options: Options?,
+        source_pattern: Pattern,
+        signature_pattern: Pattern,
+        code_diagnostics_config: untyped,
+        project: Project,
+        unreferenced: bool,
+        implicitly_returns_nil: bool
+      ) -> void
 
       # The options that applies to this target
       #

--- a/sig/steep/services/signature_service.rbs
+++ b/sig/steep/services/signature_service.rbs
@@ -57,13 +57,15 @@ module Steep
 
         attr_reader builder: RBS::DefinitionBuilder
 
+        attr_reader implicitly_returns_nil: bool
+
         @rbs_index: Index::RBSIndex?
 
         @subtyping: Subtyping::Check?
 
         @constant_resolver: RBS::Resolver::ConstantResolver?
 
-        def initialize: (files: Hash[Pathname, FileStatus], builder: RBS::DefinitionBuilder) -> void
+        def initialize: (files: Hash[Pathname, FileStatus], builder: RBS::DefinitionBuilder, implicitly_returns_nil: bool) -> void
 
         def subtyping: () -> Subtyping::Check
 
@@ -94,9 +96,11 @@ module Steep
         ) -> void
       end
 
-      def initialize: (env: RBS::Environment) -> void
+      attr_reader implicitly_returns_nil: bool
 
-      def self.load_from: (RBS::EnvironmentLoader loader) -> SignatureService
+      def initialize: (env: RBS::Environment, implicitly_returns_nil: bool) -> void
+
+      def self.load_from: (RBS::EnvironmentLoader loader, implicitly_returns_nil: bool) -> SignatureService
 
       @env_rbs_paths: Set[Pathname]?
 

--- a/smoke/alias/Steepfile
+++ b/smoke/alias/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/and/Steepfile
+++ b/smoke/and/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/array/Steepfile
+++ b/smoke/array/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/block/Steepfile
+++ b/smoke/block/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/case/Steepfile
+++ b/smoke/case/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/class/Steepfile
+++ b/smoke/class/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/compact/Steepfile
+++ b/smoke/compact/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/const/Steepfile
+++ b/smoke/const/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/diagnostics-rbs-duplicated/Steepfile
+++ b/smoke/diagnostics-rbs-duplicated/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/diagnostics-rbs/Steepfile
+++ b/smoke/diagnostics-rbs/Steepfile
@@ -5,5 +5,6 @@ all_sigs.each do |path|
     unreferenced!
     signature path.to_s
     configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
+    implicitly_returns_nil! true
   end
 end

--- a/smoke/diagnostics-ruby-unsat/Steepfile
+++ b/smoke/diagnostics-ruby-unsat/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/diagnostics/Steepfile
+++ b/smoke/diagnostics/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/dstr/Steepfile
+++ b/smoke/dstr/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/ensure/Steepfile
+++ b/smoke/ensure/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/enumerator/Steepfile
+++ b/smoke/enumerator/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/extension/Steepfile
+++ b/smoke/extension/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/hash/Steepfile
+++ b/smoke/hash/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/hello/Steepfile
+++ b/smoke/hello/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/if/Steepfile
+++ b/smoke/if/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/implements/Steepfile
+++ b/smoke/implements/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/initialize/Steepfile
+++ b/smoke/initialize/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/integer/Steepfile
+++ b/smoke/integer/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/interface/Steepfile
+++ b/smoke/interface/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/kwbegin/Steepfile
+++ b/smoke/kwbegin/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/lambda/Steepfile
+++ b/smoke/lambda/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/literal/Steepfile
+++ b/smoke/literal/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/map/Steepfile
+++ b/smoke/map/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/method/Steepfile
+++ b/smoke/method/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/module/Steepfile
+++ b/smoke/module/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/regexp/Steepfile
+++ b/smoke/regexp/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/regression/Steepfile
+++ b/smoke/regression/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/rescue/Steepfile
+++ b/smoke/rescue/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/self/Steepfile
+++ b/smoke/self/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/skip/Steepfile
+++ b/smoke/skip/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/stdout/Steepfile
+++ b/smoke/stdout/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/super/Steepfile
+++ b/smoke/super/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/toplevel/Steepfile
+++ b/smoke/toplevel/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/tsort/Steepfile
+++ b/smoke/tsort/Steepfile
@@ -3,5 +3,7 @@ target :test do
   signature "*.rbs"
   library "tsort"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/type_case/Steepfile
+++ b/smoke/type_case/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/unexpected/Steepfile
+++ b/smoke/unexpected/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/smoke/yield/Steepfile
+++ b/smoke/yield/Steepfile
@@ -2,5 +2,7 @@ target :test do
   check "*.rb"
   signature "*.rbs"
 
+  implicitly_returns_nil! true
+
   configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -385,6 +385,27 @@ end
     end
   end
 
+  def test_check__implicitly_returns_nil
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  implicitly_returns_nil!
+  check "foo.rb"
+end
+      EOF
+
+      (current_dir + "foo.rb").write(<<-EOF)
+array = [1,2,3]
+array[0] + 1
+      EOF
+
+      stdout, status = sh(*steep, "check")
+
+      refute_predicate status, :success?, stdout
+      assert_includes stdout, "foo.rb:2:9: [error]"
+    end
+  end
+
   def test_check_broken
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -24,7 +24,7 @@ class InterfaceBuilderTest < Minitest::Test
           def hello: () -> [::Integer, T, self]
         end
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::_Foo[::String]"), config).tap do |shape|
         assert_equal parse_type("::_Foo[::String]"), shape.type
@@ -49,7 +49,7 @@ class InterfaceBuilderTest < Minitest::Test
           def self.hello: () -> [::Integer, self, instance, class]
         end
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("singleton(::Foo)"), config).tap do |shape|
         assert_equal parse_type("singleton(::Foo)"), shape.type
@@ -79,7 +79,7 @@ class InterfaceBuilderTest < Minitest::Test
           def hello: () -> [::Integer, A, B, C, self, instance, class]
         end
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::Foo[::Object, ::String, ::Integer]"), config).tap do |shape|
         assert_equal parse_type("::Foo[::Object, ::String, ::Integer]"), shape.type
@@ -106,7 +106,7 @@ class InterfaceBuilderTest < Minitest::Test
 
         type bar[T] = T
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::bar[::_Foo]"), config).tap do |shape|
         assert_equal parse_type("::bar[::_Foo]"), shape.type
@@ -135,7 +135,7 @@ class InterfaceBuilderTest < Minitest::Test
           def itself: () -> self
         end
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::_Foo | ::_Bar"), config).tap do |shape|
         assert_equal parse_type("::_Foo | ::_Bar"), shape.type
@@ -156,7 +156,7 @@ class InterfaceBuilderTest < Minitest::Test
 
   def test_shape__bool
     with_factory() do
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("bool"), config).tap do |shape|
         assert_equal parse_type("bool"), shape.type
@@ -172,7 +172,7 @@ class InterfaceBuilderTest < Minitest::Test
 
   def test_shape__literal
     with_factory() do
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("1"), config).tap do |shape|
         assert_equal parse_type("1"), shape.type
@@ -200,7 +200,7 @@ interface _Bar
   def h: () -> void
 end
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::_Foo & ::_Bar"), config).tap do |shape|
         assert_equal parse_type("::_Foo & ::_Bar"), shape.type
@@ -228,7 +228,7 @@ end
           def special_types: () -> [self, class, instance]
         end
       RBS
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("^(::String) { (::Integer) -> void } -> ::String"), config).tap do |shape|
         assert_equal parse_type("^(::String) { (::Integer) -> void } -> ::String"), shape.type
@@ -278,7 +278,7 @@ end
 
   def test_shape__tuple
     with_factory() do
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("[::Integer, top]"), config).tap do |shape|
         assert_equal parse_type("[::Integer, top]"), shape.type
@@ -330,7 +330,7 @@ end
         end
       RBS
 
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("{ id: ::Integer, name: ::String }"), config).tap do |shape|
         assert_equal parse_type("{ id: ::Integer, name: ::String }"), shape.type
@@ -396,7 +396,7 @@ class Symbol
 end
       RBS
 
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::Integer | ::String"), config).tap do |shape|
         assert_equal(
@@ -438,7 +438,7 @@ end
         end
       RBS
 
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("A", variables: [:A]), config(variable_bounds: { A: parse_type("::_Foo[::String]") })).tap do |shape|
         assert_equal parse_type("A", variables: [:A]), shape.type
@@ -465,7 +465,7 @@ end
         type names = #{names.join(" | ")}
       RBS
 
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
 
       builder.shape(parse_type("::names"), config).tap do |shape|
         assert_equal parse_type("::names"), shape.type

--- a/test/interface_test.rb
+++ b/test/interface_test.rb
@@ -11,7 +11,7 @@ class InterfaceTest < Minitest::Test
   end
 
   def subtyping
-    @subtyping ||= Subtyping::Check.new(builder: Interface::Builder.new(factory))
+    @subtyping ||= Subtyping::Check.new(builder: Interface::Builder.new(factory, implicitly_returns_nil: true))
   end
 
   def test_method_type_params_plus

--- a/test/server/lsp_formatter_test.rb
+++ b/test/server/lsp_formatter_test.rb
@@ -10,7 +10,7 @@ class Steep::Server::LSPFormatterTest < Minitest::Test
 
   def type_check(content)
     source = Source.parse(content, path: Pathname("a.rb"), factory: factory)
-    builder = Interface::Builder.new(factory)
+    builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
     subtyping = Subtyping::Check.new(builder: builder)
     resolver = RBS::Resolver::ConstantResolver.new(builder: subtyping.factory.definition_builder)
     Services::TypeCheckService.type_check(source: source, subtyping: subtyping, constant_resolver: resolver, cursor: nil)

--- a/test/server_type_check_request_test.rb
+++ b/test/server_type_check_request_test.rb
@@ -63,7 +63,7 @@ class ServerTypeCheckRequestTest < Minitest::Test
 
   def test_progress
     in_tmpdir do
-      target = Steep::Project::Target.new(name: :lib, options: nil, source_pattern: nil, signature_pattern: nil, code_diagnostics_config: nil, project: nil, unreferenced: false)
+      target = Steep::Project::Target.new(name: :lib, options: nil, source_pattern: nil, signature_pattern: nil, code_diagnostics_config: nil, project: nil, unreferenced: false, implicitly_returns_nil: true)
 
       request = Server::TypeCheckController::Request.new(guid: "guid", progress: Server::WorkDoneProgress.new("guid"))
       request.library_paths << [:lib, RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs"]

--- a/test/signature_controller_test.rb
+++ b/test/signature_controller_test.rb
@@ -12,7 +12,7 @@ class SignatureServiceTest < Minitest::Test
   end
 
   def test_update
-    service = SignatureService.load_from(environment_loader)
+    service = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, service.status
 
@@ -46,7 +46,7 @@ RBS
   end
 
   def test_update_nested
-    controller = SignatureService.load_from(environment_loader)
+    controller = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, controller.status
 
@@ -103,7 +103,7 @@ RBS
   end
 
   def test_update_syntax_error
-    controller = SignatureService.load_from(environment_loader)
+    controller = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, controller.status
 
@@ -123,7 +123,7 @@ RBS
   end
 
   def test_update_syntax_error2
-    controller = SignatureService.load_from(environment_loader)
+    controller = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, controller.status
 
@@ -143,7 +143,7 @@ RBS
   end
 
   def test_update_loading_error1
-    controller = SignatureService.load_from(environment_loader)
+    controller = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, controller.status
 
@@ -166,7 +166,7 @@ RBS
   end
 
   def test_update_loading_error2
-    controller = SignatureService.load_from(environment_loader)
+    controller = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, controller.status
 
@@ -187,7 +187,7 @@ RBS
   end
 
   def test_update_after_syntax_error
-    controller = SignatureService.load_from(environment_loader)
+    controller = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, controller.status
 
@@ -233,7 +233,7 @@ RBS
   end
 
   def test_const_decls
-    service = SignatureService.load_from(environment_loader)
+    service = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, service.status
 
@@ -256,7 +256,7 @@ RBS
   end
 
   def test_global_decls
-    service = SignatureService.load_from(environment_loader)
+    service = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
 
     assert_instance_of SignatureService::LoadedStatus, service.status
 

--- a/test/signature_symbol_provider_test.rb
+++ b/test/signature_symbol_provider_test.rb
@@ -29,7 +29,7 @@ target :lib do
 end
 EOF
 
-      service = Services::SignatureService.load_from(project.targets[0].new_env_loader())
+      service = Services::SignatureService.load_from(project.targets[0].new_env_loader(), implicitly_returns_nil: true)
       service.update(
         {
           Pathname("sig/a.rbs") => [Services::ContentChange.string(<<RBS)]
@@ -106,7 +106,7 @@ target :lib do
 end
 EOF
 
-      service = Services::SignatureService.load_from(project.targets[0].new_env_loader())
+      service = Services::SignatureService.load_from(project.targets[0].new_env_loader(), implicitly_returns_nil: true)
       service.update(
         {
           Pathname("sig/a.rbs") => [Services::ContentChange.string(<<RBS)]
@@ -215,7 +215,7 @@ target :lib do
 end
 EOF
 
-      service = Services::SignatureService.load_from(project.targets[0].new_env_loader())
+      service = Services::SignatureService.load_from(project.targets[0].new_env_loader(), implicitly_returns_nil: true)
       service.update(
         {
           Pathname("sig/a.rbs") => [Services::ContentChange.string(<<RBS)]

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -117,7 +117,7 @@ end
 
     paths["builtin.rbs"] = BUILTIN unless nostdlib
     with_factory(paths, nostdlib: true) do |factory|
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
       yield Subtyping::Check.new(builder: builder)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -451,7 +451,7 @@ end
     end
 
     with_factory(paths, nostdlib: !with_stdlib) do |factory|
-      builder = Steep::Interface::Builder.new(factory)
+      builder = Steep::Interface::Builder.new(factory, implicitly_returns_nil: true)
       @checker = Steep::Subtyping::Check.new(builder: builder)
       yield @checker
     ensure

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -25,7 +25,7 @@ class TypeCheckTest < Minitest::Test
     typings = {}
 
     with_factory(signatures, nostdlib: false) do |factory|
-      builder = Interface::Builder.new(factory)
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
       subtyping = Subtyping::Check.new(builder: builder)
 
       code.each do |path, content|


### PR DESCRIPTION
Steep 1.9 started supporting `implicitly-returns-nil` annotation, but it breaks many projects unexpectedly. So, we are going it back to option, which is off by default.

We add `#implicitly_returns_nil!` method to target DSL, and you can opt-in the behavior target by target basis.

```rb
target :app do
  implicitly_returns_nil!
end

target :test do
  implicitly_returns_nil! false    # This is disabled by default, but you can explicitly call the method.
end
```