### PR TITLE
deps: Add uri gem to dependencies list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)
+      uri (>= 0.12.0)
 
 GEM
   remote: https://rubygems.org/

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -51,4 +51,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fileutils", ">= 1.1.0"
   spec.add_runtime_dependency "strscan", ">= 1.0.0"
   spec.add_runtime_dependency "csv", ">= 3.0.9"
+  spec.add_runtime_dependency "uri", ">= 0.12.0"
 end


### PR DESCRIPTION
`URI.encode_uri_component` was added since uri-v0.12.  Therefore we need to add it to the dependencies list to use the method.

Closes: #1399