### PR TITLE
Attach type assertion to keyword args

### DIFF
--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -496,6 +496,14 @@ module Steep
             # Skip
           when :def, :defs
             # Skip
+          when :kwargs
+            # skip
+          when :pair
+            key, value = node.children
+            key = insert_type_node(key, comments.except(last_line))
+            value = insert_type_node(value, comments)
+            node = node.updated(nil, [key, value])
+            return adjust_location(node)
           when :masgn
             lhs, rhs = node.children
             node = node.updated(nil, [lhs, insert_type_node(rhs, comments)])

--- a/rbs_collection.steep.lock.yaml
+++ b/rbs_collection.steep.lock.yaml
@@ -133,6 +133,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: stringio
+  version: '0'
+  source:
+    type: stdlib
 - name: strscan
   version: '0'
   source:

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -779,6 +779,47 @@ next 123 #: Integer?
     end
   end
 
+  def test_assertion__kwargs
+    with_factory do |factory|
+      source = Steep::Source.parse(<<~RUBY, path: Pathname("foo.rb"), factory: factory)
+        foo(
+          a: "", #: ""
+          b: [], #: Array[String]
+          c: ""
+        )
+      RUBY
+
+      _receiver, _name, *args = source.node.children
+      args[0].tap do |kwargs|
+        assert_equal :kwargs, kwargs.type
+
+        kwargs.children[0].tap do |pair|
+          assert_equal :pair, pair.type
+          key, value = pair.children
+
+          assert_equal :sym, key.type
+          assert_equal :assertion, value.type
+        end
+
+        kwargs.children[1].tap do |pair|
+          assert_equal :pair, pair.type
+          key, value = pair.children
+
+          assert_equal :sym, key.type
+          assert_equal :assertion, value.type
+        end
+
+        kwargs.children[2].tap do |pair|
+          assert_equal :pair, pair.type
+          key, value = pair.children
+
+          assert_equal :sym, key.type
+          assert_equal :str, value.type
+        end
+      end
+    end
+  end
+
   def test_tapp_send
     with_factory({ Pathname("foo.rbs") => <<-RBS }) do |factory|
 class Tapp


### PR DESCRIPTION
Type assertion should be attached to the value of keyword arg `pair`, not the `pair` node itself.

This allows writing type assertion for keyword args:

```rb
foo(
  array: [] #: Array[String]
)
```

This issue is reported from @Little-Rubyist. Thanks! 🙏 