### PR TITLE
Fix Source.parse crashes with selector-less sendish node

### DIFF
--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -644,7 +644,7 @@ module Steep
         receiver_node, name, _, location = deconstruct_send_node!(send_node)
 
         if receiver_node
-          if location.dot
+          if location.dot && location.selector
             location.selector.line
           end
         else

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -975,6 +975,21 @@ super { } # $ nil
     end
   end
 
+  def test_selectorless_sendish_node_with_annotation_comment
+    with_factory({ Pathname("foo.rbs") => <<-RBS }) do |factory|
+      RBS
+      source = Steep::Source.parse(<<-EOF, path: Pathname("foo.rb"), factory: factory)
+        proc{}.() do
+          x #: nil
+        end
+      EOF
+
+      source.node.children[0].tap do |node|
+        assert_equal :send, node.type
+      end
+    end
+  end
+
   def test_find_comment
     with_factory() do |factory|
       source = Steep::Source.parse(<<~RUBY, path: Pathname("foo.rb"), factory: factory)


### PR DESCRIPTION
`Steep::Source.parse` crashes if the target code contains selector-less sendish node having annotation comment inside its block.

Close #1395