### PR TITLE
Support rbs v3.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       logger (>= 1.3.0)
       parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.7.0)
+      rbs (~> 3.7)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -22,6 +22,7 @@ require "concurrent/utility/processor_counter"
 require "terminal-table"
 
 require "rbs"
+require "steep/rbs_compat"
 
 require "steep/path_helper"
 require "steep/located_value"

--- a/lib/steep/annotation_parser.rb
+++ b/lib/steep/annotation_parser.rb
@@ -104,7 +104,7 @@ module Steep
           name = match[:name] or raise
           type = parse_type(match, location: location)
 
-          AST::Annotation::ConstType.new(name: TypeName(name), type: type, location: location)
+          AST::Annotation::ConstType.new(name: RBS::TypeName.parse(name), type: type, location: location)
         end
 
       when keyword_subject_type("ivar", IVAR_NAME)
@@ -184,7 +184,7 @@ module Steep
       when /@implements\s+(?<name>#{CONST_NAME})#{TYPE_PARAMS}$/
         Regexp.last_match.yield_self do |match|
           match or raise
-          type_name = TypeName(match[:name] || raise)
+          type_name = RBS::TypeName.parse(match[:name] || raise)
           params = match[:params]&.yield_self {|params| params.split(/,/).map {|param| param.strip.to_sym } } || []
 
           name = AST::Annotation::Implements::Module.new(name: type_name, args: params)

--- a/lib/steep/ast/builtin.rb
+++ b/lib/steep/ast/builtin.rb
@@ -6,7 +6,7 @@ module Steep
         attr_reader :arity
 
         def initialize(module_name, arity: 0)
-          @module_name = TypeName(module_name)
+          @module_name = RBS::TypeName.parse(module_name)
           @arity = arity
         end
 

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -786,7 +786,7 @@ module Steep
               RBS::BuiltinNames::Symbol.name,
               RBS::BuiltinNames::TrueClass.name,
               RBS::BuiltinNames::FalseClass.name,
-              TypeName("::NilClass")
+              RBS::TypeName.parse("::NilClass")
               # Value based type-case works on literal types which is available for String, Integer, Symbol, TrueClass, FalseClass, and NilClass
               return method_type.with(
                 type: method_type.type.with(
@@ -828,7 +828,7 @@ module Steep
 
       def add_implicitly_returns_nil(annotations, method_type)
         return method_type unless implicitly_returns_nil
-        
+
         if annotations.find { _1.string == "implicitly-returns-nil" }
           return_type = method_type.type.return_type
           method_type = method_type.with(

--- a/lib/steep/method_name.rb
+++ b/lib/steep/method_name.rb
@@ -28,12 +28,12 @@ module Steep
         type_name, method_name = string.split(/#/, 2)
         type_name or raise
         method_name or raise
-        InstanceMethodName.new(type_name: TypeName(type_name), method_name: method_name.to_sym)
+        InstanceMethodName.new(type_name: RBS::TypeName.parse(type_name), method_name: method_name.to_sym)
       when /\./
         type_name, method_name = string.split(/\./, 2)
         type_name or raise
         method_name or raise
-        SingletonMethodName.new(type_name: TypeName(type_name), method_name: method_name.to_sym)
+        SingletonMethodName.new(type_name: RBS::TypeName.parse(type_name), method_name: method_name.to_sym)
       else
         raise "Unexpected method name: #{string}"
       end

--- a/lib/steep/rbs_compat.rb
+++ b/lib/steep/rbs_compat.rb
@@ -1,0 +1,8 @@
+unless ::RBS::TypeName.singleton_class.method_defined?(:parse)
+  # Before RBS 3.8.0
+  class ::RBS::TypeName
+    def self.parse(string)
+      TypeName(string)
+    end
+  end
+end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1385,10 +1385,10 @@ module Steep
           add_typing(node, type: AST::Builtin::Float.instance_type)
 
         when :rational
-          add_typing(node, type: AST::Types::Name::Instance.new(name: TypeName("::Rational"), args: []))
+          add_typing(node, type: AST::Types::Name::Instance.new(name: RBS::TypeName.parse("::Rational"), args: []))
 
         when :complex
-          add_typing(node, type: AST::Types::Name::Instance.new(name: TypeName("::Complex"), args: []))
+          add_typing(node, type: AST::Types::Name::Instance.new(name: RBS::TypeName.parse("::Complex"), args: []))
 
         when :nil
           add_typing(node, type: AST::Builtin.nil_type)

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.15", "< 4.0"
-  spec.add_runtime_dependency "rbs", "~> 3.7.0"
+  spec.add_runtime_dependency "rbs", "~> 3.7"
   spec.add_runtime_dependency "concurrent-ruby", ">= 1.1.10"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 4"
   spec.add_runtime_dependency "securerandom", ">= 0.1"

--- a/test/annotation_collection_test.rb
+++ b/test/annotation_collection_test.rb
@@ -15,7 +15,7 @@ class AnnotationCollectionTest < Minitest::Test
       annotations: [
         Annotation::VarType.new(name: :x, type: parse_type("Object")),
         Annotation::IvarType.new(name: :@y, type: parse_type("Object")),
-        Annotation::ConstType.new(name: TypeName("Object"), type: parse_type("singleton(Object)")),
+        Annotation::ConstType.new(name: RBS::TypeName.parse("Object"), type: parse_type("singleton(Object)")),
         Annotation::MethodType.new(name: :foo, type: parse_method_type("() -> Object")),
         Annotation::BlockType.new(type: parse_type("Object")),
         Annotation::ReturnType.new(type: parse_type("Object")),
@@ -23,7 +23,7 @@ class AnnotationCollectionTest < Minitest::Test
         Annotation::InstanceType.new(type: parse_type("String")),
         Annotation::ModuleType.new(type: parse_type("String")),
         Annotation::BreakType.new(type: parse_type("::Object")),
-        Annotation::Implements.new(name: Annotation::Implements::Module.new(name: TypeName("Object"), args: [])),
+        Annotation::Implements.new(name: Annotation::Implements::Module.new(name: RBS::TypeName.parse("Object"), args: [])),
         Annotation::Dynamic.new(names: [
           Annotation::Dynamic::Name.new(name: :foo, kind: :instance),
           Annotation::Dynamic::Name.new(name: :bar, kind: :module),
@@ -46,7 +46,7 @@ EOF
 
   def test_types
     with_factory RBIS do |factory|
-      annotations = new_collection(current_module: TypeName("::Person"), factory: factory)
+      annotations = new_collection(current_module: RBS::TypeName.parse("::Person"), factory: factory)
 
       assert_equal parse_type("::Person::Object"), annotations.var_type(lvar: :x)
       assert_nil annotations.var_type(lvar: :y)
@@ -54,8 +54,8 @@ EOF
       assert_equal parse_type("::Person::Object"), annotations.var_type(ivar: :@y)
       assert_nil annotations.var_type(ivar: :@x)
 
-      assert_equal parse_type("singleton(::Person::Object)"), annotations.var_type(const: TypeName("Object"))
-      assert_nil annotations.var_type(const: TypeName("::Object"))
+      assert_equal parse_type("singleton(::Person::Object)"), annotations.var_type(const: RBS::TypeName.parse("Object"))
+      assert_nil annotations.var_type(const: RBS::TypeName.parse("::Object"))
 
       assert_equal "() -> ::Person::Object", annotations.method_type(:foo).to_s
 
@@ -70,7 +70,7 @@ EOF
 
   def test_dynamics
     with_factory do |factory|
-      annotations = new_collection(current_module: TypeName("::Person"), factory: factory)
+      annotations = new_collection(current_module: RBS::TypeName.parse("::Person"), factory: factory)
 
       assert_equal [:foo, :baz], annotations.instance_dynamics
       assert_equal [:bar, :baz], annotations.module_dynamics
@@ -79,7 +79,7 @@ EOF
 
   def test_merge_block_annotations
     with_factory RBIS do |factory|
-      namespace = TypeName("::Person")
+      namespace = RBS::TypeName.parse("::Person")
       current_annotations = new_collection(current_module: namespace, factory: factory)
 
       block_annotations = Annotation::Collection.new(

--- a/test/annotation_parsing_test.rb
+++ b/test/annotation_parsing_test.rb
@@ -76,7 +76,7 @@ class AnnotationParsingTest < Minitest::Test
     with_factory do |factory|
       annot = parse_annotation("@type const Foo::Bar::Baz: String", factory: factory)
       assert_instance_of Annotation::ConstType, annot
-      assert_equal TypeName("Foo::Bar::Baz"), annot.name
+      assert_equal RBS::TypeName.parse("Foo::Bar::Baz"), annot.name
       assert_equal parse_type("String", factory: factory), annot.type
     end
   end
@@ -85,7 +85,7 @@ class AnnotationParsingTest < Minitest::Test
     with_factory do |factory|
       annot = parse_annotation("@type const Foo: String", factory: factory)
       assert_instance_of Annotation::ConstType, annot
-      assert_equal TypeName("Foo"), annot.name
+      assert_equal RBS::TypeName.parse("Foo"), annot.name
       assert_equal parse_type("String", factory: factory), annot.type
     end
   end
@@ -94,7 +94,7 @@ class AnnotationParsingTest < Minitest::Test
     with_factory do |factory|
       annot = parse_annotation("@type const ::Foo: String", factory: factory)
       assert_instance_of Annotation::ConstType, annot
-      assert_equal TypeName("::Foo"), annot.name
+      assert_equal RBS::TypeName.parse("::Foo"), annot.name
       assert_equal parse_type("String", factory: factory), annot.type
     end
   end
@@ -119,7 +119,7 @@ class AnnotationParsingTest < Minitest::Test
     with_factory do |factory|
       annot = parse_annotation("@implements String", factory: factory)
       assert_instance_of Annotation::Implements, annot
-      assert_equal TypeName("String"), annot.name.name
+      assert_equal RBS::TypeName.parse("String"), annot.name.name
       assert_empty annot.name.args
     end
   end
@@ -128,7 +128,7 @@ class AnnotationParsingTest < Minitest::Test
     with_factory do |factory|
       annot = parse_annotation("@implements Array[A]", factory: factory)
       assert_instance_of Annotation::Implements, annot
-      assert_equal TypeName('Array'), annot.name.name
+      assert_equal RBS::TypeName.parse('Array'), annot.name.name
       assert_equal [:A], annot.name.args
     end
   end

--- a/test/ast/node/type_application_test.rb
+++ b/test/ast/node/type_application_test.rb
@@ -22,7 +22,7 @@ class AST__Node__TypeApplicationTest < Minitest::Test
       app = Steep::AST::Node::TypeApplication.parse(loc)
 
       assert_equal "Bar", app.type_str
-      app.types([nil, TypeName("::Foo")], checker, []).tap do |types|
+      app.types([nil, RBS::TypeName.parse("::Foo")], checker, []).tap do |types|
         assert_equal 1, types.size
         assert_equal parse_type("::Foo::Bar"), types[0].value
         assert_equal "Bar", types[0].location.source

--- a/test/ast/node/type_assertion_test.rb
+++ b/test/ast/node/type_assertion_test.rb
@@ -38,7 +38,7 @@ class AST__Node__TypeAssertionTest < Minitest::Test
       assert_equal "Array[Bar]", assertion.type_str
       assert_predicate assertion, :type_syntax?
 
-      type = assertion.type([nil, TypeName("::Foo")], checker, [])
+      type = assertion.type([nil, RBS::TypeName.parse("::Foo")], checker, [])
       assert_equal parse_type("::Array[::Foo::Bar]"), type
     end
   end

--- a/test/completion_provider_test.rb
+++ b/test/completion_provider_test.rb
@@ -536,7 +536,7 @@ a, b = []
       RUBY
 
         provider.run(line: 1, column: 17).tap do |items|
-          assert_equal [TypeName("Array")], items.map(&:relative_type_name)
+          assert_equal [RBS::TypeName.parse("Array")], items.map(&:relative_type_name)
         end
       end
     end
@@ -549,7 +549,7 @@ a, b = []
       RUBY
 
         provider.run(line: 1, column: 12).tap do |items|
-          assert_equal [TypeName("Array")], items.map(&:relative_type_name)
+          assert_equal [RBS::TypeName.parse("Array")], items.map(&:relative_type_name)
         end
       end
     end
@@ -563,7 +563,7 @@ a, b = []
       RUBY
 
         provider.run(line: 1, column: 33).tap do |items|
-          assert_equal [TypeName("Array")], items.map(&:relative_type_name)
+          assert_equal [RBS::TypeName.parse("Array")], items.map(&:relative_type_name)
         end
       end
     end

--- a/test/constant_env_test.rb
+++ b/test/constant_env_test.rb
@@ -48,22 +48,22 @@ end
   end
 
   def test_from_module
-    with_constant_env({ "foo.rbs" => <<-EOS }, context: [nil, TypeName("::A")]) do |env|
+    with_constant_env({ "foo.rbs" => <<-EOS }, context: [nil, RBS::TypeName.parse("::A")]) do |env|
 module A end
 module A::String end
     EOS
-      assert_equal TypeName("::A::String"), env.resolve(:String)[1]
-      assert_equal TypeName("::String"), env.toplevel(:String)[1]
+      assert_equal RBS::TypeName.parse("::A::String"), env.resolve(:String)[1]
+      assert_equal RBS::TypeName.parse("::String"), env.toplevel(:String)[1]
     end
   end
 
   def test_module_alias
-    with_constant_env({ "foo.rbs" => <<-EOS }, context: [nil, TypeName("::A")]) do |env|
+    with_constant_env({ "foo.rbs" => <<-EOS }, context: [nil, RBS::TypeName.parse("::A")]) do |env|
 module A end
 module B = A
     EOS
-      assert_equal TypeName("::A"), env.resolve(:A)[1]
-      assert_equal TypeName("::B"), env.toplevel(:B)[1]
+      assert_equal RBS::TypeName.parse("::A"), env.resolve(:A)[1]
+      assert_equal RBS::TypeName.parse("::B"), env.toplevel(:B)[1]
     end
   end
 

--- a/test/constraints_test.rb
+++ b/test/constraints_test.rb
@@ -170,8 +170,8 @@ end
                  constraints.eliminate_variable(AST::Types::Intersection.build(types: [AST::Types::Var.new(name: :a),
                                                                                        AST::Types::Var.new(name: :b)]),
                                                 to: AST::Types::Bot.new)
-    assert_equal AST::Types::Name::Instance.new(name: TypeName("::String"), args: [AST::Types::Any.new]),
-                 constraints.eliminate_variable(AST::Types::Name::Instance.new(name: TypeName("::String"),
+    assert_equal AST::Types::Name::Instance.new(name: RBS::TypeName.parse("::String"), args: [AST::Types::Any.new]),
+                 constraints.eliminate_variable(AST::Types::Name::Instance.new(name: RBS::TypeName.parse("::String"),
                                                                                args: [AST::Types::Var.new(name: :a)]),
                                                 to: AST::Types::Top.new)
   end

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -95,7 +95,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::ConstantQuery, query
-        assert_equal TypeName("::Customer"), query.name
+        assert_equal RBS::TypeName.parse("::Customer"), query.name
         assert_predicate query, :from_ruby?
       end
     end
@@ -104,7 +104,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::ConstantQuery, query
-        assert_equal TypeName("::Customer::VERSION"), query.name
+        assert_equal RBS::TypeName.parse("::Customer::VERSION"), query.name
         assert_predicate query, :from_ruby?
       end
     end
@@ -113,7 +113,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::ConstantQuery, query
-        assert_equal TypeName("::Customer::SIZE"), query.name
+        assert_equal RBS::TypeName.parse("::Customer::SIZE"), query.name
         assert_predicate query, :from_ruby?
       end
     end
@@ -145,7 +145,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::ConstantQuery, query
-        assert_equal TypeName("::Customer"), query.name
+        assert_equal RBS::TypeName.parse("::Customer"), query.name
         assert_predicate query, :from_rbs?
       end
     end
@@ -154,7 +154,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::ConstantQuery, query
-        assert_equal TypeName("::Customer::VERSION"), query.name
+        assert_equal RBS::TypeName.parse("::Customer::VERSION"), query.name
         assert_predicate query, :from_rbs?
       end
     end
@@ -188,7 +188,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal InstanceMethodName.new(type_name: TypeName("::Customer"), method_name: :foo), query.name
+        assert_equal InstanceMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :foo), query.name
         assert_predicate query, :from_rbs?
       end
     end
@@ -197,7 +197,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal SingletonMethodName.new(type_name: TypeName("::Customer"), method_name: :bar), query.name
+        assert_equal SingletonMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :bar), query.name
         assert_predicate query, :from_rbs?
       end
     end
@@ -207,13 +207,13 @@ RUBY
 
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal SingletonMethodName.new(type_name: TypeName("::Customer"), method_name: :baz), query.name
+        assert_equal SingletonMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :baz), query.name
         assert_predicate query, :from_rbs?
       end
 
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal InstanceMethodName.new(type_name: TypeName("::Customer"), method_name: :baz), query.name
+        assert_equal InstanceMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :baz), query.name
         assert_predicate query, :from_rbs?
       end
     end
@@ -222,7 +222,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal InstanceMethodName.new(type_name: TypeName("::Customer"), method_name: :foo), query.name
+        assert_equal InstanceMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :foo), query.name
         assert_predicate query, :from_ruby?
       end
     end
@@ -231,7 +231,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal SingletonMethodName.new(type_name: TypeName("::Customer"), method_name: :bar), query.name
+        assert_equal SingletonMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :bar), query.name
         assert_predicate query, :from_ruby?
       end
     end
@@ -252,7 +252,7 @@ RBS
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::TypeNameQuery, query
-        assert_equal TypeName("::String"), query.name
+        assert_equal RBS::TypeName.parse("::String"), query.name
       end
     end
 
@@ -260,7 +260,7 @@ RBS
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::TypeNameQuery, query
-        assert_equal TypeName("::string"), query.name
+        assert_equal RBS::TypeName.parse("::string"), query.name
       end
     end
   end
@@ -291,7 +291,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal InstanceMethodName.new(type_name: TypeName("::Customer"), method_name: :foo), query.name
+        assert_equal InstanceMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :foo), query.name
       end
     end
 
@@ -299,7 +299,7 @@ RUBY
       assert_equal 1, qs.size
       assert_any!(qs) do |query|
         assert_instance_of Services::GotoService::MethodQuery, query
-        assert_equal SingletonMethodName.new(type_name: TypeName("::Customer"), method_name: :bar), query.name
+        assert_equal SingletonMethodName.new(type_name: RBS::TypeName.parse("::Customer"), method_name: :bar), query.name
       end
     end
 
@@ -337,7 +337,7 @@ RUBY
     end
     service = Services::GotoService.new(type_check: type_check, assignment: assignment)
 
-    service.constant_definition_in_ruby(TypeName("::Customer"), locations: []).tap do |locs|
+    service.constant_definition_in_ruby(RBS::TypeName.parse("::Customer"), locations: []).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -349,7 +349,7 @@ RUBY
       end
     end
 
-    service.constant_definition_in_rbs(TypeName("::Customer"), locations: []).tap do |locs|
+    service.constant_definition_in_rbs(RBS::TypeName.parse("::Customer"), locations: []).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -361,7 +361,7 @@ RUBY
       end
     end
 
-    service.constant_definition_in_ruby(TypeName("::Customer2"), locations: []).tap do |locs|
+    service.constant_definition_in_ruby(RBS::TypeName.parse("::Customer2"), locations: []).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -373,7 +373,7 @@ RUBY
       end
     end
 
-    service.constant_definition_in_rbs(TypeName("::Customer2"), locations: []).tap do |locs|
+    service.constant_definition_in_rbs(RBS::TypeName.parse("::Customer2"), locations: []).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -385,7 +385,7 @@ RUBY
       end
     end
 
-    service.constant_definition_in_ruby(TypeName("::Customer::NAME"), locations: []).tap do |locs|
+    service.constant_definition_in_ruby(RBS::TypeName.parse("::Customer::NAME"), locations: []).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -397,7 +397,7 @@ RUBY
       end
     end
 
-    service.constant_definition_in_rbs(TypeName("::Customer::NAME"), locations: []).tap do |locs|
+    service.constant_definition_in_rbs(RBS::TypeName.parse("::Customer::NAME"), locations: []).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -553,7 +553,7 @@ RBS
 
     service = Services::GotoService.new(type_check: type_check, assignment: assignment)
 
-    service.type_name_locations(TypeName("::Customer")).tap do |locs|
+    service.type_name_locations(RBS::TypeName.parse("::Customer")).tap do |locs|
       assert_equal 2, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -573,7 +573,7 @@ RBS
       end
     end
 
-    service.type_name_locations(TypeName("::Customer::loc")).tap do |locs|
+    service.type_name_locations(RBS::TypeName.parse("::Customer::loc")).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|
@@ -585,7 +585,7 @@ RBS
       end
     end
 
-    service.type_name_locations(TypeName("::Customer::_Base")).tap do |locs|
+    service.type_name_locations(RBS::TypeName.parse("::Customer::_Base")).tap do |locs|
       assert_equal 1, locs.size
 
       assert_any!(locs) do |target, loc|

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -39,7 +39,7 @@ HelloWorld.new()
         construction.synthesize(source.node)
         assert_no_error typing
 
-        typing.source_index.entry(constant: TypeName("::HelloWorld")).tap do |entry|
+        typing.source_index.entry(constant: RBS::TypeName.parse("::HelloWorld")).tap do |entry|
           assert_instance_of SourceIndex::ConstantEntry, entry
 
           assert_node_set entry.definitions,
@@ -50,7 +50,7 @@ HelloWorld.new()
                           [[5, 0], [5, 12]]
         end
 
-        typing.source_index.entry(constant: TypeName("::String")).tap do |entry|
+        typing.source_index.entry(constant: RBS::TypeName.parse("::String")).tap do |entry|
           assert_instance_of SourceIndex::ConstantEntry, entry
 
           assert_node_set entry.definitions
@@ -76,7 +76,7 @@ end
         construction.synthesize(source.node)
         assert_no_error typing
 
-        typing.source_index.entry(constant: TypeName("::HelloWorld")).tap do |entry|
+        typing.source_index.entry(constant: RBS::TypeName.parse("::HelloWorld")).tap do |entry|
           assert_instance_of SourceIndex::ConstantEntry, entry
 
           assert_node_set entry.definitions,
@@ -104,7 +104,7 @@ end
         construction.synthesize(source.node)
         assert_no_error typing
 
-        typing.source_index.entry(constant: TypeName("::HelloWorld::VERSION")).tap do |entry|
+        typing.source_index.entry(constant: RBS::TypeName.parse("::HelloWorld::VERSION")).tap do |entry|
           assert_instance_of SourceIndex::ConstantEntry, entry
 
           assert_node_set entry.definitions,

--- a/test/logic_type_interpreter_test.rb
+++ b/test/logic_type_interpreter_test.rb
@@ -367,13 +367,13 @@ end
       interpreter = LogicTypeInterpreter.new(subtyping: checker, typing: nil, config: config)
 
       assert_equal [parse_type("::String"), nil],
-                   interpreter.type_case_select(parse_type("::String"), TypeName("::String"))
+                   interpreter.type_case_select(parse_type("::String"), RBS::TypeName.parse("::String"))
 
       assert_equal [parse_type("::String"), parse_type("::Integer")],
-                   interpreter.type_case_select(parse_type("::String | ::Integer"), TypeName("::String"))
+                   interpreter.type_case_select(parse_type("::String | ::Integer"), RBS::TypeName.parse("::String"))
 
       assert_equal [nil, parse_type("::String | ::Integer")],
-                   interpreter.type_case_select(parse_type("::String | ::Integer"), TypeName("::Symbol"))
+                   interpreter.type_case_select(parse_type("::String | ::Integer"), RBS::TypeName.parse("::Symbol"))
     end
   end
 
@@ -416,7 +416,7 @@ end
       interpreter = LogicTypeInterpreter.new(subtyping: checker, typing: nil, config: config)
 
       assert_equal [parse_type("::String"), parse_type("untyped")],
-                   interpreter.type_case_select(parse_type("untyped"), TypeName("::String"))
+                   interpreter.type_case_select(parse_type("untyped"), RBS::TypeName.parse("::String"))
     end
   end
 
@@ -425,7 +425,7 @@ end
       interpreter = LogicTypeInterpreter.new(subtyping: checker, typing: nil, config: config)
 
       assert_equal [parse_type("::String"), parse_type("top")],
-                   interpreter.type_case_select(parse_type("top"), TypeName("::String"))
+                   interpreter.type_case_select(parse_type("top"), RBS::TypeName.parse("::String"))
     end
   end
 
@@ -443,7 +443,7 @@ end
       interpreter = LogicTypeInterpreter.new(subtyping: checker, typing: nil, config: config)
 
       assert_equal [parse_type("::TestChild1"), parse_type("::String")],
-                   interpreter.type_case_select(parse_type("::TestChild1 | ::String"), TypeName("::TestParent"))
+                   interpreter.type_case_select(parse_type("::TestChild1 | ::String"), RBS::TypeName.parse("::TestParent"))
     end
   end
 
@@ -465,16 +465,16 @@ type dm = ms | ds
       interpreter = LogicTypeInterpreter.new(subtyping: checker, typing: nil, config: config)
 
       assert_equal [parse_type("::M1"), parse_type("::M2 | ::M3")],
-                   interpreter.type_case_select(parse_type("::ms"), TypeName("::M1"))
+                   interpreter.type_case_select(parse_type("::ms"), RBS::TypeName.parse("::M1"))
 
       assert_equal [parse_type("::M1"), parse_type("::M2 | ::M3 | ::ds")],
-                   interpreter.type_case_select(parse_type("::dm"), TypeName("::M1"))
+                   interpreter.type_case_select(parse_type("::dm"), RBS::TypeName.parse("::M1"))
 
       assert_equal [parse_type("::M1 | ::M2 | ::M3"), parse_type("::ds")],
-                   interpreter.type_case_select(parse_type("::dm"), TypeName("::M"))
+                   interpreter.type_case_select(parse_type("::dm"), RBS::TypeName.parse("::M"))
 
       assert_equal [parse_type("::D2"), parse_type("::ms | ::D1")],
-                   interpreter.type_case_select(parse_type("::dm"), TypeName("::D2"))
+                   interpreter.type_case_select(parse_type("::dm"), RBS::TypeName.parse("::D2"))
     end
   end
 end

--- a/test/module_name_test.rb
+++ b/test/module_name_test.rb
@@ -11,13 +11,13 @@ class ModuleHelperTest < Minitest::Test
   def test_from_const_node
     with_factory do
       parse_ruby("C").node.tap do |node|
-        assert_equal TypeName("C"), module_name_from_node(node.children[0], node.children[1])
+        assert_equal RBS::TypeName.parse("C"), module_name_from_node(node.children[0], node.children[1])
       end
       parse_ruby("::C").node.tap do |node|
-        assert_equal TypeName("::C"), module_name_from_node(node.children[0], node.children[1])
+        assert_equal RBS::TypeName.parse("::C"), module_name_from_node(node.children[0], node.children[1])
       end
       parse_ruby("A::B::C").node.tap do |node|
-        assert_equal TypeName("A::B::C"), module_name_from_node(node.children[0], node.children[1])
+        assert_equal RBS::TypeName.parse("A::B::C"), module_name_from_node(node.children[0], node.children[1])
       end
     end
   end

--- a/test/rbs_hover_test.rb
+++ b/test/rbs_hover_test.rb
@@ -176,7 +176,7 @@ RBS
         assert_instance_of RBS::Location, content.location
         assert_equal "Object", content.location.source
         assert_instance_of RBS::AST::Declarations::Class, content.decl
-        assert_equal TypeName("::Object"), content.decl.name
+        assert_equal RBS::TypeName.parse("::Object"), content.decl.name
       end
 
       hover.content_for(target: target, path: Pathname("hello.rbs"), line: 2, column: 6).tap do |content|
@@ -184,7 +184,7 @@ RBS
         assert_instance_of RBS::Location, content.location
         assert_equal "Thread::", content.location.source
         assert_instance_of RBS::AST::Declarations::Class, content.decl
-        assert_equal TypeName("::Thread"), content.decl.name
+        assert_equal RBS::TypeName.parse("::Thread"), content.decl.name
       end
     end
   end

--- a/test/rbs_index_test.rb
+++ b/test/rbs_index_test.rb
@@ -18,7 +18,7 @@ end
 
       builder.env(env)
 
-      assert_equal 1, index.each_declaration(type_name: TypeName("::HelloWorld")).count
+      assert_equal 1, index.each_declaration(type_name: RBS::TypeName.parse("::HelloWorld")).count
     end
   end
 
@@ -33,8 +33,8 @@ module Foo = Kernel
 
       builder.env(env)
 
-      assert_equal 1, index.each_declaration(type_name: TypeName("::Foo")).count
-      assert_equal 1, index.each_reference(type_name: TypeName("::Kernel")).count {|ref| ref.is_a?(RBS::AST::Declarations::ModuleAlias) }
+      assert_equal 1, index.each_declaration(type_name: RBS::TypeName.parse("::Foo")).count
+      assert_equal 1, index.each_reference(type_name: RBS::TypeName.parse("::Kernel")).count {|ref| ref.is_a?(RBS::AST::Declarations::ModuleAlias) }
     end
   end
 
@@ -118,7 +118,7 @@ end
 
       builder.env(env)
 
-      assert_equal 1, index.each_declaration(type_name: TypeName("::_HelloStr")).count
+      assert_equal 1, index.each_declaration(type_name: RBS::TypeName.parse("::_HelloStr")).count
     end
   end
 
@@ -133,7 +133,7 @@ type num = Integer | Float | Rational
 
       builder.env(env)
 
-      assert_equal 1, index.each_declaration(type_name: TypeName("::num")).count
+      assert_equal 1, index.each_declaration(type_name: RBS::TypeName.parse("::num")).count
     end
   end
 
@@ -148,7 +148,7 @@ Version: String
 
       builder.env(env)
 
-      assert_equal 1, index.each_declaration(const_name: TypeName("::Version")).count
+      assert_equal 1, index.each_declaration(const_name: RBS::TypeName.parse("::Version")).count
     end
   end
 end

--- a/test/ruby_hover_test.rb
+++ b/test/ruby_hover_test.rb
@@ -391,17 +391,17 @@ RBS
       hover.content_for(target: target, path: Pathname("hello.rb"), line: 1, column: 7).tap do |content|
         assert_instance_of HoverProvider::Ruby::ConstantContent, content
         assert_equal [1,6]...[1,11], [content.location.line,content.location.column]...[content.location.last_line, content.location.last_column]
-        assert_equal TypeName("::Hello"), content.full_name
+        assert_equal RBS::TypeName.parse("::Hello"), content.full_name
         assert_equal "singleton(::Hello)", content.type.to_s
-        assert_equal service.signature_services[:lib].latest_env.class_decls[TypeName("::Hello")], content.decl
+        assert_equal service.signature_services[:lib].latest_env.class_decls[RBS::TypeName.parse("::Hello")], content.decl
       end
 
       hover.content_for(target: target, path: Pathname("hello.rb"), line: 2, column: 5).tap do |content|
         assert_instance_of HoverProvider::Ruby::ConstantContent, content
         assert_equal [2,2]...[2,7], [content.location.line,content.location.column]...[content.location.last_line, content.location.last_column]
-        assert_equal TypeName("::Hello::World"), content.full_name
+        assert_equal RBS::TypeName.parse("::Hello::World"), content.full_name
         assert_equal "::String", content.type.to_s
-        assert_equal service.signature_services[:lib].latest_env.constant_decls[TypeName("::Hello::World")], content.decl
+        assert_equal service.signature_services[:lib].latest_env.constant_decls[RBS::TypeName.parse("::Hello::World")], content.decl
       end
     end
   end

--- a/test/server/lsp_formatter_test.rb
+++ b/test/server/lsp_formatter_test.rb
@@ -241,10 +241,14 @@ class Steep::Server::LSPFormatterTest < Minitest::Test
           ----
           ### 📚 Array#compact
 
-          Returns a new Array containing all non-`nil` elements from `self`:
+          Returns a new array containing only the non-`nil` elements from `self`;
+          element order is preserved:
 
-              a = [nil, 0, nil, 1, nil, 2, nil]
-              a.compact # => [0, 1, 2]
+              a = [nil, 0, nil, false, nil, '', nil, [], nil, {}]
+              a.compact # => [0, false, \"\", [], {}]
+
+          Related: Array#compact!; see also [Methods for
+          Deleting](rdoc-ref:Array@Methods+for+Deleting).
 
 
         MD
@@ -303,7 +307,7 @@ class Steep::Server::LSPFormatterTest < Minitest::Test
         node: nil,
         method_name: MethodName("::HoverMethodCallTest#foo"),
         method_type: parse_method_type("(::String | nil) -> (::Integer | ::String)"),
-        definition: factory.definition_builder.build_instance(TypeName("::HoverMethodCallTest")).methods[:foo],
+        definition: factory.definition_builder.build_instance(RBS::TypeName.parse("::HoverMethodCallTest")).methods[:foo],
         location: nil
       )
 
@@ -342,7 +346,7 @@ class Steep::Server::LSPFormatterTest < Minitest::Test
         node: nil,
         method_name: MethodName("::HoverMethodCallTest.foo"),
         method_type: parse_method_type("(::Symbol | ::String | ::Integer | nil) -> (::Integer | ::String | ::Symbol)"),
-        definition: factory.definition_builder.build_singleton(TypeName("::HoverMethodCallTest")).methods[:foo],
+        definition: factory.definition_builder.build_singleton(RBS::TypeName.parse("::HoverMethodCallTest")).methods[:foo],
         location: nil
       )
 
@@ -382,9 +386,9 @@ class ClassHover[A < String] < BasicObject
 end
 RBS
       content = Services::HoverProvider::Ruby::ConstantContent.new(
-        full_name: TypeName("::ClassHover"),
+        full_name: RBS::TypeName.parse("::ClassHover"),
         type: parse_type("singleton(::ClassHover)"),
-        decl: factory.env.class_decls[TypeName("::ClassHover")],
+        decl: factory.env.class_decls[RBS::TypeName.parse("::ClassHover")],
         location: nil
       )
 
@@ -408,9 +412,9 @@ RBS
         end
       RBS
       content = Services::HoverProvider::Ruby::ConstantContent.new(
-        full_name: TypeName("::ClassHover"),
+        full_name: RBS::TypeName.parse("::ClassHover"),
         type: parse_type("singleton(::ClassHover)"),
-        decl: factory.env.class_decls[TypeName("::ClassHover")],
+        decl: factory.env.class_decls[RBS::TypeName.parse("::ClassHover")],
         location: nil
       )
 
@@ -440,9 +444,9 @@ RBS
       RBS
 
       content = Services::HoverProvider::Ruby::ConstantContent.new(
-        full_name: TypeName("::ClassHover"),
+        full_name: RBS::TypeName.parse("::ClassHover"),
         type: parse_type("singleton(::ClassHover)"),
-        decl: factory.env.class_decls[TypeName("::ClassHover")],
+        decl: factory.env.class_decls[RBS::TypeName.parse("::ClassHover")],
         location: nil
       )
 
@@ -473,7 +477,7 @@ RBS
       RBS
 
       Services::HoverProvider::RBS::ClassContent.new(
-        decl: factory.env.class_decls[TypeName("::HelloWorld")].primary.decl,
+        decl: factory.env.class_decls[RBS::TypeName.parse("::HelloWorld")].primary.decl,
         location: nil
       ).tap do |content|
         comment = Server::LSPFormatter.format_hover_content(content)
@@ -498,7 +502,7 @@ RBS
       RBS
 
       content = Services::HoverProvider::RBS::ClassContent.new(
-        decl: factory.env.class_decls[TypeName("::ClassHover")].primary.decl,
+        decl: factory.env.class_decls[RBS::TypeName.parse("::ClassHover")].primary.decl,
         location: nil
       )
 
@@ -523,9 +527,9 @@ RBS
       RBS
 
       content = Services::HoverProvider::Ruby::ConstantContent.new(
-        full_name: TypeName("::ClassHover::VERSION"),
+        full_name: RBS::TypeName.parse("::ClassHover::VERSION"),
         type: parse_type("::String"),
-        decl: factory.env.constant_decls[TypeName("::ClassHover::VERSION")],
+        decl: factory.env.constant_decls[RBS::TypeName.parse("::ClassHover::VERSION")],
         location: nil
       )
 
@@ -589,7 +593,7 @@ RBS
       RBS
 
       Services::HoverProvider::RBS::TypeAliasContent.new(
-        decl: factory.env.type_alias_decls[TypeName("::foo")].decl,
+        decl: factory.env.type_alias_decls[RBS::TypeName.parse("::foo")].decl,
         location: nil
       ).tap do |content|
         comment = Server::LSPFormatter.format_hover_content(content)
@@ -601,7 +605,7 @@ RBS
       end
 
       Services::HoverProvider::RBS::TypeAliasContent.new(
-        decl: factory.env.type_alias_decls[TypeName("::bar")].decl,
+        decl: factory.env.type_alias_decls[RBS::TypeName.parse("::bar")].decl,
         location: nil
       ).tap do |content|
         comment = Server::LSPFormatter.format_hover_content(content)
@@ -631,7 +635,7 @@ RBS
       RBS
 
       Services::HoverProvider::RBS::InterfaceContent.new(
-        decl: factory.env.interface_decls[TypeName("::_HelloWorld")].decl,
+        decl: factory.env.interface_decls[RBS::TypeName.parse("::_HelloWorld")].decl,
         location: nil
       ).tap do |content|
         comment = Server::LSPFormatter.format_hover_content(content)
@@ -648,7 +652,7 @@ RBS
       end
 
       Services::HoverProvider::RBS::InterfaceContent.new(
-        decl: factory.env.interface_decls[TypeName("::_HelloWorld2")].decl,
+        decl: factory.env.interface_decls[RBS::TypeName.parse("::_HelloWorld2")].decl,
         location: nil
       ).tap do |content|
         comment = Server::LSPFormatter.format_hover_content(content)
@@ -701,7 +705,7 @@ RBS
         identifier: :Foo,
         range: nil,
         type: parse_type("::String | ::Symbol"),
-        full_name: TypeName("::Foo")
+        full_name: RBS::TypeName.parse("::Foo")
       ).tap do |item|
         comment = Server::LSPFormatter.format_completion_docs(item)
         assert_equal <<~MD, comment
@@ -724,7 +728,7 @@ RBS
         identifier: :Foo,
         range: nil,
         type: parse_type("::String | ::Symbol"),
-        full_name: TypeName("::Foo")
+        full_name: RBS::TypeName.parse("::Foo")
       ).tap do |item|
         comment = Server::LSPFormatter.format_completion_docs(item)
         assert_equal <<~MD, comment
@@ -756,7 +760,7 @@ RBS
         identifier: :Foo,
         range: nil,
         type: parse_type("singleton(::Foo)"),
-        full_name: TypeName("::Foo")
+        full_name: RBS::TypeName.parse("::Foo")
       ).tap do |item|
         comment = Server::LSPFormatter.format_completion_docs(item)
         assert_equal <<~MD, comment
@@ -783,7 +787,7 @@ RBS
       end
       RBS
 
-      definition = factory.definition_builder.build_instance(TypeName("::Foo"))
+      definition = factory.definition_builder.build_instance(RBS::TypeName.parse("::Foo"))
       method = definition.methods[:foo]
 
       Services::CompletionProvider::SimpleMethodNameItem.new(
@@ -814,7 +818,7 @@ RBS
       end
       RBS
 
-      definition = factory.definition_builder.build_instance(TypeName("::Foo"))
+      definition = factory.definition_builder.build_instance(RBS::TypeName.parse("::Foo"))
       method = definition.methods[:foo]
 
       Services::CompletionProvider::SimpleMethodNameItem.new(
@@ -861,21 +865,21 @@ RBS
 
       method_decls = []
 
-      factory.definition_builder.build_instance(TypeName("::Foo")).methods[:foo].defs.each do |defn|
+      factory.definition_builder.build_instance(RBS::TypeName.parse("::Foo")).methods[:foo].defs.each do |defn|
         method_decls << MethodDecl.new(
           method_name: MethodName("::Foo#foo"),
           method_def: defn
         )
       end
 
-      factory.definition_builder.build_instance(TypeName("::Bar")).methods[:foo].defs.each do |defn|
+      factory.definition_builder.build_instance(RBS::TypeName.parse("::Bar")).methods[:foo].defs.each do |defn|
         method_decls << MethodDecl.new(
           method_name: MethodName("::Bar#foo"),
           method_def: defn
         )
       end
 
-      factory.definition_builder.build_instance(TypeName("::Baz")).methods[:foo].defs.each do |defn|
+      factory.definition_builder.build_instance(RBS::TypeName.parse("::Baz")).methods[:foo].defs.each do |defn|
         method_decls << MethodDecl.new(
           method_name: MethodName("::Baz#foo"),
           method_def: defn
@@ -943,9 +947,9 @@ RBS
         end
       RBS
 
-      decl = factory.env.class_decls[TypeName("::RBSCompletionTest")].primary.decl
+      decl = factory.env.class_decls[RBS::TypeName.parse("::RBSCompletionTest")].primary.decl
 
-      comment = Server::LSPFormatter.format_rbs_completion_docs(TypeName("::RBSCompletionTest"), decl, [decl.comment])
+      comment = Server::LSPFormatter.format_rbs_completion_docs(RBS::TypeName.parse("::RBSCompletionTest"), decl, [decl.comment])
 
       assert_equal <<~MD, comment
         ```rbs

--- a/test/signature_controller_test.rb
+++ b/test/signature_controller_test.rb
@@ -26,9 +26,9 @@ RBS
       service.update(changes)
     end
 
-    service.latest_builder.build_instance(TypeName("::Hello"))
-    assert_operator service.latest_builder.instance_cache, :key?, TypeName("::Hello")
-    assert_operator service.latest_builder.instance_cache, :key?, TypeName("::Object")
+    service.latest_builder.build_instance(RBS::TypeName.parse("::Hello"))
+    assert_operator service.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::Hello")
+    assert_operator service.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::Object")
 
     {}.tap do |changes|
       changes[Pathname("sig/foo.rbs")] = [
@@ -41,8 +41,8 @@ RBS
       service.update(changes)
     end
 
-    refute_operator service.latest_builder.instance_cache, :key?, TypeName("::Hello")
-    assert_operator service.latest_builder.instance_cache, :key?, TypeName("::Object")
+    refute_operator service.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::Hello")
+    assert_operator service.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::Object")
   end
 
   def test_update_nested
@@ -73,15 +73,15 @@ RBS
       controller.update(changes)
     end
 
-    controller.latest_builder.build_instance(TypeName("::A"))
-    controller.latest_builder.build_instance(TypeName("::A::B"))
-    controller.latest_builder.build_instance(TypeName("::A::C"))
-    controller.latest_builder.build_instance(TypeName("::X"))
+    controller.latest_builder.build_instance(RBS::TypeName.parse("::A"))
+    controller.latest_builder.build_instance(RBS::TypeName.parse("::A::B"))
+    controller.latest_builder.build_instance(RBS::TypeName.parse("::A::C"))
+    controller.latest_builder.build_instance(RBS::TypeName.parse("::X"))
 
-    assert_operator controller.latest_builder.instance_cache, :key?, TypeName("::A")
-    assert_operator controller.latest_builder.instance_cache, :key?, TypeName("::A::B")
-    assert_operator controller.latest_builder.instance_cache, :key?, TypeName("::A::C")
-    assert_operator controller.latest_builder.instance_cache, :key?, TypeName("::X")
+    assert_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::A")
+    assert_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::A::B")
+    assert_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::A::C")
+    assert_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::X")
 
     {}.tap do |changes|
       changes[Pathname("sig/foo.rbs")] = [
@@ -96,10 +96,10 @@ RBS
       controller.update(changes)
     end
 
-    refute_operator controller.latest_builder.instance_cache, :key?, TypeName("::A")
-    refute_operator controller.latest_builder.instance_cache, :key?, TypeName("::A::B")
-    refute_operator controller.latest_builder.instance_cache, :key?, TypeName("::A::C")
-    assert_operator controller.latest_builder.instance_cache, :key?, TypeName("::X")
+    refute_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::A")
+    refute_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::A::B")
+    refute_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::A::C")
+    assert_operator controller.latest_builder.instance_cache, :key?, RBS::TypeName.parse("::X")
   end
 
   def test_update_syntax_error
@@ -228,8 +228,8 @@ RBS
       controller.update(changes)
     end
 
-    assert_operator controller.latest_env.class_decls, :key?, TypeName("::B")
-    assert_operator controller.latest_env.class_decls, :key?, TypeName("::A")
+    assert_operator controller.latest_env.class_decls, :key?, RBS::TypeName.parse("::B")
+    assert_operator controller.latest_env.class_decls, :key?, RBS::TypeName.parse("::A")
   end
 
   def test_const_decls
@@ -247,11 +247,11 @@ RBS
     end
 
     service.const_decls(paths: Set[Pathname("sig/foo.rbs")], env: service.latest_env).tap do |consts|
-      assert_equal Set[TypeName("::VERSION")], Set.new(consts.each_key)
+      assert_equal Set[RBS::TypeName.parse("::VERSION")], Set.new(consts.each_key)
     end
 
     service.const_decls(paths: Set[RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "file.rbs"], env: service.latest_env).tap do |consts|
-      assert_operator consts.each_key, :include?, TypeName("::File::PATH_SEPARATOR")
+      assert_operator consts.each_key, :include?, RBS::TypeName.parse("::File::PATH_SEPARATOR")
     end
   end
 

--- a/test/source_index_test.rb
+++ b/test/source_index_test.rb
@@ -22,7 +22,7 @@ RUBY
 
       assert_equal 0, index.count
 
-      index.add_definition(constant: TypeName("::Foo"), definition: dig(source.node, 0, 0))
+      index.add_definition(constant: RBS::TypeName.parse("::Foo"), definition: dig(source.node, 0, 0))
 
       assert_equal 1, index.count
 
@@ -30,7 +30,7 @@ RUBY
 
       assert_equal 1, child.count
 
-      child.add_definition(constant: TypeName("::Bar"), definition: dig(source.node, 1, 0))
+      child.add_definition(constant: RBS::TypeName.parse("::Bar"), definition: dig(source.node, 1, 0))
 
       assert_equal 1, index.count
       assert_equal 2, child.count
@@ -54,7 +54,7 @@ RUBY
       index = SourceIndex.new(source: source)
       child = index.new_child
 
-      index.add_definition(constant: TypeName("::Foo"), definition: dig(source.node, 0, 0))
+      index.add_definition(constant: RBS::TypeName.parse("::Foo"), definition: dig(source.node, 0, 0))
 
       assert_raises do
         index.merge!(child)
@@ -88,17 +88,17 @@ end
 
         assert_instance_of SourceIndex, typing.source_index
 
-        typing.source_index.constant_index[TypeName("::Foo")].tap do |entry|
+        typing.source_index.constant_index[RBS::TypeName.parse("::Foo")].tap do |entry|
           assert_equal Set[dig(source.node, 0)].compare_by_identity, entry.definitions
           assert_empty entry.references
         end
 
-        typing.source_index.constant_index[TypeName("::Bar")].tap do |entry|
+        typing.source_index.constant_index[RBS::TypeName.parse("::Bar")].tap do |entry|
           assert_equal Set[dig(source.node, 2, 1, 0)].compare_by_identity, entry.definitions
           assert_empty entry.references
         end
 
-        typing.source_index.constant_index[TypeName("::Foo::VERSION")].tap do |entry|
+        typing.source_index.constant_index[RBS::TypeName.parse("::Foo::VERSION")].tap do |entry|
           assert_equal Set[dig(source.node, 2, 0)].compare_by_identity, entry.definitions
           assert_empty entry.references
         end

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -55,7 +55,7 @@ Foo::Bar.new
       # module
       source.annotations(block: dig(source.node, 0),
                          factory: factory,
-                         context: [nil, TypeName("::Foo")]).yield_self do |annotations|
+                         context: [nil, RBS::TypeName.parse("::Foo")]).yield_self do |annotations|
         assert_any annotations do |a|
           a == A::VarType.new(name: :x2, type: T::Any.new)
         end
@@ -67,7 +67,7 @@ Foo::Bar.new
 
       source.annotations(block: dig(source.node, 0, 1),
                          factory: factory,
-                         context: [nil, TypeName("::Foo::Bar")]).yield_self do |annotations|
+                         context: [nil, RBS::TypeName.parse("::Foo::Bar")]).yield_self do |annotations|
         assert_equal 5, annotations.size
         assert_equal parse_type("::String"), annotations.instance_type
         assert_equal parse_type("singleton(::String)"), annotations.module_type
@@ -77,7 +77,7 @@ Foo::Bar.new
       # def
       source.annotations(block: dig(source.node, 0, 1, 2, 0),
                          factory: factory,
-                         context: [nil, TypeName("::Foo::Bar")]).yield_self do |annotations|
+                         context: [nil, RBS::TypeName.parse("::Foo::Bar")]).yield_self do |annotations|
         assert_equal 2, annotations.size
         assert_equal T::Any.new, annotations.var_type(lvar: :x4)
         assert_equal T::Any.new, annotations.return_type
@@ -86,7 +86,7 @@ Foo::Bar.new
       # block
       source.annotations(block: dig(source.node, 0, 1, 2, 0, 2),
                          factory: factory,
-                         context: [nil, TypeName("::Foo::Bar")]).yield_self do |annotations|
+                         context: [nil, RBS::TypeName.parse("::Foo::Bar")]).yield_self do |annotations|
         assert_equal 2, annotations.size
         assert_equal T::Any.new, annotations.var_type(lvar: :x5)
         assert_equal parse_type("::Integer"), annotations.block_type
@@ -433,7 +433,7 @@ end
       EOF
       def_node = dig(source.node, 2)
 
-      annotations = source.annotations(block: def_node, factory: factory, context: [nil, TypeName("::A")])
+      annotations = source.annotations(block: def_node, factory: factory, context: [nil, RBS::TypeName.parse("::A")])
       assert_equal parse_type("::Integer"), annotations.var_type(lvar: :x)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,12 +47,12 @@ end
 
 module Steep::AST::Types::Name
   def self.new_singleton(name:)
-    name = TypeName(name.to_s) unless name.is_a?(RBS::TypeName)
+    name = RBS::TypeName.parse(name.to_s) unless name.is_a?(RBS::TypeName)
     Steep::AST::Types::Name::Singleton.new(name: name)
   end
 
   def self.new_instance(name:, args: [])
-    name = TypeName(name.to_s) unless name.is_a?(RBS::TypeName)
+    name = RBS::TypeName.parse(name.to_s) unless name.is_a?(RBS::TypeName)
     Steep::AST::Types::Name::Instance.new(name: name, args: args)
   end
 end

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -1004,10 +1004,10 @@ class Person end
       source = parse_ruby("class Person; end")
 
       with_standard_construction(checker, source) do |construction, typing|
-        for_class = construction.for_class(source.node, TypeName("::Person"), nil)
+        for_class = construction.for_class(source.node, RBS::TypeName.parse("::Person"), nil)
 
         assert_equal(
-          Annotation::Implements::Module.new(name: TypeName("::Person"), args: []),
+          Annotation::Implements::Module.new(name: RBS::TypeName.parse("::Person"), args: []),
           for_class.module_context.implement_name
         )
         assert_equal parse_type("::Person"), for_class.module_context.instance_type
@@ -1024,7 +1024,7 @@ end
       source = parse_ruby("class Person; end")
 
       with_standard_construction(checker, source) do |construction, typing|
-        for_class = construction.for_class(source.node, TypeName("::Person"), nil)
+        for_class = construction.for_class(source.node, RBS::TypeName.parse("::Person"), nil)
 
         assert_nil for_class.module_context.implement_name
         assert_equal parse_type("::Object"), for_class.module_context.instance_type
@@ -1043,11 +1043,11 @@ end
     EOF
       source = parse_ruby("module Steep; class Names::Module; end; end")
 
-      context = [nil, TypeName("::Steep")]
+      context = [nil, RBS::TypeName.parse("::Steep")]
       annotations = source.annotations(block: source.node, factory: checker.factory, context: context)
       const_env = ConstantEnv.new(
         factory: factory,
-        context: [nil, TypeName("::Steep")],
+        context: [nil, RBS::TypeName.parse("::Steep")],
         resolver: RBS::Resolver::ConstantResolver.new(builder: factory.definition_builder)
       )
       type_env = TypeEnv.new(const_env)
@@ -1080,11 +1080,11 @@ end
                                           context: context,
                                           typing: typing)
 
-      for_module = construction.for_class(module_name_class_node, TypeName("::Steep::Names::Module"), nil)
+      for_module = construction.for_class(module_name_class_node, RBS::TypeName.parse("::Steep::Names::Module"), nil)
 
       assert_equal(
         Annotation::Implements::Module.new(
-          name: TypeName("::Steep::Names::Module"),
+          name: RBS::TypeName.parse("::Steep::Names::Module"),
           args: []
         ),
         for_module.module_context.implement_name)
@@ -1099,10 +1099,10 @@ module Steep end
       source = parse_ruby("module Steep; end")
 
       with_standard_construction(checker, source) do |construction, typing|
-        for_module = construction.for_module(source.node, TypeName("::Steep"))
+        for_module = construction.for_module(source.node, RBS::TypeName.parse("::Steep"))
 
         assert_equal(
-          Annotation::Implements::Module.new(name: TypeName("::Steep"), args: []),
+          Annotation::Implements::Module.new(name: RBS::TypeName.parse("::Steep"), args: []),
           for_module.module_context.implement_name
         )
         assert_equal parse_type("::Object & ::Steep"), for_module.module_context.instance_type
@@ -1121,7 +1121,7 @@ module Rails end
       with_standard_construction(checker, source) do |construction, typing|
         construction.synthesize(source.node)
 
-        for_module = construction.for_module(source.node, TypeName("::Steep"))
+        for_module = construction.for_module(source.node, RBS::TypeName.parse("::Steep"))
 
         assert_nil for_module.module_context.implement_name
         assert_equal parse_type("::BasicObject"), for_module.module_context.instance_type
@@ -1138,9 +1138,9 @@ class Steep end
     EOS
       source = parse_ruby("class Steep; module Printable; end; end")
 
-      context = [nil, TypeName("::Steep")]
+      context = [nil, RBS::TypeName.parse("::Steep")]
       annotations = source.annotations(block: source.node, factory: checker.factory, context: context)
-      const_env = ConstantEnv.new(factory: factory, context: [nil, TypeName("::Steep")], resolver: RBS::Resolver::ConstantResolver.new(builder: factory.definition_builder))
+      const_env = ConstantEnv.new(factory: factory, context: [nil, RBS::TypeName.parse("::Steep")], resolver: RBS::Resolver::ConstantResolver.new(builder: factory.definition_builder))
       type_env = TypeEnv.new(const_env)
 
       module_context = Context::ModuleContext.new(
@@ -1148,7 +1148,7 @@ class Steep end
         module_type: parse_type("singleton(::Steep)"),
         implement_name: nil,
         nesting: const_env.context,
-        class_name: TypeName("::Steep")
+        class_name: RBS::TypeName.parse("::Steep")
       )
 
       context = Context.new(
@@ -1158,7 +1158,7 @@ class Steep end
         break_context: nil,
         self_type: nil,
         type_env: type_env,
-        call_context: MethodCall::ModuleContext.new(type_name: TypeName("::Steep")),
+        call_context: MethodCall::ModuleContext.new(type_name: RBS::TypeName.parse("::Steep")),
         variable_context: Context::TypeVariableContext.empty
       )
       typing = Typing.new(source: source, root_context: context, cursor: nil)
@@ -1171,10 +1171,10 @@ class Steep end
                                           context: context,
                                           typing: typing)
 
-      for_module = construction.for_module(module_node, TypeName("::Steep::Printable"))
+      for_module = construction.for_module(module_node, RBS::TypeName.parse("::Steep::Printable"))
 
       assert_equal(
-        Annotation::Implements::Module.new(name: TypeName("::Steep::Printable"), args: []),
+        Annotation::Implements::Module.new(name: RBS::TypeName.parse("::Steep::Printable"), args: []),
         for_module.module_context.implement_name)
     end
   end
@@ -5518,7 +5518,7 @@ end
 EOF
 
       with_standard_construction(checker, source) do |construction, typing|
-        class_constr = construction.for_class(source.node, TypeName("::WithSingleton"), nil)
+        class_constr = construction.for_class(source.node, RBS::TypeName.parse("::WithSingleton"), nil)
         type, _ = class_constr.synthesize(dig(source.node, 2, 0))
         sclass_constr = class_constr.for_sclass(dig(source.node, 2), type)
 
@@ -5585,10 +5585,10 @@ end
 
         assert_equal parse_type("::WithSingleton"), module_context.instance_type
         assert_equal parse_type("singleton(::WithSingleton)"), module_context.module_type
-        assert_equal TypeName("::Object"), module_context.class_name
+        assert_equal RBS::TypeName.parse("::Object"), module_context.class_name
         assert_nil module_context.implement_name
-        assert_equal TypeName("::WithSingleton"), module_context.module_definition.type_name
-        assert_equal TypeName("::WithSingleton"), module_context.instance_definition.type_name
+        assert_equal RBS::TypeName.parse("::WithSingleton"), module_context.module_definition.type_name
+        assert_equal RBS::TypeName.parse("::WithSingleton"), module_context.instance_definition.type_name
 
         construction.synthesize(source.node)
 

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -154,13 +154,13 @@ class TypeFactoryTest < Minitest::Test
     with_factory() do |factory|
       factory.type(parse_type("foo")).yield_self do |type|
         assert_instance_of Types::Name::Alias, type
-        assert_equal TypeName("foo"), type.name
+        assert_equal RBS::TypeName.parse("foo"), type.name
         assert_equal [], type.args
       end
 
       factory.type(parse_type("foo[untyped]")).yield_self do |type|
         assert_instance_of Types::Name::Alias, type
-        assert_equal TypeName("foo"), type.name
+        assert_equal RBS::TypeName.parse("foo"), type.name
         assert_equal [Types::Any.new], type.args
       end
 
@@ -385,7 +385,7 @@ end
     EOF
 
       factory.type(parse_type("Bar")).tap do |type|
-        factory.absolute_type(type, context: [nil, TypeName("::Foo")]) do |absolute_type|
+        factory.absolute_type(type, context: [nil, RBS::TypeName.parse("::Foo")]) do |absolute_type|
           assert_equal factory.type(parse_type("::Foo::Bar")), absolute_type
         end
       end

--- a/test/type_name_completion_test.rb
+++ b/test/type_name_completion_test.rb
@@ -67,18 +67,18 @@ class TypeNameCompletionTest < Minitest::Test
       completion = Services::TypeNameCompletion.new(env: factory.env, context: nil, dirs: [])
 
       # Returns all accessible type names from the context
-      assert_equal [TypeName("::Foo")], completion.find_type_names(nil)
+      assert_equal [RBS::TypeName.parse("::Foo")], completion.find_type_names(nil)
 
       # Returns all type names that contains the identifier case-insensitively
-      assert_equal [TypeName("::Foo::Bar"), TypeName("::Foo::Bar::baz"), TypeName("::Foo::Bar::_Quax")], completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("ba"))
+      assert_equal [RBS::TypeName.parse("::Foo::Bar"), RBS::TypeName.parse("::Foo::Bar::baz"), RBS::TypeName.parse("::Foo::Bar::_Quax")], completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("ba"))
 
       # Returns all type names that shares the prefix and contains the identifier case-insensitively
-      assert_equal [TypeName("::Foo::Bar::baz")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("::Foo::Bar::"), "ba"))
+      assert_equal [RBS::TypeName.parse("::Foo::Bar::baz")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("::Foo::Bar::"), "ba"))
 
-      assert_equal [TypeName("::Foo")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("::"), "Fo"))
+      assert_equal [RBS::TypeName.parse("::Foo")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("::"), "Fo"))
 
       # Returns all type names that shares the prefix
-      assert_equal [TypeName("::Foo::Bar::baz"), TypeName("::Foo::Bar::_Quax")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacePrefix.new(RBS::Namespace.parse("::Foo::Bar::")))
+      assert_equal [RBS::TypeName.parse("::Foo::Bar::baz"), RBS::TypeName.parse("::Foo::Bar::_Quax")], completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacePrefix.new(RBS::Namespace.parse("::Foo::Bar::")))
     end
   end
 
@@ -96,8 +96,8 @@ class TypeNameCompletionTest < Minitest::Test
         dirs: dirs
       )
 
-      refute completion.each_type_name.include?(TypeName("NoSuchClass"))
-      assert completion.each_type_name.include?(TypeName("ExistingClass"))
+      refute completion.each_type_name.include?(RBS::TypeName.parse("NoSuchClass"))
+      assert completion.each_type_name.include?(RBS::TypeName.parse("ExistingClass"))
     end
   end
 
@@ -121,11 +121,11 @@ class TypeNameCompletionTest < Minitest::Test
         dirs: dirs
       )
 
-      assert completion.each_type_name.include?(TypeName("::Foo"))
-      assert completion.each_type_name.include?(TypeName("::Foo::Bar"))
-      assert completion.each_type_name.include?(TypeName("::Foo::Bar::Baz"))
-      assert completion.each_type_name.include?(TypeName("::Bar"))
-      assert completion.each_type_name.include?(TypeName("::Bar::Baz"))
+      assert completion.each_type_name.include?(RBS::TypeName.parse("::Foo"))
+      assert completion.each_type_name.include?(RBS::TypeName.parse("::Foo::Bar"))
+      assert completion.each_type_name.include?(RBS::TypeName.parse("::Foo::Bar::Baz"))
+      assert completion.each_type_name.include?(RBS::TypeName.parse("::Bar"))
+      assert completion.each_type_name.include?(RBS::TypeName.parse("::Bar::Baz"))
     end
   end
 
@@ -153,9 +153,9 @@ class TypeNameCompletionTest < Minitest::Test
 
       type_names = completion.each_type_name.to_set
 
-      assert type_names.include?(TypeName("FOO"))
-      assert type_names.include?(TypeName("FOO::Bar"))
-      assert type_names.include?(TypeName("FOO::Bar::t"))
+      assert type_names.include?(RBS::TypeName.parse("FOO"))
+      assert type_names.include?(RBS::TypeName.parse("FOO::Bar"))
+      assert type_names.include?(RBS::TypeName.parse("FOO::Bar::t"))
     end
   end
 
@@ -174,12 +174,12 @@ class TypeNameCompletionTest < Minitest::Test
         end
       RBS
 
-      completion = Services::TypeNameCompletion.new(env: factory.env, context: [nil, TypeName("::Foo")], dirs: [])
+      completion = Services::TypeNameCompletion.new(env: factory.env, context: [nil, RBS::TypeName.parse("::Foo")], dirs: [])
 
-      assert_equal [TypeName("::Foo::baz"), TypeName("baz")], completion.resolve_name_in_context(TypeName("::Foo::baz"))
-      assert_equal [TypeName("::Foo::Bar::baz"), TypeName("Bar::baz")], completion.resolve_name_in_context(TypeName("::Foo::Bar::baz"))
+      assert_equal [RBS::TypeName.parse("::Foo::baz"), RBS::TypeName.parse("baz")], completion.resolve_name_in_context(RBS::TypeName.parse("::Foo::baz"))
+      assert_equal [RBS::TypeName.parse("::Foo::Bar::baz"), RBS::TypeName.parse("Bar::baz")], completion.resolve_name_in_context(RBS::TypeName.parse("::Foo::Bar::baz"))
 
-      assert_equal [TypeName("::Foo::_Quax"), TypeName("_Quax")], completion.resolve_name_in_context(TypeName("::Foo::_Quax"))
+      assert_equal [RBS::TypeName.parse("::Foo::_Quax"), RBS::TypeName.parse("_Quax")], completion.resolve_name_in_context(RBS::TypeName.parse("::Foo::_Quax"))
     end
   end
 
@@ -197,25 +197,25 @@ class TypeNameCompletionTest < Minitest::Test
 
       completion = Services::TypeNameCompletion.new(env: factory.env, context: nil, dirs: dirs)
 
-      assert_operator completion.each_type_name, :include?, TypeName("Foo")
-      assert_operator completion.each_type_name, :include?, TypeName("String")
-      assert_operator completion.each_type_name, :include?, TypeName("::String")
+      assert_operator completion.each_type_name, :include?, RBS::TypeName.parse("Foo")
+      assert_operator completion.each_type_name, :include?, RBS::TypeName.parse("String")
+      assert_operator completion.each_type_name, :include?, RBS::TypeName.parse("::String")
 
-      assert_operator completion.find_type_names(nil), :include?, TypeName("Foo")
-      assert_operator completion.find_type_names(nil), :include?, TypeName("String")
-      assert_operator completion.find_type_names(nil), :include?, TypeName("::String")
+      assert_operator completion.find_type_names(nil), :include?, RBS::TypeName.parse("Foo")
+      assert_operator completion.find_type_names(nil), :include?, RBS::TypeName.parse("String")
+      assert_operator completion.find_type_names(nil), :include?, RBS::TypeName.parse("::String")
 
-      assert_operator completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Foo")), :include?, TypeName("Foo")
+      assert_operator completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Foo")), :include?, RBS::TypeName.parse("Foo")
       assert_operator(
         completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacePrefix.new(RBS::Namespace.parse("Long::"), 6)),
         :include?,
-        TypeName("Long::hello")
+        RBS::TypeName.parse("Long::hello")
       )
 
-      assert_equal [TypeName("::Object"), TypeName("Foo")], completion.resolve_name_in_context(TypeName("Foo"))
-      assert_equal [TypeName("::Integer"), TypeName("String")], completion.resolve_name_in_context(TypeName("String"))
-      assert_equal [TypeName("::String"), TypeName("::String")], completion.resolve_name_in_context(TypeName("::String"))
-      assert_equal [TypeName("::LongName::hello"), TypeName("Long::hello")], completion.resolve_name_in_context(TypeName("Long::hello"))
+      assert_equal [RBS::TypeName.parse("::Object"), RBS::TypeName.parse("Foo")], completion.resolve_name_in_context(RBS::TypeName.parse("Foo"))
+      assert_equal [RBS::TypeName.parse("::Integer"), RBS::TypeName.parse("String")], completion.resolve_name_in_context(RBS::TypeName.parse("String"))
+      assert_equal [RBS::TypeName.parse("::String"), RBS::TypeName.parse("::String")], completion.resolve_name_in_context(RBS::TypeName.parse("::String"))
+      assert_equal [RBS::TypeName.parse("::LongName::hello"), RBS::TypeName.parse("Long::hello")], completion.resolve_name_in_context(RBS::TypeName.parse("Long::hello"))
     end
   end
 
@@ -233,12 +233,12 @@ class TypeNameCompletionTest < Minitest::Test
       completion = Services::TypeNameCompletion.new(env: factory.env, context: nil, dirs: [])
 
       assert_equal(
-        [TypeName("::Baz::id")],
+        [RBS::TypeName.parse("::Baz::id")],
         completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacePrefix.new(RBS::Namespace.parse("Baz::")))
       )
 
       assert_equal(
-        [TypeName("::Baz::id")],
+        [RBS::TypeName.parse("::Baz::id")],
         completion.find_type_names(Services::TypeNameCompletion::Prefix::NamespacedIdentPrefix.new(RBS::Namespace.parse("Baz::"), "i"))
       )
     end
@@ -261,35 +261,35 @@ class TypeNameCompletionTest < Minitest::Test
       buf = factory.env.buffers.find {|buf| Pathname(buf.name).basename == Pathname("a.rbs") }
       dirs = factory.env.signatures[buf][0]
 
-      completion = Services::TypeNameCompletion.new(env: factory.env, context: [[nil, TypeName("::Foo")], TypeName("::Foo::Bar")], dirs: dirs)
+      completion = Services::TypeNameCompletion.new(env: factory.env, context: [[nil, RBS::TypeName.parse("::Foo")], RBS::TypeName.parse("::Foo::Bar")], dirs: dirs)
 
       assert_operator(
         completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Baz")),
         :include?,
-        TypeName("Bar::Baz")
+        RBS::TypeName.parse("Bar::Baz")
       )
       assert_operator(
         completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Baz")),
         :include?,
-        TypeName("::Bar::Baz")
+        RBS::TypeName.parse("::Bar::Baz")
       )
       assert_operator(
         completion.find_type_names(Services::TypeNameCompletion::Prefix::RawIdentPrefix.new("Baz")),
         :include?,
-        TypeName("::Foo::Bar::Baz")
+        RBS::TypeName.parse("::Foo::Bar::Baz")
       )
 
       assert_equal(
-        [TypeName("::Foo::Bar::Baz"), TypeName("Baz")],
-        completion.resolve_name_in_context(TypeName("::Foo::Bar::Baz"))
+        [RBS::TypeName.parse("::Foo::Bar::Baz"), RBS::TypeName.parse("Baz")],
+        completion.resolve_name_in_context(RBS::TypeName.parse("::Foo::Bar::Baz"))
       )
       assert_equal(
-        [TypeName("::Foo::Bar::Baz"), TypeName("::Bar::Baz")],
-        completion.resolve_name_in_context(TypeName("::Bar::Baz"))
+        [RBS::TypeName.parse("::Foo::Bar::Baz"), RBS::TypeName.parse("::Bar::Baz")],
+        completion.resolve_name_in_context(RBS::TypeName.parse("::Bar::Baz"))
       )
       assert_equal(
-        [TypeName("::Foo::Bar::Baz"), TypeName("Bar::Baz")],
-        completion.resolve_name_in_context(TypeName("Bar::Baz"))
+        [RBS::TypeName.parse("::Foo::Bar::Baz"), RBS::TypeName.parse("Bar::Baz")],
+        completion.resolve_name_in_context(RBS::TypeName.parse("Bar::Baz"))
       )
     end
   end

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -102,12 +102,12 @@ type b = no_such_type
 
       assert_any! validator.each_error do |error|
         assert_instance_of Diagnostic::Signature::UnknownTypeName, error
-        assert_equal TypeName("::X::Y::Z"), error.name
+        assert_equal RBS::TypeName.parse("::X::Y::Z"), error.name
       end
 
       assert_any! validator.each_error do |error|
         assert_instance_of Diagnostic::Signature::UnknownTypeName, error
-        assert_equal TypeName("::no_such_type"), error.name
+        assert_equal RBS::TypeName.parse("::no_such_type"), error.name
       end
     end
   end
@@ -134,7 +134,7 @@ type broken[T] = Array[broken[Array[T]]]
       assert_operator validator, :has_error?
       assert_any!(validator.each_error, size: 1) do |error|
         assert_instance_of Diagnostic::Signature::NonregularTypeAlias, error
-        assert_equal TypeName("::broken"), error.type_name
+        assert_equal RBS::TypeName.parse("::broken"), error.type_name
         assert_equal parse_type("::broken[::Array[T]]", variables: [:T]), error.nonregular_type
       end
     end
@@ -149,7 +149,7 @@ type broken[T] = broken[Array[T]]
       assert_operator validator, :has_error?
       assert_any! validator.each_error, size: 1 do |error|
         assert_instance_of Diagnostic::Signature::RecursiveTypeAlias, error
-        assert_equal [TypeName("::broken")], error.alias_names
+        assert_equal [RBS::TypeName.parse("::broken")], error.alias_names
       end
     end
   end
@@ -185,7 +185,7 @@ end
       assert_predicate validator, :has_error?
       assert_any! validator.each_error.to_a, size: 1 do |error|
         assert_instance_of Diagnostic::Signature::UnknownTypeName, error
-        assert_equal TypeName("Arraay"), error.name
+        assert_equal RBS::TypeName.parse("Arraay"), error.name
       end
     end
   end
@@ -331,7 +331,7 @@ end
       assert_operator validator, :has_error?
       assert_any! validator.each_error do |error|
         assert_instance_of Diagnostic::Signature::UnknownMethodAlias, error
-        assert_equal TypeName("::_Hello"), error.class_name
+        assert_equal RBS::TypeName.parse("::_Hello"), error.class_name
         assert_equal :bar, error.method_name
         assert_equal "alias foo bar", error.location.source
       end
@@ -353,7 +353,7 @@ end
       assert_operator validator, :has_error?
       assert_any! validator.each_error do |error|
         assert_instance_of Diagnostic::Signature::DuplicatedMethodDefinition, error
-        assert_equal TypeName("::Foo"), error.class_name
+        assert_equal RBS::TypeName.parse("::Foo"), error.class_name
         assert_equal :foo, error.method_name
       end
     end
@@ -381,7 +381,7 @@ end
       assert_operator validator, :has_error?
       assert_any! validator.each_error do |error|
         assert_instance_of Diagnostic::Signature::DuplicatedMethodDefinition, error
-        assert_equal TypeName("::Foo"), error.class_name
+        assert_equal RBS::TypeName.parse("::Foo"), error.class_name
         assert_equal :foo, error.method_name
       end
     end
@@ -401,7 +401,7 @@ end
       assert_operator validator, :has_error?
       assert_any! validator.each_error do |error|
         assert_instance_of Diagnostic::Signature::RecursiveAlias, error
-        assert_equal TypeName("::Foo"), error.class_name
+        assert_equal RBS::TypeName.parse("::Foo"), error.class_name
         assert_equal Set[:foo, :bar], Set.new(error.names)
       end
     end
@@ -445,13 +445,13 @@ end
     EOF
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::A"))
+        validator.validate_one_class(RBS::TypeName.parse("::A"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::B"))
+        validator.validate_one_class(RBS::TypeName.parse("::B"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -460,7 +460,7 @@ end
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C"))
+        validator.validate_one_class(RBS::TypeName.parse("::C"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -469,13 +469,13 @@ end
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::D"))
+        validator.validate_one_class(RBS::TypeName.parse("::D"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::E"))
+        validator.validate_one_class(RBS::TypeName.parse("::E"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -514,19 +514,19 @@ end
     EOF
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::A"))
+        validator.validate_one_class(RBS::TypeName.parse("::A"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::B"))
+        validator.validate_one_class(RBS::TypeName.parse("::B"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C"))
+        validator.validate_one_class(RBS::TypeName.parse("::C"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -563,13 +563,13 @@ class D
 end
 EOF
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::A"))
+        validator.validate_one_class(RBS::TypeName.parse("::A"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::B"))
+        validator.validate_one_class(RBS::TypeName.parse("::B"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -578,7 +578,7 @@ EOF
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C"))
+        validator.validate_one_class(RBS::TypeName.parse("::C"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -587,7 +587,7 @@ EOF
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::D"))
+        validator.validate_one_class(RBS::TypeName.parse("::D"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -611,19 +611,19 @@ class C < B
 end
     EOF
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::A"))
+        validator.validate_one_class(RBS::TypeName.parse("::A"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C"))
+        validator.validate_one_class(RBS::TypeName.parse("::C"))
 
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::B"))
+        validator.validate_one_class(RBS::TypeName.parse("::B"))
 
         assert_predicate validator, :has_error?
         assert_any!(validator.each_error, size: 1) do |error|
@@ -698,12 +698,12 @@ end
     EOF
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::Foo"))
+        validator.validate_one_class(RBS::TypeName.parse("::Foo"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::Bar"))
+        validator.validate_one_class(RBS::TypeName.parse("::Bar"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -734,17 +734,17 @@ end
 RBS
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::Base"))
+        validator.validate_one_class(RBS::TypeName.parse("::Base"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C0"))
+        validator.validate_one_class(RBS::TypeName.parse("::C0"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C1"))
+        validator.validate_one_class(RBS::TypeName.parse("::C1"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -755,12 +755,12 @@ RBS
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::D0"))
+        validator.validate_one_class(RBS::TypeName.parse("::D0"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::D1"))
+        validator.validate_one_class(RBS::TypeName.parse("::D1"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -791,17 +791,17 @@ end
 RBS
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::Base"))
+        validator.validate_one_class(RBS::TypeName.parse("::Base"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::M1"))
+        validator.validate_one_class(RBS::TypeName.parse("::M1"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::M2"))
+        validator.validate_one_class(RBS::TypeName.parse("::M2"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -812,12 +812,12 @@ RBS
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::M3"))
+        validator.validate_one_class(RBS::TypeName.parse("::M3"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::M4"))
+        validator.validate_one_class(RBS::TypeName.parse("::M4"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -874,22 +874,22 @@ end
 RBS
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::M"))
+        validator.validate_one_class(RBS::TypeName.parse("::M"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::N"))
+        validator.validate_one_class(RBS::TypeName.parse("::N"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C0"))
+        validator.validate_one_class(RBS::TypeName.parse("::C0"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::C1"))
+        validator.validate_one_class(RBS::TypeName.parse("::C1"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 4) do |error|
@@ -918,12 +918,12 @@ RBS
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::D0"))
+        validator.validate_one_class(RBS::TypeName.parse("::D0"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_class(TypeName("::D1"))
+        validator.validate_one_class(RBS::TypeName.parse("::D1"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 2) do |error|
@@ -964,17 +964,17 @@ end
 RBS
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_A"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_A"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_I0"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_I0"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_I1"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_I1"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -985,12 +985,12 @@ RBS
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_J0"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_J0"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_J1"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_J1"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -1016,12 +1016,12 @@ end
     EOF
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_Foo"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_Foo"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_Bar"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_Bar"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -1047,12 +1047,12 @@ end
     EOF
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_Foo"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_Foo"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_interface(TypeName("::_Bar"))
+        validator.validate_one_interface(RBS::TypeName.parse("::_Bar"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|
@@ -1074,12 +1074,12 @@ type bar[X < String] = x[X]
     EOF
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_alias(TypeName("::foo"))
+        validator.validate_one_alias(RBS::TypeName.parse("::foo"))
         assert_predicate validator, :no_error?
       end
 
       Validator.new(checker: checker).tap do |validator|
-        validator.validate_one_alias(TypeName("::bar"))
+        validator.validate_one_alias(RBS::TypeName.parse("::bar"))
         refute_predicate validator, :no_error?
 
         assert_any!(validator.each_error, size: 1) do |error|


### PR DESCRIPTION
### The `TypeName` is deprecated in rbs 3.8.

I add `lib/steep/rbs_compat.rb` and It works in both rbs v3.7 and v3.8.

### Fix testing code

I fixed `test/server/lsp_formatter_test.rb`.
It appears that the Array#compact documentation has been updated.

### `gem 'rbs', '~> 3.7'`

We can try!