### PR TITLE
Steepfile: Allow to change the extension of the source files

### DIFF
--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -74,6 +74,10 @@ module Steep
           sources.concat(args)
         end
 
+        def ext(ext)
+          @ext = ext
+        end
+
         def ignore(*args)
           ignored_sources.concat(args)
         end
@@ -103,7 +107,7 @@ module Steep
         end
 
         def source_pattern
-          Pattern.new(patterns: sources, ignores: ignored_sources, ext: ".rb")
+          Pattern.new(patterns: sources, ignores: ignored_sources, ext: @ext || ".rb")
         end
 
         def signature_pattern

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -421,7 +421,7 @@ module Steep
                   end
                   target.source_pattern.prefixes.each do |pat|
                     path = project.base_dir + pat
-                    patterns << (path + "**/*.rb").to_s unless path.file?
+                    patterns << (path + "**/*#{target.source_pattern.ext}").to_s unless path.file?
                   end
                   target.signature_pattern.patterns.each do |pat|
                     path = project.base_dir + pat
@@ -800,7 +800,7 @@ module Steep
           Steep.logger.info "Starting new progress..."
 
           @current_type_check_request = request
-          
+
           if progress
             # If `request:` keyword arg is not given
             request.work_done_progress.begin("Type checking", request_id: fresh_request_id)

--- a/sample/Steepfile
+++ b/sample/Steepfile
@@ -20,3 +20,8 @@ end
 #   signature "sig/length.rbs"
 #   unreferenced!
 # end
+
+# target :templates do
+#   check "lib/templates"                       # Directory name
+#   ext ".erb"
+# end

--- a/sig/steep/project/dsl.rbs
+++ b/sig/steep/project/dsl.rbs
@@ -59,7 +59,11 @@ module Steep
 
         attr_reader ignored_signatures: Array[String]
 
+        @ext: String?
+
         def check: (*String args) -> void
+
+        def ext: (String ext) -> void
 
         def ignore: (*String args) -> void
 

--- a/test/steepfile_test.rb
+++ b/test/steepfile_test.rb
@@ -336,4 +336,28 @@ YAML
       end
     end
   end
+
+  def test_ext
+    in_tmpdir do
+      project = Project.new(steepfile_path: current_dir + "Steepfile")
+
+      Project::DSL.parse(project, <<EOF)
+target :views do
+  check "app/views"
+  ext ".erb"
+  signature "sig"
+end
+EOF
+
+      assert_equal 1, project.targets.size
+
+      project.targets.find {|target| target.name == :views }.tap do |target|
+        assert_instance_of Project::Target, target
+
+        assert_equal ["app/views"], target.source_pattern.patterns
+        assert_equal ".erb", target.source_pattern.ext
+        assert_equal ["sig"], target.signature_pattern.patterns
+      end
+    end
+  end
 end


### PR DESCRIPTION
To support ERB, this allows to change the extension of the source files via `ext` setting in Steepfile.

Example:

```
target :views do
  check "app/views"
  ext ".erb"
end
```

refs: #1409