### PR TITLE
Strict record and tuple subtyping

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -493,7 +493,7 @@ module Steep
           end
 
         when relation.sub_type.is_a?(AST::Types::Tuple) && relation.super_type.is_a?(AST::Types::Tuple)
-          if relation.sub_type.types.size >= relation.super_type.types.size
+          if relation.sub_type.types.size == relation.super_type.types.size
             pairs = relation.sub_type.types.take(relation.super_type.types.size).zip(relation.super_type.types)
 
             All(relation) do |result|

--- a/sig/test/subtyping_test.rbs
+++ b/sig/test/subtyping_test.rbs
@@ -69,6 +69,8 @@ class SubtypingTest < Minitest::Test
 
   def test_tuple: () -> untyped
 
+  def test_record: () -> untyped
+
   def print_result: (untyped result, untyped output, ?prefix: untyped) -> untyped
 
   def assert_success_check: (untyped checker, untyped sub_type, untyped super_type, ?self_type: untyped, ?instance_type: untyped, ?class_type: untyped, ?constraints: untyped) -> untyped

--- a/sig/test/subtyping_test.rbs
+++ b/sig/test/subtyping_test.rbs
@@ -67,6 +67,8 @@ class SubtypingTest < Minitest::Test
 
   def test_void: () -> untyped
 
+  def test_tuple: () -> untyped
+
   def print_result: (untyped result, untyped output, ?prefix: untyped) -> untyped
 
   def assert_success_check: (untyped checker, untyped sub_type, untyped super_type, ?self_type: untyped, ?instance_type: untyped, ?class_type: untyped, ?constraints: untyped) -> untyped

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -183,4 +183,6 @@ class TypeCheckTest < Minitest::Test
   def test_when__assertion: () -> untyped
 
   def test_when__type_annotation: () -> untyped
+
+  def test_tuple_type_assertion: () -> untyped
 end

--- a/smoke/hash/d.rb
+++ b/smoke/hash/d.rb
@@ -1,5 +1,8 @@
 # @type var params: { name: String, id: Integer }
 
-params = { id: 30, name: "Matz" }
+params = { id: 30, name: "Matz", email: "matz@example.com" }
+params = { id: 30, name: "foo" }
 
-params = { id: "30", name: "foo", email: "matsumoto@soutaro.com" }
+# @type var params2: { name: String, id: Integer, email: String? }
+params2 = { id: 30, name: "Matz", email: "matz@example.com" }
+params2 = { id: 30, name: "foo" }

--- a/smoke/hash/test_expectations.yml
+++ b/smoke/hash/test_expectations.yml
@@ -54,26 +54,23 @@
   diagnostics:
   - range:
       start:
-        line: 5
+        line: 3
         character: 0
       end:
-        line: 5
-        character: 66
+        line: 3
+        character: 60
     severity: ERROR
     message: |-
-      Cannot assign a value of type `{ ?:email => ::String, :id => ::String, :name => ::String }` to a variable of type `{ :id => ::Integer, :name => ::String }`
-        { ?:email => ::String, :id => ::String, :name => ::String } <: { :id => ::Integer, :name => ::String }
-          ::String <: ::Integer
-            ::Object <: ::Integer
-              ::BasicObject <: ::Integer
+      Cannot assign a value of type `{ ?:email => ::String, :id => ::Integer, :name => ::String }` to a variable of type `{ :id => ::Integer, :name => ::String }`
+        { ?:email => ::String, :id => ::Integer, :name => ::String } <: { :id => ::Integer, :name => ::String }
     code: Ruby::IncompatibleAssignment
   - range:
       start:
-        line: 5
-        character: 34
+        line: 3
+        character: 33
       end:
-        line: 5
-        character: 39
+        line: 3
+        character: 38
     severity: ERROR
     message: Unknown key `:email` is given to a record type
     code: Ruby::UnknownRecordKey

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -442,6 +442,19 @@ end
     end
   end
 
+  def test_record
+    with_checker do |checker|
+      assert_success_check checker, "{ foo: String }", "{ foo: untyped }"
+      assert_success_check checker, "{ foo: String }", "{ foo: Object }"
+
+      assert_fail_check checker, "{ foo: String, bar: Integer }", "{ foo: String }"
+      assert_fail_check checker, "{ foo: String }", "{ foo: String, bar: Integer }"
+
+      assert_success_check checker, "{ foo: String }", "{ foo: String, ?bar: Integer }"
+      assert_success_check checker, "{ foo: String }", "{ foo: String, bar: Integer? }"
+    end
+  end
+
   def print_result(result, output, prefix: "  ")
     mark = result.success? ? "👍" : "🤦"
 
@@ -743,7 +756,6 @@ type json = String | Integer | Array[json] | Hash[String, json]
 
   def test_hash
     with_checker do |checker|
-      assert_success_check checker, "{ foo: ::Integer, bar: ::String }", "{ foo: ::Integer }"
       assert_fail_check checker, "{ foo: ::String }", "{ foo: ::Integer }"
       assert_success_check checker, "{ foo: ::String, bar: ::Integer }", "{ foo: ::String, bar: ::Integer? }"
       assert_success_check checker, "{ foo: ::String, bar: nil }", "{ foo: ::String, bar: ::Integer? }"

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -431,6 +431,17 @@ end
     end
   end
 
+  def test_tuple
+    with_checker do |checker|
+      assert_success_check checker, "[String]", "[untyped]"
+      assert_success_check checker, "[String]", "[top]"
+      assert_success_check checker, "[123]", "[Integer]"
+
+      assert_fail_check checker, "[String]", "[String, Integer]"
+      assert_fail_check checker, "[String, Symbol]", "[String]"
+    end
+  end
+
   def print_result(result, output, prefix: "  ")
     mark = result.success? ? "👍" : "🤦"
 

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2897,4 +2897,34 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_tuple_type_assertion
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          [1, ""] #: [1, "", bool]
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 0
+              end:
+                line: 1
+                character: 24
+            severity: ERROR
+            message: 'Assertion cannot hold: no relationship between inferred type (`[1, \"\"]`)
+              and asserted type (`[1, \"\", bool]`)'
+            code: Ruby::FalseAssertion
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
* The length of the tuple types *must be* same
* Record type with additional key *cannot* be a subtype of another record type