### PR TITLE
Fix self union type checking

### DIFF
--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -285,11 +285,6 @@ module Steep
             )
           end
 
-        when relation.sub_type.is_a?(AST::Types::Self) && !self_type.is_a?(AST::Types::Self)
-          Expand(relation) do
-            check_type(Relation.new(sub_type: self_type, super_type: relation.super_type))
-          end
-
         when relation.sub_type.is_a?(AST::Types::Instance) && !instance_type.is_a?(AST::Types::Instance)
           Expand(relation) do
             check_type(Relation.new(sub_type: instance_type, super_type: relation.super_type))
@@ -417,6 +412,11 @@ module Steep
                 check_type(rel)
               end
             end
+          end
+
+        when relation.sub_type.is_a?(AST::Types::Self) && !self_type.is_a?(AST::Types::Self)
+          Expand(relation) do
+            check_type(Relation.new(sub_type: self_type, super_type: relation.super_type))
           end
 
         when relation.super_type.is_a?(AST::Types::Name::Interface)
@@ -608,7 +608,6 @@ module Steep
           Expand(relation) do
             check_type(Relation.new(sub_type: relation.sub_type.back_type, super_type: relation.super_type))
           end
-
         else
           Failure(relation, Result::Failure::UnknownPairError.new(relation: relation))
         end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2982,6 +2982,33 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  def test_self_type_union_assertion
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Foo
+            def bar: (bool) -> self?
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class Foo
+            def bar(var)
+              return nil if var
+              self
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
   def test_case_when__no_subject__assignment_in_when__no_else
     run_type_check_test(
       signatures: {


### PR DESCRIPTION
This fixes the case where a method can return either `self` or another value (e.g. `-> (self | nil)`).

Here's the concrete example: https://github.com/DataDog/dd-trace-rb/blob/5361e8e9a7092ca081ff0d5126daf8950bb2c792/lib/datadog/tracing/span_operation.rb#L202-L223

```ruby
      def stop(stop_time = nil)
        return if stopped?

        now = Core::Utils::Time.now.utc

        start(stop_time || now) unless started?

        @end_time = stop_time || now
        @duration_end = stop_time.nil? ? duration_marker : nil

        events.after_stop.publish(self)

        self
      end
```

Currently this fails with:
```
Cannot allow method body have type `self` because declared as type `(self | nil)`
Diagnostic ID: Ruby::MethodBodyTypeMismatch
```