### PR TITLE
Type narrowing union types via return type of method call

### DIFF
--- a/sig/steep/type_inference/logic_type_interpreter.rbs
+++ b/sig/steep/type_inference/logic_type_interpreter.rbs
@@ -45,6 +45,8 @@ module Steep
 
       def evaluate_method_call: (env: TypeEnv, type: AST::Types::Logic::Base, receiver: Parser::AST::Node?, arguments: Array[Parser::AST::Node]) -> [Result, Result]?
 
+      def evaluate_union_method_call: (node: Parser::AST::Node, env: TypeEnv, receiver: Parser::AST::Node, receiver_type: AST::Types::Union) -> [Result, Result]?
+
       # Apply type refinement to `node` as `truthy_type` and `falsy_type`.
       #
       # This is done by top-down manner.

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -98,6 +98,8 @@ class TypeCheckTest < Minitest::Test
 
   def test_type_narrowing__local_variable_safe_navigation_operator: () -> untyped
 
+  def test_type_narrowing__union_send: () -> untyped
+
   def test_argument_error__unexpected_unexpected_positional_argument: () -> untyped
 
   def test_type_assertion__type_error: () -> untyped

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1500,6 +1500,34 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  def test_type_narrowing__union_send
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Object
+            def present?: () -> bool
+          end
+
+          class NilClass
+            def present?: () -> false
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          a = [1].first
+          a + 1 if a.present?
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+
   def test_argument_error__unexpected_unexpected_positional_argument
     run_type_check_test(
       signatures: {


### PR DESCRIPTION
This tries to narrow types unions by the return type of the method call. If the return type of the method is always truthy or falsy, the receiver type will be narrowed on the truthy branch and the falsy branch.

This helps to narrow types via method definitions (ex. `#nil?`, `#present?`, `#blank?` and so on).