### PR TITLE
Implement user-defined type guard method

### DIFF
--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -4,7 +4,7 @@ module Steep
       module Logic
         class Base
           extend SharedInstance
-          
+
           def subst(s)
             self
           end
@@ -51,6 +51,28 @@ module Steep
         end
 
         class ArgIsAncestor < Base
+        end
+
+        class Guard < Base
+          PATTERN = /\Aguard:\s*(self)\s+(is)\s+(.*?)\s*\Z/
+
+          attr_reader :subject
+          attr_reader :operator
+          attr_reader :type
+
+          def initialize(subject:, operator:, type:)
+            @subject = subject
+            @operator = operator
+            @type = type
+          end
+
+          def ==(other)
+            super && subject == other.subject && operator == other.operator && type == other.type
+          end
+
+          def hash
+            self.class.hash ^ subject.hash ^ operator.hash ^ type.hash
+          end
         end
 
         class Env < Base

--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -1043,6 +1043,22 @@ module Steep
         end
       end
 
+      class InsufficientTypeGuard < Base
+        attr_reader :super_type
+        attr_reader :sub_type
+
+        def initialize(node:, super_type:, sub_type:)
+          @super_type = super_type
+          @sub_type = sub_type
+
+          super(node: node)
+        end
+
+        def header_line
+          "Cannot narrow the type: #{super_type} is not a subtype of #{sub_type}"
+        end
+      end
+
       ALL = ObjectSpace.each_object(Class).with_object([]) do |klass, array|
         if klass < Base
           array << klass

--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -504,6 +504,32 @@ module Steep
         end
       end
 
+      class TypeGuardSyntaxError < Base
+        attr_reader :predicate
+
+        def initialize(predicate, location:)
+          super(location: location)
+          @predicate = predicate
+        end
+
+        def header_line
+          "Type guard `#{predicate}` is invalid"
+        end
+      end
+
+      class InvalidTypeGuardType < Base
+        attr_reader :type
+
+        def initialize(type, location:)
+          super(location: location)
+          @type = type
+        end
+
+        def header_line
+          "Type guard `#{type}` is invalid"
+        end
+      end
+
 
       def self.from_rbs_error(error, factory:)
         case error

--- a/manual/ruby-diagnostics.md
+++ b/manual/ruby-diagnostics.md
@@ -639,6 +639,46 @@ test.rb:8:0: [error] Requires 2 types, but 1 given: `[T, S] (T, S) -> [T, S]`
 | - | - | - | - | - |
 | error | error | hint | - | - |
 
+<a name='Ruby::InsufficientTypeGuard'></a>
+## Ruby::InsufficientTypeGuard
+
+A type guard method doesn't narrow the type because the determined type is not a subtype of the actual type.
+
+### RBS
+
+```rbs
+class Object
+  %a{guard:self is String}
+  def string?: () -> bool
+end
+```
+
+### Ruby code
+
+```ruby
+a = 123
+if a.string?
+  puts "Hello"
+end
+```
+
+### Diagnostic
+
+```
+test.rb:2:4: [error] Cannot narrow the type: ::Integer is not a subtype of ::String
+│ Diagnostic ID: Ruby::InsufficientTypeGuard
+│
+└   if a.string?
+       ~
+```
+
+
+### Severity
+
+| all_error | strict | default | lenient | silent |
+| - | - | - | - | - |
+| error | error | error | error | - |
+
 <a name='Ruby::InvalidIgnoreComment'></a>
 ## Ruby::InvalidIgnoreComment
 

--- a/sig/steep/ast/types.rbs
+++ b/sig/steep/ast/types.rbs
@@ -6,7 +6,7 @@ module Steep
            | Intersection  | Record | Tuple | Union
            | Name::Alias | Name::Instance | Name::Interface | Name::Singleton
            | Proc | Var
-           | Logic::Not | Logic::ReceiverIsNil | Logic::ReceiverIsNotNil | Logic::ReceiverIsArg | Logic::ArgIsReceiver | Logic::ArgEqualsReceiver | Logic::ArgIsAncestor | Logic::Env
+           | Logic::Not | Logic::ReceiverIsNil | Logic::ReceiverIsNotNil | Logic::ReceiverIsArg | Logic::ArgIsReceiver | Logic::ArgEqualsReceiver | Logic::ArgIsAncestor | Logic::Guard | Logic::Env
 
       # Variables and special types that is subject for substitution
       #

--- a/sig/steep/ast/types/logic.rbs
+++ b/sig/steep/ast/types/logic.rbs
@@ -50,6 +50,19 @@ module Steep
         class ArgIsAncestor < Base
         end
 
+        # A type for type guard.
+        class Guard < Base
+          PATTERN: Regexp
+
+          attr_reader subject: String
+          attr_reader operator: String
+          attr_reader type: RBS::Types::t
+
+          def self.new: (subject: String, operator: String, type: RBS::Types::t) -> Guard
+
+          def initialize: (subject: String, operator: String, type: RBS::Types::t) -> void
+        end
+
         # A type with truthy/falsy type environment.
         class Env < Base
           attr_reader truthy: TypeInference::TypeEnv

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -1955,6 +1955,46 @@ module Steep
         def header_line: () -> void
       end
 
+      # A type guard method doesn't narrow the type because the determined type is not a subtype of the actual type.
+      #
+      # ### RBS
+      #
+      # ```rbs
+      # class Object
+      #   %a{guard:self is String}
+      #   def string?: () -> bool
+      # end
+      # ```
+      #
+      # ### Ruby code
+      #
+      # ```ruby
+      # a = 123
+      # if a.string?
+      #   puts "Hello"
+      # end
+      # ```
+      #
+      # ### Diagnostic
+      #
+      # ```
+      # test.rb:2:4: [error] Cannot narrow the type: ::Integer is not a subtype of ::String
+      # │ Diagnostic ID: Ruby::InsufficientTypeGuard
+      # │
+      # └   if a.string?
+      #        ~
+      # ```
+      #
+      class InsufficientTypeGuard < Base
+        attr_reader node (): Node
+        attr_reader super_type: AST::Types::t
+        attr_reader sub_type: AST::Types::t
+
+        def initialize: (node: Node, super_type: AST::Types::t, sub_type: AST::Types::t) -> void
+
+        def header_line: () -> String
+      end
+
       ALL: Array[singleton(Base)]
 
       type template = Hash[singleton(Base), LSPFormatter::severity?]

--- a/sig/steep/diagnostic/signature.rbs
+++ b/sig/steep/diagnostic/signature.rbs
@@ -282,6 +282,20 @@ module Steep
         attr_reader message: String?
 
         def initialize: (RBS::TypeName type_name, String? message, location: RBS::Location[untyped, untyped]?) -> void
+      end
+
+      class TypeGuardSyntaxError < Base
+        attr_reader predicate: String
+
+        def initialize: (String predicate, location: RBS::Location[untyped, untyped]?) -> void
+
+        def header_line: () -> String
+      end
+
+      class InvalidTypeGuardType < Base
+        attr_reader type: String
+
+        def initialize: (String type, location: RBS::Location[untyped, untyped]?) -> void
 
         def header_line: () -> String
       end

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -110,6 +110,10 @@ module Steep
 
       def method_name_for: (RBS::Definition::Method::TypeDef, Symbol name) -> method_name
 
+      def replace_guard_method: (RBS::Definition, RBS::Definition::Method::TypeDef, MethodType) -> MethodType
+
+      def context_from: (RBS::TypeName) -> RBS::Resolver::context
+
       def replace_primitive_method: (method_name, RBS::Definition::Method::TypeDef, MethodType) -> MethodType
 
       def replace_kernel_class: (method_name, RBS::Definition::Method::TypeDef, MethodType) { () -> AST::Types::t } -> MethodType

--- a/sig/steep/signature/validator.rbs
+++ b/sig/steep/signature/validator.rbs
@@ -77,11 +77,17 @@ module Steep
 
       def mixin_constraints: (RBS::Definition definition, Array[RBS::Definition::Ancestor::Instance] mixin_ancestors, immediate_self_types: Array[RBS::Definition::Ancestor::t]?) -> Array[[Subtyping::Relation[AST::Types::t], RBS::Definition::Ancestor::Instance]]
 
-      def each_method_type: (RBS::Definition) { (RBS::MethodType) -> void } -> void
+      def each_method_type: (RBS::Definition) { (RBS::Definition::Method, RBS::MethodType) -> void } -> void
 
       def each_variable_type: (RBS::Definition) { (RBS::Types::t) -> void } -> void
 
       def validate_definition_type: (RBS::Definition) -> void
+
+      def validate_method_type: (RBS::Definition, RBS::Definition::Method, RBS::MethodType) -> void
+
+      def validate_type_guard_annotation: (RBS::Definition, RBS::MethodType, RBS::AST::Annotation) -> void
+
+      def context_from: (RBS::TypeName) -> RBS::Resolver::context
 
       def validate_one_class: (RBS::TypeName) -> void
 

--- a/sig/steep/type_inference/logic_type_interpreter.rbs
+++ b/sig/steep/type_inference/logic_type_interpreter.rbs
@@ -96,9 +96,11 @@ module Steep
       #
       def literal_var_type_case_select: (Parser::AST::Node value_node, AST::Types::t arg_type) -> [Array[AST::Types::t], Array[AST::Types::t]]?
 
+      def type_guard_type_case_select: (AST::Types::t `type`, AST::Types::t guard_type) -> [AST::Types::t?, AST::Types::t?]
+
       def type_case_select: (AST::Types::t `type`, RBS::TypeName klass) -> [AST::Types::t?, AST::Types::t?]
 
-      def type_case_select0: (AST::Types::t `type`, RBS::TypeName klass) -> [Array[AST::Types::t], Array[AST::Types::t]]
+      def type_case_select0: (AST::Types::t `type`, AST::Types::t instance_type) -> [Array[AST::Types::t], Array[AST::Types::t]]
 
       def try_convert: (AST::Types::t, Symbol) -> AST::Types::t?
 

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -102,6 +102,14 @@ class TypeCheckTest < Minitest::Test
 
   def test_type_narrowing__union_send2: () -> untyped
 
+  def test_type_guard__self_is_TYPE: () -> untyped
+
+  def test_type_guard__self_is_TYPE_no_subtyping: () -> untyped
+
+  def test_type_guard__self_is_TYPE_unknown: () -> untyped
+
+  def test_type_guard__self_is_TYPE_singleton: () -> untyped
+
   def test_argument_error__unexpected_unexpected_positional_argument: () -> untyped
 
   def test_type_assertion__type_error: () -> untyped

--- a/sig/test/validation_test.rbs
+++ b/sig/test/validation_test.rbs
@@ -77,6 +77,14 @@ class ValidationTest < Minitest::Test
 
   def test_validate_type__generics_default_upperbound: () -> untyped
 
+  def test_validate_type_guard: () -> untyped
+
+  def test_validate_type_guard__invalid_syntax: () -> untyped
+
+  def test_validate_type_guard__unparsable_type: () -> untyped
+
+  def test_validate_type_guard__unknown_type: () -> untyped
+
   def test_validate__deprecated__type_name: () -> untyped
 
   def test_validate__deprecated__class: () -> untyped


### PR DESCRIPTION
This implements the minimal version of user-defined type guard method. A user-defined type guard methos is a method defined by user that is able to guarantee the type of the objects (receiver or arguments).

At present, Steep supports type guard methods provided by ruby-core (ex. `#is_a?`, `#nil?`, and so on).  But we also have many kinds of user-defined methods that are able to check the type of the objects.

Therefore user-defined type guard will help checking the type of these applications by narrowing types.

This implementation uses an annotation to declare user-defined type guard method.

```
class Example < Integer
  %a{guard:self is Integer}
  def integer?: () -> bool
end
```

For example, the following method `Example#integer?` is a user-defined type guard method that narrows the Example object itself to an Integer if the conditional branch passed.

```
example = Example.new
if example.integer?
  example  #=> Integer
end
```

In this PR, the predicate of type guards only supports "self is TYPE" statement.  I have a plan to extend it:

* `%a{guard:self is arg}`
* `%a{guard:self is_a arg}`
* `%a{guard:self is TYPE_PARAM}`
* `%a{guard:arg is TYPE}`

Note: The compatibility of RBS syntax is the large reason of using annotations.  I'm afraid that adding a new syntax to define it will bring breaking change to the RBS, and difficult to use it on common repository or generators (ex. gem_rbs_collection and rbs_rails).

refs:

* https://github.com/ruby/rbs/issues/1822