### PR TITLE
Support `InvalidTypeApplication` on `#update_env`

### DIFF
--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -295,7 +295,7 @@ module Steep
 
           unless errors.empty?
             # Builder won't be used.
-            factory = AST::Types::Factory.new(builder: _ = nil)
+            factory = AST::Types::Factory.new(builder: RBS::DefinitionBuilder.new(env: env, ancestor_builder: builder))
             return errors.map {|error| Diagnostic::Signature.from_rbs_error(error, factory: factory) }
           end
 

--- a/smoke/diagnostics-rbs/invalid-type-application-class.rbs
+++ b/smoke/diagnostics-rbs/invalid-type-application-class.rbs
@@ -1,0 +1,2 @@
+class InvalidTypeApplicationClass < String[String]
+end

--- a/smoke/diagnostics-rbs/invalid-type-application-module.rbs
+++ b/smoke/diagnostics-rbs/invalid-type-application-module.rbs
@@ -1,0 +1,2 @@
+module InvalidTypeApplicationModule : String[int]
+end

--- a/smoke/diagnostics-rbs/test_expectations.yml
+++ b/smoke/diagnostics-rbs/test_expectations.yml
@@ -70,6 +70,30 @@
     severity: ERROR
     message: Cannot find a non-overloading definition of `foo` in `::InvalidMethodOverload`
     code: RBS::InvalidMethodOverload
+- file: invalid-type-application-class.rbs
+  diagnostics:
+  - range:
+      start:
+        line: 1
+        character: 36
+      end:
+        line: 1
+        character: 50
+    severity: ERROR
+    message: Type `::String` is not generic but used as a generic type with 1 arguments
+    code: RBS::InvalidTypeApplication
+- file: invalid-type-application-module.rbs
+  diagnostics:
+  - range:
+      start:
+        line: 1
+        character: 38
+      end:
+        line: 1
+        character: 49
+    severity: ERROR
+    message: Type `::String` is not generic but used as a generic type with 1 arguments
+    code: RBS::InvalidTypeApplication
 - file: invalid-type-application.rbs
   diagnostics:
   - range:


### PR DESCRIPTION
ref: https://github.com/ruby/rbs/pull/2289

When `InvalidTypeApplicationError` occurs in the RBS validator, there is a possibility that Steep will raise an **Unexpected error** if the type argument is `RBS::Types::ClassInstance`, `RBS::Types::Interface`, or `RBS::Types::Alias`.

This PR fixes the issue so that problems are reported correctly.