### PR TITLE
Dedup error message on ancestors check

### DIFF
--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -294,7 +294,7 @@ module Steep
           end
 
           unless errors.empty?
-            # Builder won't be used.
+            errors.uniq! { |e| [e.class, e.message] }
             factory = AST::Types::Factory.new(builder: RBS::DefinitionBuilder.new(env: env, ancestor_builder: builder))
             return errors.map {|error| Diagnostic::Signature.from_rbs_error(error, factory: factory) }
           end


### PR DESCRIPTION
In ancestors error checking, the same issue may be reported multiple times.  

```
$ cat sample.rbs
class InheritModule < Kernel
end

$ bundle exec steep check
# Type checking files:

F

sample.rbs:1:22: [error] Cannot inherit from a module `::Kernel`
│ Diagnostic ID: RBS::InheritModuleError
│
└ class InheritModule < Kernel
                        ~~~~~~

sample.rbs:1:22: [error] Cannot inherit from a module `::Kernel`
│ Diagnostic ID: RBS::InheritModuleError
│
└ class InheritModule < Kernel
                        ~~~~~~

Detected 2 problems from 1 file
```

This happens because both `#one_instance_ancestors` and `#one_singleton_ancestors` in `RBS::DefinitionBuilder::AncestorBuilder` generate the same error.  

This issue can be reproduced by running the following command in the `smoke/diagnostics-rbs` directory:  

```sh
$ bundle exec steep check --save-expectations=test_expectations.yml
```

So far, this issue seems to occur only in ancestors checking.  

Therefore, I propose limiting the deduplication to this specific case.