### PR TITLE
Implement GitHub formatter

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -151,6 +151,9 @@ require "steep/drivers/init"
 require "steep/drivers/vendor"
 require "steep/drivers/worker"
 require "steep/drivers/diagnostic_printer"
+require "steep/drivers/diagnostic_printer/base_formatter"
+require "steep/drivers/diagnostic_printer/code_formatter"
+require "steep/drivers/diagnostic_printer/github_actions_formatter"
 
 require "steep/annotations_helper"
 

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -187,6 +187,10 @@ BANNER
             end
           end
 
+          opts.on("--format=FORMATTER", ["code", "github"], "Output formatters (default: code, options: code,github)") do |formatter|
+            command.formatter = formatter
+          end
+
           handle_jobs_option command.jobs_option, opts
           handle_logging_options opts
         end.parse!(argv)

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -16,6 +16,7 @@ module Steep
       attr_accessor :validate_group_signatures
       attr_accessor :validate_project_signatures
       attr_accessor :validate_library_signatures
+      attr_accessor :formatter
 
       include Utils::DriverHelper
 
@@ -30,6 +31,7 @@ module Steep
         @validate_group_signatures = true
         @validate_project_signatures = false
         @validate_library_signatures = false
+        @formatter = 'code'
       end
 
       def active_group?(group)
@@ -322,7 +324,7 @@ module Steep
           errors.each do |notification|
             path = Steep::PathHelper.to_pathname(notification[:uri]) or raise
             buffer = RBS::Buffer.new(name: project.relative_path(path), content: path.read)
-            printer = DiagnosticPrinter.new(buffer: buffer, stdout: stdout)
+            printer = DiagnosticPrinter.new(buffer: buffer, stdout: stdout, formatter: formatter)
 
             notification[:diagnostics].each do |diag|
               printer.print(diag)

--- a/lib/steep/drivers/diagnostic_printer.rb
+++ b/lib/steep/drivers/diagnostic_printer.rb
@@ -1,104 +1,27 @@
 module Steep
   module Drivers
     class DiagnosticPrinter
+
       LSP = LanguageServer::Protocol
 
       attr_reader :stdout
       attr_reader :buffer
 
-      def initialize(stdout:, buffer:)
+      def initialize(stdout:, buffer:, formatter: 'code')
         @stdout = stdout
         @buffer = buffer
-      end
-
-      def path
-        Pathname(buffer.name)
-      end
-
-      def color_severity(string, severity:)
-        s = Rainbow(string)
-
-        case severity
-        when LSP::Constant::DiagnosticSeverity::ERROR
-          s.red
-        when LSP::Constant::DiagnosticSeverity::WARNING
-          s.yellow
-        when LSP::Constant::DiagnosticSeverity::INFORMATION
-          s.blue
+        @formatter = case formatter
+        when 'code'
+          CodeFormatter.new(stdout: stdout, buffer: buffer)
+        when 'github'
+          GitHubActionsFormatter.new(stdout: stdout, buffer: buffer)
         else
-          s
+          raise "Unknown formatter: #{formatter}"
         end
-      end
-
-      def severity_message(severity)
-        string = case severity
-                 when LSP::Constant::DiagnosticSeverity::ERROR
-                   "error"
-                 when LSP::Constant::DiagnosticSeverity::WARNING
-                   "warning"
-                 when LSP::Constant::DiagnosticSeverity::INFORMATION
-                   "information"
-                 when LSP::Constant::DiagnosticSeverity::HINT
-                   "hint"
-                 else
-                  raise
-                 end
-
-        color_severity(string, severity: severity)
-      end
-
-      def location(diagnostic)
-        start = diagnostic[:range][:start]
-        Rainbow("#{path}:#{start[:line]+1}:#{start[:character]}").magenta
       end
 
       def print(diagnostic, prefix: "", source: true)
-        header, *rest = diagnostic[:message].split(/\n/)
-
-        stdout.puts "#{prefix}#{location(diagnostic)}: [#{severity_message(diagnostic[:severity])}] #{Rainbow(header).underline}"
-
-        unless rest.empty?
-          rest.each do |message|
-            stdout.puts "#{prefix}│ #{message}"
-          end
-        end
-
-        if diagnostic[:code]
-          stdout.puts "#{prefix}│" unless rest.empty?
-          stdout.puts "#{prefix}│ Diagnostic ID: #{diagnostic[:code]}"
-        end
-
-        stdout.puts "#{prefix}│"
-
-        if source
-          print_source_line(diagnostic, prefix: prefix)
-        else
-          stdout.puts "#{prefix}└ (no source code available)"
-          stdout.puts "#{prefix}"
-        end
-      end
-
-      def print_source_line(diagnostic, prefix: "")
-        start_pos = diagnostic[:range][:start]
-        end_pos = diagnostic[:range][:end]
-
-        line = buffer.lines.fetch(start_pos[:line])
-
-        leading = line[0...start_pos[:character]] || ""
-        if start_pos[:line] == end_pos[:line]
-          subject = line[start_pos[:character]...end_pos[:character]] || ""
-          trailing = (line[end_pos[:character]...] || "").chomp
-        else
-          subject = (line[start_pos[:character]...] || "").chomp
-          trailing = ""
-        end
-
-        unless subject.valid_encoding?
-          subject.scrub!
-        end
-
-        stdout.puts "#{prefix}└ #{leading}#{color_severity(subject, severity: diagnostic[:severity])}#{trailing}"
-        stdout.puts "#{prefix}  #{" " * leading.size}#{"~" * subject.size}"
+        @formatter.print(diagnostic, prefix: prefix, source: source)
       end
     end
   end

--- a/lib/steep/drivers/diagnostic_printer/base_formatter.rb
+++ b/lib/steep/drivers/diagnostic_printer/base_formatter.rb
@@ -1,0 +1,19 @@
+module Steep
+  module Drivers
+    class DiagnosticPrinter
+      class BaseFormatter
+        attr_reader :stdout
+        attr_reader :buffer
+
+        def initialize(stdout:, buffer:)
+          @stdout = stdout
+          @buffer = buffer
+        end
+
+        def path
+          Pathname(buffer.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/steep/drivers/diagnostic_printer/code_formatter.rb
+++ b/lib/steep/drivers/diagnostic_printer/code_formatter.rb
@@ -1,0 +1,95 @@
+module Steep
+  module Drivers
+    class DiagnosticPrinter
+      class CodeFormatter < BaseFormatter
+        def print(diagnostic, prefix: "", source: true)
+          header, *rest = diagnostic[:message].split(/\n/)
+
+          stdout.puts "#{prefix}#{location(diagnostic)}: [#{severity_message(diagnostic[:severity])}] #{Rainbow(header).underline}"
+
+          unless rest.empty?
+            rest.each do |message|
+              stdout.puts "#{prefix}│ #{message}"
+            end
+          end
+
+          if diagnostic[:code]
+            stdout.puts "#{prefix}│" unless rest.empty?
+            stdout.puts "#{prefix}│ Diagnostic ID: #{diagnostic[:code]}"
+          end
+
+          stdout.puts "#{prefix}│"
+
+          if source
+            print_source_line(diagnostic, prefix: prefix)
+          else
+            stdout.puts "#{prefix}└ (no source code available)"
+            stdout.puts "#{prefix}"
+          end
+        end
+
+        private
+
+        def color_severity(string, severity:)
+          s = Rainbow(string)
+
+          case severity
+          when LSP::Constant::DiagnosticSeverity::ERROR
+            s.red
+          when LSP::Constant::DiagnosticSeverity::WARNING
+            s.yellow
+          when LSP::Constant::DiagnosticSeverity::INFORMATION
+            s.blue
+          else
+            s
+          end
+        end
+
+        def severity_message(severity)
+          string = case severity
+                  when LSP::Constant::DiagnosticSeverity::ERROR
+                    "error"
+                  when LSP::Constant::DiagnosticSeverity::WARNING
+                    "warning"
+                  when LSP::Constant::DiagnosticSeverity::INFORMATION
+                    "information"
+                  when LSP::Constant::DiagnosticSeverity::HINT
+                    "hint"
+                  else
+                    raise
+                  end
+
+          color_severity(string, severity: severity)
+        end
+
+        def location(diagnostic)
+          start = diagnostic[:range][:start]
+          Rainbow("#{path}:#{start[:line]+1}:#{start[:character]}").magenta
+        end
+
+        def print_source_line(diagnostic, prefix: "")
+          start_pos = diagnostic[:range][:start]
+          end_pos = diagnostic[:range][:end]
+
+          line = buffer.lines.fetch(start_pos[:line])
+
+          leading = line[0...start_pos[:character]] || ""
+          if start_pos[:line] == end_pos[:line]
+            subject = line[start_pos[:character]...end_pos[:character]] || ""
+            trailing = (line[end_pos[:character]...] || "").chomp
+          else
+            subject = (line[start_pos[:character]...] || "").chomp
+            trailing = ""
+          end
+
+          unless subject.valid_encoding?
+            subject.scrub!
+          end
+
+          stdout.puts "#{prefix}└ #{leading}#{color_severity(subject, severity: diagnostic[:severity])}#{trailing}"
+          stdout.puts "#{prefix}  #{" " * leading.size}#{"~" * subject.size}"
+        end
+      end
+    end
+  end
+end

--- a/lib/steep/drivers/diagnostic_printer/github_actions_formatter.rb
+++ b/lib/steep/drivers/diagnostic_printer/github_actions_formatter.rb
@@ -1,0 +1,44 @@
+module Steep
+  module Drivers
+    class DiagnosticPrinter
+      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+      class GitHubActionsFormatter < BaseFormatter
+        ESCAPE_MAP = { '%' => '%25', "\n" => '%0A', "\r" => '%0D' }.freeze
+
+        def print(diagnostic, prefix: "", source: true)
+          stdout.printf(
+            "::%<severity>s file=%<file>s,line=%<line>d,endLine=%<endLine>d,col=%<column>d,endColumn=%<endColumn>d::%<message>s",
+            severity: github_severity(diagnostic[:severity]),
+            file: path,
+            line: diagnostic[:range][:start][:line] + 1,
+            endLine: diagnostic[:range][:end][:line] + 1,
+            column: diagnostic[:range][:start][:character],
+            endColumn: diagnostic[:range][:end][:character],
+            message: github_escape("[#{diagnostic[:code]}] #{diagnostic[:message]}")
+          )
+        end
+
+        private
+
+        def github_severity(severity)
+          case severity
+          when LSP::Constant::DiagnosticSeverity::ERROR
+            "error"
+          when LSP::Constant::DiagnosticSeverity::WARNING
+            "warning"
+          when LSP::Constant::DiagnosticSeverity::INFORMATION
+            "notice"
+          when LSP::Constant::DiagnosticSeverity::HINT
+            "notice"
+          else
+            raise
+          end
+        end
+
+        def github_escape(string)
+          string.gsub(Regexp.union(ESCAPE_MAP.keys), ESCAPE_MAP)
+        end
+      end
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -125,6 +125,25 @@ end
     end
   end
 
+  def test_check_failure_with_formatter
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+end
+      EOF
+
+      (current_dir + "foo.rb").write(<<-EOF)
+1 + "2"
+      EOF
+
+      stdout, status = sh(*steep, "check", "--format", "github")
+
+      refute_predicate status, :success?, stdout
+      assert_match(/^::error file=foo.rb,line=1,endLine=1,col=0,endColumn=7/, stdout)
+    end
+  end
+
   def test_check_group__target
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)

--- a/test/diagnostics_printer_test.rb
+++ b/test/diagnostics_printer_test.rb
@@ -52,6 +52,20 @@ RUBY
 MESSAGE
   end
 
+  def test_single_line_message_with_github_actions_formatter
+    printer = DiagnosticPrinter.new(stdout: io, buffer: buffer, formatter: "github")
+    printer.print({
+                    code: "Error",
+                    range: {
+                      start: { line: 5, character: 4 },
+                      end: { line: 5, character: 9 }
+                    },
+                    severity: LSP::Constant::DiagnosticSeverity::ERROR,
+                    message: "Instance variable @name is not defined"
+                  })
+    assert_equal "::error file=a.rb,line=6,endLine=6,col=4,endColumn=9::[Error] Instance variable @name is not defined", io.string
+  end
+
   def test_multiline_message
     printer = DiagnosticPrinter.new(stdout: io, buffer: buffer)
 
@@ -76,6 +90,25 @@ MESSAGE
 MESSAGE
   end
 
+  def test_multiline_message_with_github_actions_formatter
+    printer = DiagnosticPrinter.new(stdout: io, buffer: buffer, formatter: "github")
+
+    printer.print({
+                    code: "Error",
+                    range: {
+                      start: { line: 5, character: 4 },
+                      end: { line: 5, character: 9 }
+                    },
+                    severity: LSP::Constant::DiagnosticSeverity::ERROR,
+                    message: [
+                      "Instance variable @name is not defined",
+                      "Attribute declarations or `@name: untyped` will solve the issue."
+                    ].join("\n")
+                  })
+
+    assert_equal "::error file=a.rb,line=6,endLine=6,col=4,endColumn=9::[Error] Instance variable @name is not defined%0AAttribute declarations or `@name: untyped` will solve the issue.", io.string
+  end
+
   def test_multiline_source
     printer = DiagnosticPrinter.new(stdout: io, buffer: buffer)
 
@@ -94,5 +127,21 @@ MESSAGE
 └   #{Rainbow("def initialize(name:, year:)").yellow}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 MESSAGE
+  end
+
+  def test_multiline_source_with_github_actions_formatter
+    printer = DiagnosticPrinter.new(stdout: io, buffer: buffer, formatter: "github")
+
+    printer.print({
+                    code: "Error",
+                    range: {
+                      start: { line: 4, character: 2 },
+                      end: { line: 7, character: 7 }
+                    },
+                    severity: LSP::Constant::DiagnosticSeverity::WARNING,
+                    message: "Duplicated method definition"
+                  })
+
+    assert_equal "::warning file=a.rb,line=5,endLine=8,col=2,endColumn=7::[Error] Duplicated method definition", io.string
   end
 end


### PR DESCRIPTION
I will add a formatter for GitHub Actions.  

By using this formatter in GitHub Actions, it will become easier to display type errors directly in code reviews on github.com.
The default behavior remains unchanged.
Rubocop has a similar feature, and it is also used in [the rbs repository](https://github.com/ruby/rbs/blob/1209f49fd9073374d5660e8d9fc25ce2fc5c1af0/Rakefile#L150).

You can see the demo by https://github.com/ksss/rubocop-on-rbs/pull/86/files also.

<img width="918" alt="image" src="https://github.com/user-attachments/assets/1ec9ce85-f286-48b2-bd1d-12b01fab19d3" />
