### PR TITLE
Fix union self type refinement based on method call

### DIFF
--- a/sig/steep/type_inference/logic_type_interpreter.rbs
+++ b/sig/steep/type_inference/logic_type_interpreter.rbs
@@ -45,7 +45,7 @@ module Steep
 
       def evaluate_method_call: (env: TypeEnv, type: AST::Types::Logic::Base, receiver: Parser::AST::Node?, arguments: Array[Parser::AST::Node]) -> [Result, Result]?
 
-      def evaluate_union_method_call: (node: Parser::AST::Node, env: TypeEnv, receiver: Parser::AST::Node, receiver_type: AST::Types::Union) -> [Result, Result]?
+      def evaluate_union_method_call: (node: Parser::AST::Node, type: AST::Types::t, env: TypeEnv, receiver: Parser::AST::Node, receiver_type: AST::Types::Union) -> [Result, Result]?
 
       # Apply type refinement to `node` as `truthy_type` and `falsy_type`.
       #

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1527,6 +1527,38 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  def test_type_narrowing__union_send2
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Foo
+            attr_reader foo: String?
+
+            def foo!: () -> void
+          end
+
+          class Bar
+            attr_reader foo: nil
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          foo = rand > 0.1 ? Foo.new : Bar.new
+          if x = foo.foo
+            foo.foo!
+            x + ""
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
 
   def test_argument_error__unexpected_unexpected_positional_argument
     run_type_check_test(


### PR DESCRIPTION
This PR fixes type checking the following Ruby code:

```
if location = node.location         # Assume `node` has a union type
  # location must be nonnil here
end
```