### PR TITLE
Add deprecation validation on RBS

### DIFF
--- a/lib/steep/annotations_helper.rb
+++ b/lib/steep/annotations_helper.rb
@@ -14,5 +14,30 @@ module Steep
 
       nil
     end
+
+    def deprecated_type_name?(type_name, env)
+      annotations =
+        case
+        when type_name.class?
+          case
+          when decl = env.class_decls.fetch(type_name, nil)
+            decl.decls.flat_map { _1.decl.annotations }
+          when decl = env.class_alias_decls.fetch(type_name, nil)
+            decl.decl.annotations
+          end
+        when type_name.interface?
+          if decl = env.interface_decls.fetch(type_name, nil)
+            decl.decl.annotations
+          end
+        when type_name.alias?
+          if decl = env.type_alias_decls.fetch(type_name, nil)
+            decl.decl.annotations
+          end
+        end
+
+      if annotations
+        deprecated_annotation?(annotations)
+      end
+    end
   end
 end

--- a/lib/steep/diagnostic/lsp_formatter.rb
+++ b/lib/steep/diagnostic/lsp_formatter.rb
@@ -52,8 +52,11 @@ module Steep
           tags = [] #: Array[LSP::Constant::DiagnosticTag::t]
 
           case diagnostic
-          when Ruby::DeprecatedReference, Signature::DeprecatedTypeName
+          when Ruby::DeprecatedReference
             tags << LSP::Constant::DiagnosticTag::DEPRECATED
+          when Signature::DeprecatedTypeName
+            tags << LSP::Constant::DiagnosticTag::DEPRECATED
+            severity = LSP::Constant::DiagnosticSeverity::WARNING
           end
 
           json = {

--- a/lib/steep/diagnostic/lsp_formatter.rb
+++ b/lib/steep/diagnostic/lsp_formatter.rb
@@ -52,7 +52,7 @@ module Steep
           tags = [] #: Array[LSP::Constant::DiagnosticTag::t]
 
           case diagnostic
-          when Ruby::DeprecatedReference
+          when Ruby::DeprecatedReference, Signature::DeprecatedTypeName
             tags << LSP::Constant::DiagnosticTag::DEPRECATED
           end
 

--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -460,6 +460,26 @@ module Steep
         end
       end
 
+      class DeprecatedTypeName < Base
+        attr_reader :type_name
+        attr_reader :message
+
+        def initialize(type_name, message, location:)
+          super(location: location)
+          @type_name = type_name
+          @message = message
+        end
+
+        def header_line
+          buffer = "Type `#{type_name}` is deprecated"
+          if message
+            buffer = +buffer
+            buffer << ": " << message
+          end
+          buffer
+        end
+      end
+
 
       def self.from_rbs_error(error, factory:)
         case error

--- a/lib/steep/services/completion_provider.rb
+++ b/lib/steep/services/completion_provider.rb
@@ -53,19 +53,7 @@ module Steep
         end
 
         def deprecated?
-          annotations =
-            case entry = env.constant_entry(full_name)
-            when RBS::Environment::ConstantEntry
-              entry.decl.annotations
-            when RBS::Environment::ClassEntry, RBS::Environment::ModuleEntry
-              entry.decls.flat_map { _1.decl.annotations }
-            when RBS::Environment::ClassAliasEntry, RBS::Environment::ModuleAliasEntry
-              entry.decl.annotations
-            else
-              raise
-            end
-            
-          if AnnotationsHelper.deprecated_annotation?(annotations)
+          if AnnotationsHelper.deprecated_type_name?(full_name, env)
             true
           else
             false

--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -174,29 +174,8 @@ module Steep
       end
 
       def validate_type_name_deprecation(type_name, location)
-        annotations =
-          case
-          when type_name.class?
-            case
-            when decl = env.class_decls.fetch(type_name, nil)
-              decl.decls.flat_map { _1.decl.annotations }
-            when decl = env.class_alias_decls.fetch(type_name, nil)
-              decl.decl.annotations
-            end
-          when type_name.interface?
-            if decl = env.interface_decls.fetch(type_name, nil)
-              decl.decl.annotations
-            end
-          when type_name.alias?
-            if decl = env.type_alias_decls.fetch(type_name, nil)
-              decl.decl.annotations
-            end
-          end
-
-        if annotations
-          if (_, message = AnnotationsHelper.deprecated_annotation?(annotations))
-            @errors << Diagnostic::Signature::DeprecatedTypeName.new(type_name, message, location: location)
-          end
+        if (_, message = AnnotationsHelper.deprecated_type_name?(type_name, env))
+          @errors << Diagnostic::Signature::DeprecatedTypeName.new(type_name, message, location: location)
         end
       end
 

--- a/sample/lib/deprecated.rb
+++ b/sample/lib/deprecated.rb
@@ -3,3 +3,5 @@ Foo
 Bar.bar()
 
 Bar.new.hogehoge("")
+
+foo = nil #: Foo

--- a/sample/lib/deprecated.rb
+++ b/sample/lib/deprecated.rb
@@ -2,3 +2,4 @@ Foo
 
 Bar.bar()
 
+Bar.new.hogehoge("")

--- a/sample/sig/deprecated.rbs
+++ b/sample/sig/deprecated.rbs
@@ -11,4 +11,6 @@ class Bar
               | %a{deprecated: Pass an positional argument} (string: String) -> void
 end
 
+type t = Foo
+
 %a{deprecated} $test: untyped

--- a/sample/sig/deprecated.rbs
+++ b/sample/sig/deprecated.rbs
@@ -1,4 +1,4 @@
-%a{deprecated} class Foo end
+%a{deprecated: Use Bar instead} class Foo end
 
 class Bar
   # Original bar
@@ -6,6 +6,9 @@ class Bar
 
   # Overloading bar
   def self.bar: (String) -> String | ...
+
+  def hogehoge: (String) -> void
+              | %a{deprecated: Pass an positional argument} (string: String) -> void
 end
 
 %a{deprecated} $test: untyped

--- a/sig/steep/annotations_helper.rbs
+++ b/sig/steep/annotations_helper.rbs
@@ -9,5 +9,9 @@ module Steep
     # Returns the pair of the annotation and given message.
     #
     def self?.deprecated_annotation?: (Array[Annotation]) -> [Annotation, String?]?
+
+    # Returns truthy if the type name is declared *deprecated*
+    #
+    def self?.deprecated_type_name?: (RBS::TypeName, RBS::Environment) -> [Annotation, String?]?
   end
 end

--- a/sig/steep/diagnostic/signature.rbs
+++ b/sig/steep/diagnostic/signature.rbs
@@ -276,6 +276,16 @@ module Steep
         include ResultPrinter2
       end
 
+      class DeprecatedTypeName < Base
+        attr_reader type_name: RBS::TypeName
+
+        attr_reader message: String?
+
+        def initialize: (RBS::TypeName type_name, String? message, location: RBS::Location[untyped, untyped]?) -> void
+
+        def header_line: () -> String
+      end
+
       def self.from_rbs_error: (RBS::BaseError error, factory: AST::Types::Factory) -> Base
     end
   end

--- a/sig/steep/signature/validator.rbs
+++ b/sig/steep/signature/validator.rbs
@@ -49,11 +49,29 @@ module Steep
       #
       def validate_type_params: (RBS::TypeName, Array[RBS::AST::TypeParam]) -> void
 
-      def validate_type_application_constraints: (RBS::TypeName type_name, Array[RBS::AST::TypeParam] type_params, Array[RBS::Types::t] type_args, location: RBS::Location[untyped, untyped]?) -> void
+      # Validate type application constraints
+      #
+      # Doesn't validate descendant types.
+      #
+      private def validate_type_application_constraints: (RBS::TypeName type_name, Array[RBS::AST::TypeParam] type_params, Array[RBS::Types::t] type_args, location: RBS::Location[untyped, untyped]?) -> void
 
-      def validate_type_application: (RBS::Types::t) -> void
+      # Validate type application
+      #
+      # Doesn't validate descendant types.
+      #
+      private def validate_type_application: (RBS::Types::t) -> void
 
+      # Validate if type name is deprecated
+      #
+      private def validate_type_name_deprecation: (RBS::TypeName, RBS::Location[untyped, untyped]) -> void
+
+      # Validate a type and its descendants
+      #
       def validate_type: (RBS::Types::t `type`) -> void
+
+      # Validate a type, and calls the method with its descendants
+      #
+      def validate_type_0: (RBS::Types::t) -> void
 
       def ancestor_to_type: (RBS::Definition::Ancestor::t ancestor) -> (AST::Types::Name::Interface | AST::Types::Name::Instance)
 


### PR DESCRIPTION
<img width="415" alt="スクリーンショット 2025-03-11 12 33 03" src="https://github.com/user-attachments/assets/c12c9287-e346-4f6a-b386-9253e60840bf" />

Note that it doesn't print diagnostics correctly -- without strikethrough -- for deprecated type names embedded in Ruby code.