### PR TITLE
Catch the message of VariableDuplicationError

### DIFF
--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -273,6 +273,30 @@ module Steep
         end
       end
 
+      class VariableDuplicationError < Base
+        attr_reader :type_name
+        attr_reader :variable_name
+        attr_reader :location
+
+        def initialize(type_name:, variable_name:, location:)
+          @type_name = type_name
+          @variable_name = variable_name
+          @location = location
+        end
+      end
+
+      class InstanceVariableDuplicationError < VariableDuplicationError
+        def header_line
+          "Duplicated instance variable name `#{variable_name}` in `#{type_name}`"
+        end
+      end
+
+      class ClassInstanceVariableDuplicationError < VariableDuplicationError
+        def header_line
+          "Duplicated class instance variable name `#{variable_name}` in `#{type_name}`"
+        end
+      end
+
       class ClassVariableDuplicationError < Base
         attr_reader :class_name
         attr_reader :other_class_name
@@ -581,6 +605,10 @@ module Steep
           Diagnostic::Signature::CyclicClassAliasDefinitionError.new(decl: error.alias_entry.decl)
         when RBS::TypeParamDefaultReferenceError
           Diagnostic::Signature::TypeParamDefaultReferenceError.new(error.type_param, location: error.location)
+        when RBS::InstanceVariableDuplicationError
+          Diagnostic::Signature::InstanceVariableDuplicationError.new(type_name: error.type_name, variable_name: error.variable_name, location: error.location)
+        when RBS::ClassInstanceVariableDuplicationError
+          Diagnostic::Signature::ClassInstanceVariableDuplicationError.new(type_name: error.type_name, variable_name: error.variable_name, location: error.location)
         else
           raise error
         end

--- a/smoke/diagnostics-rbs/test_expectations.yml
+++ b/smoke/diagnostics-rbs/test_expectations.yml
@@ -322,3 +322,25 @@
     severity: ERROR
     message: Cannot find type `ZZZ`
     code: RBS::UnknownTypeName
+- file: variable-duplication.rbs
+  diagnostics:
+  - range:
+      start:
+        line: 3
+        character: 2
+      end:
+        line: 3
+        character: 13
+    severity: ERROR
+    message: Duplicated instance variable name `@i` in `::Instance`
+    code: RBS::InstanceVariableDuplicationError
+  - range:
+      start:
+        line: 8
+        character: 2
+      end:
+        line: 8
+        character: 19
+    severity: ERROR
+    message: Duplicated class instance variable name `@ci` in `::ClassInstance`
+    code: RBS::ClassInstanceVariableDuplicationError

--- a/smoke/diagnostics-rbs/variable-duplication.rbs
+++ b/smoke/diagnostics-rbs/variable-duplication.rbs
@@ -1,0 +1,24 @@
+class Instance
+  @i: Integer
+  @i: Integer
+end
+
+class ClassInstance
+  self.@ci: Integer
+  self.@ci: Integer
+end
+
+class InstanceClassInstanceNoError
+  @i: Integer
+  self.@i: Integer
+end
+
+class Inherit
+  @i: Integer
+  self.@ci: Integer
+end
+
+class InheritNoError < Inherit
+  @i: Integer
+  self.@ci: Integer
+end


### PR DESCRIPTION
ref: https://github.com/ruby/rbs/pull/2310

`RBS::InstanceVariableDuplicationError` and `RBS::ClassInstanceVariableDuplicationError` have been introduced in rbs, but since Steep does not recognize these errors, it results in an **Unexpected error**.  

This PR fixes the issue so that Steep can properly display validation messages for these errors.

### Message example

```
variable-duplication.rbs:3:2: [error] Duplicated instance variable name `@i` in `::Instance`
│ Diagnostic ID: RBS::InstanceVariableDuplicationError
│
└   @i: Integer
    ~~~~~~~~~~~

variable-duplication.rbs:8:2: [error] Duplicated class instance variable name `@ci` in `::ClassInstance`
│ Diagnostic ID: RBS::ClassInstanceVariableDuplicationError
│
└   self.@ci: Integer
    ~~~~~~~~~~~~~~~~~
```