### PR TITLE
Fix type checking block calls on `untyped` receiver

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3458,7 +3458,7 @@ module Steep
             block_annotations = source.annotations(block: node, factory: checker.factory, context: nesting)
             block_params or raise
 
-            constr = constr.synthesize_children(node.children[0])
+            constr = constr.synthesize_children(node.children[0], skips: [receiver])
 
             constr.type_block_without_hint(
               node: node,

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -3533,4 +3533,33 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_type_check_untyped_calls_with_blocks
+    run_type_check_test(
+      signatures: {
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Foo
+            .foo {}
+            .foo {}
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 0
+              end:
+                line: 1
+                character: 3
+            severity: ERROR
+            message: 'Cannot find the declaration of constant: `Foo`'
+            code: Ruby::UnknownConstant
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
Closes https://github.com/soutaro/steep/issues/1522

The issue is caused by type checking the `receiver` twice (per call) by `synthesize_children`. Having `skips:` keyword with `receiver` solves the problem.