### PR TITLE
Delay type variable resolution on method call with blocks

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -4119,6 +4119,15 @@ module Steep
 
                 fvs_.merge(method_type.type.params.free_variables) if method_type.type.params
                 fvs_.merge(method_type.block.type.params.free_variables) if method_type.block.type.params
+                (method_type.type.return_type.free_variables + method_type.block.type.return_type.free_variables).each do |var|
+                  if var.is_a?(Symbol)
+                    if constraints.unknown?(var)
+                      unless constraints.has_constraint?(var)
+                        fvs_.delete(var)
+                      end
+                    end
+                  end
+                end
 
                 constraints.solution(checker, variables: fvs_, context: ccontext)
               }

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -223,4 +223,6 @@ class TypeCheckTest < Minitest::Test
   def test_argument_forwarding__undeclared: () -> untyped
 
   def test_type_check_untyped_calls_with_blocks: () -> untyped
+
+  def test_generics_optional_arg: () -> void
 end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -3562,4 +3562,47 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_generics_optional_arg #: void
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Test
+            def foo: [T] (?T) { () -> T } -> T
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Test.new.foo(1) { 1 }.fooo
+          Test.new.foo() { 1 }.fooo
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 22
+              end:
+                line: 1
+                character: 26
+            severity: ERROR
+            message: Type `::Integer` does not have method `fooo`
+            code: Ruby::NoMethod
+          - range:
+              start:
+                line: 2
+                character: 21
+              end:
+                line: 2
+                character: 25
+            severity: ERROR
+            message: Type `::Integer` does not have method `fooo`
+            code: Ruby::NoMethod
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
The following example unexpectedly type checks.

```rb
# Assume `Foo.foo` has a type: [T] (?T) { () -> T } -> T
Foo.foo() { 1 }.foooooo       # NoMethod error is expected, but the inferred return type is untyped
```

This is because `T` is resolved to `untyped` after type checking parameters -- no constraint is given because the positional argument is omitted here.

This PR delays the resolution if the block return type/return type is `T`.