### PR TITLE
case/when record type narrowing

### DIFF
--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -3050,6 +3050,29 @@ EOF
     end
   end
 
+  def test_when_record_typing
+    with_checker do |checker|
+      source = parse_ruby(<<EOF)
+# @type var x: { type: :foo, value: Integer } | { type: :bar, value: String }
+x = (_ = nil)
+case x[:type]
+when :foo
+  y = x[:value]
+when :bar
+  z = x[:value]
+end
+EOF
+
+      with_standard_construction(checker, source) do |construction, typing|
+        pair = construction.synthesize(source.node)
+
+        assert_no_error typing
+        assert_equal parse_type("::Integer"), pair.context.type_env[:y]
+        assert_equal parse_type("::String"), pair.context.type_env[:z]
+      end
+    end
+  end
+
   def test_while_typing
     with_checker do |checker|
       source = parse_ruby(<<EOF)


### PR DESCRIPTION
This is a WIP to add type narrowing support for the following use-case:

```ruby
# @type var x: { type: :foo, value: Integer } | {type: :bar, value: String }
case x[:type]
when :foo
  # x[:value] is an integer
when :bar
  # x[:value] is a string
end
```

@soutaro I'm needing some assistance on how to implement this. I'm looking at the type inference code, particularly the `CaseWhen` statement, but I'm not sure how to cleanly implement this. It seems that, when doing `when_pats.add_pattern(pat) {|test, constr| constr.synthesize(test) }`, the value for `lvar` should be correctly inferred, but this annotation does not bubble up to the `x` from the case condition, which in the case statement is represented as a `s(:send, s(:lvar, :x), :[], s(:sym, :type)))` node. My assumption is that the same limitation applies for the same method-call pattern, i.e. if `x` were declared as `A | B` and there was a method `foo` which returns `:foo` for `A` and `:bar` for `B`, the when block would not be able to distinguish between them.