### PR TITLE
Escape special characters in path before globbing

### DIFF
--- a/lib/steep/services/file_loader.rb
+++ b/lib/steep/services/file_loader.rb
@@ -35,14 +35,18 @@ module Steep
           pats = commandline_patterns.empty? ? pattern.patterns : commandline_patterns
 
           pats.each do |path|
-            Pathname.glob((base_dir + path).to_s).each do |absolute_path|
+            # Escape special characters {}[]*? by prefixing with \ 
+            escaped_base_dir = Pathname(base_dir.to_s.gsub(/[\{\}\[\]\*\?]/) { |x| "\\#{x}" })
+            Pathname.glob((escaped_base_dir + path).to_s).each do |absolute_path|
               if absolute_path.file?
                 relative_path = absolute_path.relative_path_from(base_dir)
                 if pattern =~ relative_path
                   yield relative_path
                 end
               else
-                files = Pathname.glob("#{absolute_path}/**/*#{pattern.ext}")
+                # Escape special characters {}[]*? by prefixing with \ 
+                escaped_absolute_path = Pathname(absolute_path.to_s.gsub(/[\{\}\[\]\*\?]/) { |x| "\\#{x}" })
+                files = Pathname.glob("#{escaped_absolute_path}/**/*#{pattern.ext}")
 
                 files.sort.each do |source_path|
                   if source_path.file?


### PR DESCRIPTION
Resolves https://github.com/soutaro/steep/issues/1574

## Changes

This change fixes the bug reported in https://github.com/soutaro/steep/issues/1574

## Testing

I created a minimal reproduction of the error in this repository: https://github.com/navapbc/ruby-steep-bug-repro

Before any changes were made, running `bundle exec steep check` within the folder `\{\{foo\}\}` could not find the type error, even though running the same command in the identical folder `foo` could find it.

<img width="340" alt="image" src="https://github.com/user-attachments/assets/ac5b8afe-4384-4288-a7cb-178f44734bc7" />

After editing steep locally with the changes, running `bundle exec steep check` within the `\{\{foo\}\}` folder now properly detects the type error:

<img width="708" alt="image" src="https://github.com/user-attachments/assets/7e35059a-1ed5-4f79-ae11-d77c52225fb1" />

