### PR TITLE
Call `Process.warmup` before refork

### DIFF
--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -110,6 +110,8 @@ module Steep
 
       attr_reader child_pids: Array[Integer]
 
+      attr_reader need_to_warmup: boolish
+
       include ChangeBuffer
 
       def initialize: (


### PR DESCRIPTION
Call `Process.warmup` before reforking to improve memory usage.


`Process.warmup` does major GC, memory compaction, and returns unused memory to the OS.
It's designed to be called before `fork` to reduce memory usage.


## Benchmarking

I benchmarked the memory usage with `free` command on a Rails app.
https://docs.google.com/spreadsheets/d/1dMhuYqEdbxcuxE-a-fy_X5g6-5_Dn3IHfLO_xPQj1Pg/edit?usp=sharing

<img width="1407" alt="Screenshot 2025-05-20 at 18 34 26" src="https://github.com/user-attachments/assets/596974a7-76f9-457c-8be1-eef9aaa6187a" />

The summary is:

* When `warmup` is called, it reduces ~1.7GB (33%) memory compared to the current implementation.
* When `warmup` is called, it reduces ~4.1GB (55%) memory compared to that if Steep does not refork.


