### PR TITLE
Type check service supports inline type declarations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ group :development, optional: true do
   gem "majo"
 end
 
-# gem "rbs", path: "../rbs"
-gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"
+gem "rbs", path: "../rbs"
+# gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ group :development, optional: true do
   gem "majo"
 end
 
-gem "rbs", path: "../rbs"
-# gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"
+# gem "rbs", path: "../rbs"
+gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ruby/rbs.git
-  revision: 075742b677705a3024c44b4dbd67ad283d8e3a6e
+  revision: 346fcae5dc1ad3c6c1af45a24e3dcce2837cff82
   branch: master
   specs:
     rbs (4.0.0.dev.4)

--- a/lib/steep/ast/types/factory.rb
+++ b/lib/steep/ast/types/factory.rb
@@ -294,6 +294,7 @@ module Steep
                 raise "`#{u_}` cannot be type parameter upper bound"
               end
             },
+            lower_bound: nil,
             location: type_param.location
           ).unchecked!(type_param.unchecked)
         end

--- a/lib/steep/diagnostic/signature.rb
+++ b/lib/steep/diagnostic/signature.rb
@@ -503,6 +503,18 @@ module Steep
         end
       end
 
+      class InlineDiagnostic < Base
+        attr_reader :diagnostic
+
+        def initialize(diagnostic)
+          super(location: diagnostic.location)
+          @diagnostic = diagnostic
+        end
+
+        def header_line
+          diagnostic.message
+        end
+      end
 
       def self.from_rbs_error(error, factory:)
         case error

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -208,22 +208,21 @@ module Steep
 
       def load_files(files, target, group, params:)
         if type_check_code
-          files.source_paths.each_group_path(group) do |path|
+          files.source_paths.each_group_path(group) do |path, *|
             params[:code_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end
         if validate_group_signatures
-          files.signature_paths.each_group_path(group) do |path|
+          files.signature_paths.each_group_path(group) do |path, *|
             params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end
         if validate_project_signatures
-          files.signature_paths.each_project_path(except: target) do |path|
-            path_target = files.signature_paths.target(path) or raise
+          files.signature_paths.each_project_path(except: target) do |path, path_target, *|
             params[:signature_paths] << [path_target.name.to_s, target.project.absolute_path(path).to_s]
           end
           if group.is_a?(Project::Group)
-            files.signature_paths.each_target_path(target, except: group) do |path|
+            files.signature_paths.each_target_path(target, except: group) do |path, *|
               params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
             end
           end

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -93,7 +93,7 @@ module Steep
         client_writer.write({ method: :initialize, id: initialize_id, params: DEFAULT_CLI_LSP_INITIALIZE_PARAMS })
         wait_for_response_id(reader: client_reader, id: initialize_id)
 
-        params = { library_paths: [], signature_paths: [], code_paths: [] } #: Server::CustomMethods::TypeCheck::params
+        params = { library_paths: [], inline_paths: [], signature_paths: [], code_paths: [] } #: Server::CustomMethods::TypeCheck::params
 
         if command_line_patterns.empty?
           files = Server::TargetGroupFiles.new(project)
@@ -208,23 +208,22 @@ module Steep
 
       def load_files(files, target, group, params:)
         if type_check_code
-          files.each_group_source_path(group, true) do |path|
+          files.source_paths.each_group_path(group, no_sub_groups: true) do |path|
             params[:code_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end
         if validate_group_signatures
-          files.each_group_signature_path(group) do |path|
+          files.signature_paths.each_group_path(group) do |path|
             params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end
         if validate_project_signatures
-          files.each_project_signature_path(target) do |path|
-            if path_target = files.signature_path_target(path)
-              params[:signature_paths] << [path_target.name.to_s, target.project.absolute_path(path).to_s]
-            end
+          files.signature_paths.each_project_path(except: target) do |path|
+            path_target = files.signature_paths.target(path) or raise
+            params[:signature_paths] << [path_target.name.to_s, target.project.absolute_path(path).to_s]
           end
           if group.is_a?(Project::Group)
-            files.each_target_signature_path(target, group) do |path|
+            files.signature_paths.each_target_path(target, except: group) do |path|
               params[:signature_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
             end
           end

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -114,7 +114,7 @@ module Steep
           project.targets.each do |target|
             target.groups.each do |group|
               if active_group?(group)
-                load_files(files, group.target, group, params: params)
+                load_files(files, target, group, params: params)
               end
             end
             if active_group?(target)
@@ -208,7 +208,7 @@ module Steep
 
       def load_files(files, target, group, params:)
         if type_check_code
-          files.source_paths.each_group_path(group, no_sub_groups: true) do |path|
+          files.source_paths.each_group_path(group) do |path|
             params[:code_paths] << [target.name.to_s, target.project.absolute_path(path).to_s]
           end
         end

--- a/lib/steep/drivers/print_project.rb
+++ b/lib/steep/drivers/print_project.rb
@@ -53,10 +53,10 @@ module Steep
         } #: target_json
 
         if files
-          files.signature_paths.each_group_path(target, no_sub_groups: true) do |path|
+          files.signature_paths.each_group_path(target) do |path, *|
             (json["signature_paths"] ||= []) << path.to_s
           end
-          files.source_paths.each_group_path(target, no_sub_groups: true) do |path|
+          files.source_paths.each_group_path(target) do |path, *|
             (json["source_paths"] ||= []) << path.to_s
           end
         end
@@ -72,11 +72,11 @@ module Steep
         } #: group_json
 
         if files
-          files.signature_paths.each_group_path(group, no_sub_groups: true) do |path|
+          files.signature_paths.each_group_path(group) do |path, *|
             (json["signature_paths"] ||= []) << path.to_s
           end
 
-          files.source_paths.each_group_path(group, no_sub_groups: true) do |path|
+          files.source_paths.each_group_path(group) do |path, *|
             (json["source_paths"] ||= []) << path.to_s
           end
         end

--- a/lib/steep/drivers/print_project.rb
+++ b/lib/steep/drivers/print_project.rb
@@ -53,10 +53,10 @@ module Steep
         } #: target_json
 
         if files
-          files.each_group_signature_path(target, true) do |path|
+          files.signature_paths.each_group_path(target, no_sub_groups: true) do |path|
             (json["signature_paths"] ||= []) << path.to_s
           end
-          files.each_group_source_path(target, true) do |path|
+          files.source_paths.each_group_path(target, no_sub_groups: true) do |path|
             (json["source_paths"] ||= []) << path.to_s
           end
         end
@@ -72,11 +72,11 @@ module Steep
         } #: group_json
 
         if files
-          files.each_group_signature_path(group, true) do |path|
+          files.signature_paths.each_group_path(group, no_sub_groups: true) do |path|
             (json["signature_paths"] ||= []) << path.to_s
-
           end
-          files.each_group_source_path(group, true) do |path|
+
+          files.source_paths.each_group_path(group, no_sub_groups: true) do |path|
             (json["source_paths"] ||= []) << path.to_s
           end
         end

--- a/lib/steep/drivers/watch.rb
+++ b/lib/steep/drivers/watch.rb
@@ -112,7 +112,7 @@ module Steep
             end
           end
 
-          params = { library_paths: [], signature_paths: [], code_paths: [] } #: Server::CustomMethods::TypeCheck::params
+          params = { library_paths: [], inline_paths: [], signature_paths: [], code_paths: [] } #: Server::CustomMethods::TypeCheck::params
 
           (modified + added).each do |path|
             path = Pathname(path)
@@ -132,7 +132,7 @@ module Steep
         begin
           stdout.puts Rainbow("👀 Watching directories, Ctrl-C to stop.").bold
 
-          params = { library_paths: [], signature_paths: [], code_paths: [] } #: Server::CustomMethods::TypeCheck::params
+          params = { library_paths: [], inline_paths: [], signature_paths: [], code_paths: [] } #: Server::CustomMethods::TypeCheck::params
           file_loader = Services::FileLoader.new(base_dir: project.base_dir)
           project.targets.each do |target|
             file_loader.each_path_in_patterns(target.source_pattern, dirs.map(&:to_s)) do |path|

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -412,10 +412,8 @@ module Steep
           return SingletonMethodName.new(type_name: type_name, method_name: name)
         end
 
-        if type_def.member.is_a?(RBS::AST::Ruby::Members::DefMember)
-          # DefMember is always instance method
-          InstanceMethodName.new(type_name: type_name, method_name: name)
-        else
+        case type_def.member
+        when RBS::AST::Members::Base
           case type_def.member.kind
           when :instance
             InstanceMethodName.new(type_name: type_name, method_name: name)
@@ -427,6 +425,8 @@ module Steep
           else
             raise
           end
+        when RBS::AST::Ruby::Members::DefMember
+          InstanceMethodName.new(type_name: type_name, method_name: name)
         end
       end
 

--- a/lib/steep/interface/shape.rb
+++ b/lib/steep/interface/shape.rb
@@ -36,13 +36,15 @@ module Steep
               method_name = SingletonMethodName.new(type_name: type_name, method_name: name)
             else
               method_name =
-                if defn.member.is_a?(RBS::AST::Ruby::Members::DefMember)
-                  # DefMember is always instance method
-                  InstanceMethodName.new(type_name: defn.defined_in, method_name: name)
-                elsif defn.member.kind == :singleton
-                  SingletonMethodName.new(type_name: defn.defined_in, method_name: name)
-                else
-                  # Call the `self?` method an instance method, because the definition is done with instance method definition, not with singleton method
+                case defn.member
+                when RBS::AST::Members::Base
+                  if defn.member.kind == :singleton
+                    SingletonMethodName.new(type_name: defn.defined_in, method_name: name)
+                  else
+                    # Call the `self?` method an instance method, because the definition is done with instance method definition, not with singleton method
+                    InstanceMethodName.new(type_name: defn.defined_in, method_name: name)
+                  end
+                when RBS::AST::Ruby::Members::DefMember
                   InstanceMethodName.new(type_name: defn.defined_in, method_name: name)
                 end
             end

--- a/lib/steep/server/interaction_worker.rb
+++ b/lib/steep/server/interaction_worker.rb
@@ -189,9 +189,13 @@ module Steep
                   dirs = [] #: Array[RBS::AST::Directives::t]
                 end
               else
-                signature = sig_service.files.fetch(relative_path).signature
-                signature.is_a?(Array) or raise
-                buffer, dirs, decls = signature
+                file = sig_service.files.fetch(relative_path)
+                file.is_a?(Services::SignatureService::RBSFileStatus) or raise
+                source = file.source
+                source.is_a?(RBS::Source::RBS) or raise
+                buffer = source.buffer
+                dirs = source.directives
+                decls = source.declarations
 
                 locator = RBS::Locator.new(buffer: buffer, dirs: dirs, decls: decls)
 

--- a/lib/steep/server/target_group_files.rb
+++ b/lib/steep/server/target_group_files.rb
@@ -74,25 +74,41 @@ module Steep
               yield path
             end
           else
-            enum_for(_ = __method__, target: target, except: except)
+            enum_for(_ = __method__, target, except: except)
           end
         end
 
-        def each_group_path(target_group, no_sub_groups: false, &block)
+        def each_group_path(target_group, include_sub_groups: false, &block)
           if block
             @paths.each do |path, tg|
-              if no_sub_groups
-                if tg == target_group
+              if include_sub_groups
+                if tg == target_group || target_group == target_of(tg)
                   yield path
                 end
               else
-                if tg == target_group || target_group == target_of(tg)
+                if tg == target_group
                   yield path
                 end
               end
             end
           else
-            enum_for(_ = __method__, target_group)
+            enum_for(_ = __method__, target_group, include_sub_groups: include_sub_groups)
+          end
+        end
+
+        def target_of(target_group)
+          case target_group
+          when Project::Target
+            target_group
+          when Project::Group
+            target_group.target
+          end
+        end
+
+        def group_of(target_group)
+          case target_group
+          when Project::Group
+            target_group
           end
         end
       end

--- a/lib/steep/server/target_group_files.rb
+++ b/lib/steep/server/target_group_files.rb
@@ -1,6 +1,102 @@
 module Steep
   module Server
     class TargetGroupFiles
+      class PathEnumerator
+        def initialize
+          @paths = {}
+        end
+
+        def empty?
+          @paths.empty?
+        end
+
+        def []=(path, target_group)
+          @paths[path] = target_group
+        end
+
+        def [](path)
+          @paths[path]
+        end
+
+        def each(&block)
+          if block
+            @paths.each do |path, target_group|
+              target = target_of(target_group)
+              group = group_of(target_group)
+
+              yield [path, target, group]
+            end
+          else
+            enum_for(_ = __method__)
+          end
+        end
+
+        def target(path)
+          if target_group = @paths.fetch(path, nil)
+            target_of(target_group)
+          end
+        end
+
+        def target_group(path)
+          if target_group = @paths.fetch(path, nil)
+            target = target_of(target_group)
+            group = group_of(target_group)
+
+            [target, group]
+          end
+        end
+
+        def each_project_path(except: nil, &block)
+          if block
+            @paths.each_key do |path|
+              target = target(path)
+
+              next if target == except
+
+              yield path
+            end
+          else
+            enum_for(_ = __method__, except: except)
+          end
+        end
+
+        def each_target_path(target, except: nil, &block)
+          if block
+            @paths.each_key do |path|
+              t, g = target_group(path)
+
+              if except
+                next if g == except
+              end
+
+              next unless t == target
+
+              yield path
+            end
+          else
+            enum_for(_ = __method__, target: target, except: except)
+          end
+        end
+
+        def each_group_path(target_group, no_sub_groups: false, &block)
+          if block
+            @paths.each do |path, tg|
+              if no_sub_groups
+                if tg == target_group
+                  yield path
+                end
+              else
+                if tg == target_group || target_group == target_of(tg)
+                  yield path
+                end
+              end
+            end
+          else
+            enum_for(_ = __method__, target_group)
+          end
+        end
+      end
+
       attr_reader :project
 
       attr_reader :source_paths, :signature_paths
@@ -9,14 +105,18 @@ module Steep
 
       def initialize(project)
         @project = project
-        @source_paths = {}
-        @signature_paths = {}
+        @source_paths = PathEnumerator.new
+        @signature_paths = PathEnumerator.new
         @library_paths = {}
       end
 
       def add_path(path)
         if target_group = project.group_for_signature_path(path)
           signature_paths[path] = target_group
+          return true
+        end
+        if target_group = project.group_for_inline_source_path(path)
+          inline_paths[path] = target_group
           return true
         end
         if target_group = project.group_for_source_path(path)
@@ -41,164 +141,6 @@ module Steep
 
       def library_path?(path)
         library_paths.each_value.any? { _1.include?(path) }
-      end
-
-      def signature_path_target(path)
-        case target_group = signature_paths.fetch(path, nil)
-        when Project::Target
-          target_group
-        when Project::Group
-          target_group.target
-        end
-      end
-
-      def source_path_target(path)
-        case target_group = source_paths.fetch(path, nil)
-        when Project::Target
-          target_group
-        when Project::Group
-          target_group.target
-        end
-      end
-
-      def target_group_for_source_path(path)
-        ret = source_paths.fetch(path, nil)
-        case ret
-        when Project::Group
-          [ret.target, ret]
-        when Project::Target
-          [ret, nil]
-        end
-      end
-
-      def target_group_for_signature_path(path)
-        ret = signature_paths.fetch(path, nil)
-        case ret
-        when Project::Group
-          [ret.target, ret]
-        when Project::Target
-          [ret, nil]
-        end
-      end
-
-      def each_group_signature_path(target, no_group = false, &block)
-        if block
-          signature_paths.each_key do |path|
-            t, g = target_group_for_signature_path(path)
-
-            if target.is_a?(Project::Target)
-              if no_group
-                yield path if t == target && g == nil
-              else
-                yield path if t == target
-              end
-            else
-              yield path if g == target
-            end
-          end
-        else
-          enum_for(_ = __method__, target, no_group)
-        end
-      end
-
-      def each_target_signature_path(target, group, &block)
-        raise unless group.target == target if group
-
-        if block
-          signature_paths.each_key do |path|
-            t, g = target_group_for_signature_path(path)
-
-            next unless target == t
-            next if group && group == g
-
-            yield path
-          end
-        else
-          enum_for(_ = __method__, target, group)
-        end
-      end
-
-      def each_project_signature_path(target, &block)
-        if block
-          signature_paths.each do |path, target_group|
-            t =
-              case target_group
-              when Project::Target
-                target_group
-              when Project::Group
-                target_group.target
-              end
-
-            if target
-              next if t.unreferenced
-              next if t == target
-            end
-
-            yield path
-          end
-        else
-          enum_for(_ = __method__, target)
-        end
-      end
-
-      def each_group_source_path(target, no_group = false, &block)
-        if block
-          source_paths.each_key do |path|
-            t, g = target_group_for_source_path(path)
-
-            if target.is_a?(Project::Target)
-              if no_group
-                yield path if t == target && g == nil
-              else
-                yield path if t == target
-              end
-            else
-              yield path if g == target
-            end
-          end
-        else
-          enum_for(_ = __method__, target, no_group)
-        end
-      end
-
-      def each_target_source_path(target, group, &block)
-        raise unless group.target == target if group
-
-        if block
-          source_paths.each_key do |path|
-            t, g = target_group_for_source_path(path)
-
-            next unless target == t
-            next if group && group == g
-
-            yield path
-          end
-        else
-          enum_for(_ = __method__, target, group)
-        end
-      end
-
-      def each_project_source_path(target, &block)
-        if block
-          source_paths.each do |path, target_group|
-            t =
-              case target_group
-              when Project::Target
-                target_group
-              when Project::Group
-                target_group.target
-              end
-
-            if target
-              next if t.unreferenced
-              next if t == target
-            end
-
-            yield path
-          end
-        else
-          enum_for(_ = __method__, target)
-        end
       end
     end
   end

--- a/lib/steep/server/target_group_files.rb
+++ b/lib/steep/server/target_group_files.rb
@@ -10,6 +10,10 @@ module Steep
           @paths.empty?
         end
 
+        def paths
+          @paths.keys
+        end
+
         def []=(path, target_group)
           @paths[path] = target_group
         end

--- a/lib/steep/server/target_group_files.rb
+++ b/lib/steep/server/target_group_files.rb
@@ -80,12 +80,11 @@ module Steep
 
         def each_group_path(target_group, include_sub_groups: false, &block)
           if block
-            @paths.each do |path, tg|
-              if include_sub_groups
-                if tg == target_group || target_group == target_of(tg)
-                  yield path
-                end
-              else
+            if include_sub_groups
+              target_group.is_a?(Project::Target) or raise "target_group must be a target if `include_sub_groups:` is given. (#{target_group.name})"
+              each_target_path(target_group, &block)
+            else
+              @paths.each do |path, tg|
                 if tg == target_group
                   yield path
                 end

--- a/lib/steep/server/target_group_files.rb
+++ b/lib/steep/server/target_group_files.rb
@@ -118,7 +118,7 @@ module Steep
 
       attr_reader :project
 
-      attr_reader :source_paths, :signature_paths
+      attr_reader :source_paths, :signature_paths, :inline_paths
 
       attr_reader :library_paths
 
@@ -126,6 +126,7 @@ module Steep
         @project = project
         @source_paths = PathEnumerator.new
         @signature_paths = PathEnumerator.new
+        @inline_paths = PathEnumerator.new
         @library_paths = {}
       end
 

--- a/lib/steep/server/type_check_controller.rb
+++ b/lib/steep/server/type_check_controller.rb
@@ -359,21 +359,18 @@ module Steep
 
       def make_request(guid: SecureRandom.uuid, progress:)
         TypeCheckController::Request.new(guid: guid, progress: progress).tap do |request|
-          code_paths = Set[] #: Set[[Project::Target, Pathname]]
-          signature_paths = Set[] #: Set[[Project::Target, Pathname]]
-          inline_paths = Set[] #: Set[[Project::Target, Pathname]]
+          code_paths = Set[] #: Set[[group, Pathname]]
+          signature_paths = Set[] #: Set[[group, Pathname]]
+          inline_paths = Set[] #: Set[[group, Pathname]]
 
           dirty_paths.each do |path|
             case
             when group = files.source_paths[path]
-              target = target_of(path) or raise
-              code_paths << [target, path]
+              code_paths << [group, path]
             when group = files.signature_paths[path]
-              target = target_of(path) or raise
-              signature_paths << [target, path]
+              signature_paths << [group, path]
             when group = files.inline_paths[path]
-              target = target_of(path) or raise
-              inline_paths << [target, path]
+              inline_paths << [group, path]
             end
           end
 
@@ -405,15 +402,18 @@ module Steep
             end
           end
 
-          signature_paths.each do |target, path|
+          signature_paths.each do |_, path|
+            target = target_of(path) or raise
             request.signature_paths << [target.name, path]
           end
 
-          inline_paths.each do |target, path|
+          inline_paths.each do |_, path|
+            target = target_of(path) or raise
             request.inline_paths << [target.name, path]
           end
 
-          code_paths.each do |target, path|
+          code_paths.each do |_, path|
+            target = target_of(path) or raise
             request.code_paths << [target.name, path]
           end
 

--- a/lib/steep/services/file_loader.rb
+++ b/lib/steep/services/file_loader.rb
@@ -20,10 +20,12 @@ module Steep
 
           target.groups.each do |group|
             each_path_in_patterns(group.source_pattern, command_line_patterns, &handler)
+            each_path_in_patterns(group.inline_source_pattern, command_line_patterns, &handler)
             each_path_in_patterns(group.signature_pattern, &handler)
           end
 
           each_path_in_patterns(target.source_pattern, command_line_patterns, &handler)
+          each_path_in_patterns(target.inline_source_pattern, command_line_patterns, &handler)
           each_path_in_patterns(target.signature_pattern, &handler)
         else
           enum_for :each_path_in_target, target, command_line_patterns

--- a/lib/steep/services/signature_service.rb
+++ b/lib/steep/services/signature_service.rb
@@ -385,15 +385,25 @@ module Steep
       end
 
       def type_names(paths:, env:)
-        env.each_rbs_source.with_object(Set[]) do |source, set|
-          source.declarations.each do |decl|
-            if decl.location
-              if paths.include?(Pathname(decl.location.buffer.name))
-                type_name_from_decl(decl, set: set)
-              end
-            end
+
+        Hash.new {}
+        set = Set[] #: Set[RBS::TypeName]
+
+        env.each_rbs_source do |source|
+          next unless paths.include?(source.buffer.name)
+          source.each_type_name do |type_name|
+            set << type_name
           end
         end
+
+        env.each_ruby_source do |source|
+          next unless paths.include?(source.buffer.name)
+          source.each_type_name do |type_name|
+            set << type_name
+          end
+        end
+
+        set
       end
 
       def const_decls(paths:, env:)

--- a/sig/steep/diagnostic/signature.rbs
+++ b/sig/steep/diagnostic/signature.rbs
@@ -302,6 +302,14 @@ module Steep
         def header_line: () -> String
       end
 
+      class InlineDiagnostic < Base
+        attr_reader diagnostic: RBS::InlineParser::Diagnostic::t
+
+        def initialize: (RBS::InlineParser::Diagnostic::t) -> void
+
+        def header_line: () -> String
+      end
+
       def self.from_rbs_error: (RBS::BaseError error, factory: AST::Types::Factory) -> Base
     end
   end

--- a/sig/steep/server/custom_methods.rbs
+++ b/sig/steep/server/custom_methods.rbs
@@ -39,6 +39,7 @@ module Steep
         type params = {
           library_paths: Array[target_path_string],
           signature_paths: Array[target_path_string],
+          inline_paths: Array[target_path_string],
           code_paths: Array[target_path_string]
         }
 

--- a/sig/steep/server/target_group_files.rbs
+++ b/sig/steep/server/target_group_files.rbs
@@ -49,11 +49,11 @@ module Steep
 
         # Yields files that belongs to the group or the target
         #
-        # If `no_sub_groups: true` is given, it skips files in sub groups of the target.
-        # If `no_sub_groups: false` is given (default), it yields files in sub groups of the target.
+        # If `include_sub_groups: true` is given, it skips files in sub groups of the target.
+        # If `include_sub_groups: false` is given (default), it yields files in sub groups of the target.
         #
-        def each_group_path: (Target | Group, ?no_sub_groups: bool) { (Pathname) -> void } -> void
-                           | (Target | Group, ?no_sub_groups: bool) -> Enumerator[Pathname]
+        def each_group_path: (Target | Group, ?include_sub_groups: bool) { (Pathname) -> void } -> void
+                           | (Target | Group, ?include_sub_groups: bool) -> Enumerator[Pathname]
 
         # Returns the target of the argument
         #

--- a/sig/steep/server/target_group_files.rbs
+++ b/sig/steep/server/target_group_files.rbs
@@ -52,8 +52,10 @@ module Steep
         # If `include_sub_groups: true` is given, it skips files in sub groups of the target.
         # If `include_sub_groups: false` is given (default), it yields files in sub groups of the target.
         #
-        def each_group_path: (Target | Group, ?include_sub_groups: bool) { (Pathname) -> void } -> void
-                           | (Target | Group, ?include_sub_groups: bool) -> Enumerator[Pathname]
+        def each_group_path: (Target | Group) { (Pathname) -> void } -> void
+                           | (Target | Group) -> Enumerator[Pathname]
+                           | (Target, ?include_sub_groups: bool) { (Pathname) -> void } -> void
+                           | (Target, ?include_sub_groups: bool) -> Enumerator[Pathname]
 
         # Returns the target of the argument
         #

--- a/sig/steep/server/target_group_files.rbs
+++ b/sig/steep/server/target_group_files.rbs
@@ -2,12 +2,77 @@ use Steep::Project::Target, Steep::Project::Group
 
 module Steep
   module Server
+    # TargetGroupFiles keeps track of paths that belongs to a target or group
+    #
+    # A path can be one of the following:
+    #
+    # 1. It is a path of a library RBS file (library path)
+    # 2. It is a path of a signature file that belongs to a target or a group (signature path)
+    # 3. It is a path of a Ruby source file that belongs to a target or a group (source path)
+    # 4. It is a path of a Ruby code with inline type declaration that belongs to the project (inline path)
+    #
     class TargetGroupFiles
+      class PathEnumerator
+        @paths: Hash[Pathname, Target | Group]
+
+        def initialize: () -> void
+
+        def empty?: () -> bool
+
+        def []=: (Pathname, Target | Group) -> (Target | Group)
+
+        def []: (Pathname) -> (Target | Group | nil)
+
+        def paths: () -> Array[Pathname]
+
+        def each: () { ([Pathname, Target, Group?]) -> void } -> void
+                | () -> Enumerator[[Pathname, Target, Group?]]
+
+        # Returns the target associated to the path
+        def target: (Pathname) -> Target?
+
+        # Returns a pair of target and group associated to the path
+        def target_group: (Pathname) -> [Target, Group?]?
+
+        # Yields all files from the collection
+        #
+        def each_project_path: (?except: Target?) { (Pathname) -> void } -> void
+                            | (?except: Target?) -> Enumerator[Pathname]
+
+        # Yields files that belongs to the target
+        #
+        # It also yields files that belongs to the sub-groups of the target.
+        # When `except:` is given, files that belongs to the group are skipped.
+        #
+        def each_target_path: (Target, ?except: Group?) { (Pathname) -> void } -> void
+                            | (Target, ?except: Group?) -> Enumerator[Pathname]
+
+        # Yields files that belongs to the group or the target
+        #
+        # If `no_sub_groups: true` is given, it skips files in sub groups of the target.
+        # If `no_sub_groups: false` is given (default), it yields files in sub groups of the target.
+        #
+        def each_group_path: (Target | Group, ?no_sub_groups: bool) { (Pathname) -> void } -> void
+                           | (Target | Group, ?no_sub_groups: bool) -> Enumerator[Pathname]
+
+        # Returns the target of the argument
+        #
+        # * Returns the target itself if the argument is a target
+        # * Returns the target of the group if the argument is a group
+        #
+        private def target_of: (Target | Group) -> Target
+
+        # Returns the group if the argument is a group
+        private def group_of: (Target | Group) -> Group?
+      end
+
       attr_reader project: Project
 
-      attr_reader source_paths: Hash[Pathname, Target | Group]
+      attr_reader source_paths: PathEnumerator
 
-      attr_reader signature_paths: Hash[Pathname, Target | Group]
+      attr_reader inline_paths: PathEnumerator
+
+      attr_reader signature_paths: PathEnumerator
 
       attr_reader library_paths: Hash[Symbol, Set[Pathname]]
 
@@ -20,59 +85,14 @@ module Steep
       #
       def add_path: (Pathname path) -> bool
 
+      # Add a path to a library RBS file
+      #
       def add_library_path: (Target, *Pathname) -> void
 
       def each_library_path: (Target) { (Pathname) -> void } -> void
                            | (Target) -> Enumerator[Pathname]
 
       def library_path?: (Pathname) -> bool
-
-      def signature_path_target: (Pathname) -> Target?
-
-      def source_path_target: (Pathname) -> Target?
-
-      # Yield signature paths that belongs to given target/group
-      #
-      def each_group_signature_path: (Target | Group, ?bool no_group) { (Pathname) -> void } -> void
-                                   | (Target | Group, ?bool no_group) -> Enumerator[Pathname]
-
-      # Yields signature paths that belongs to given target
-      #
-      # Skips yielding signature paths that belongs to group, if given.
-      #
-      def each_target_signature_path: (Target, Group? skip) { (Pathname) -> void } -> void
-                                    | (Target, Group? skip) -> Enumerator[Pathname]
-
-      # Yields signature paths that belongs to the project
-      #
-      # * Skips yielding signature paths that belongs to target, if given.
-      # * Skips yielding signature paths that belongs to *unreferenced* target.
-      #
-      def each_project_signature_path: (Target? skip) { (Pathname) -> void } -> void
-                                     | (Target? skip) -> Enumerator[Pathname]
-
-      # Yield source paths that belongs to given target/group
-      #
-      def each_group_source_path: (Target | Group, ?bool no_group) { (Pathname) -> void } -> void
-                                | (Target | Group, ?bool no_group) -> Enumerator[Pathname]
-
-      # Yield source paths that belongs to given target
-      #
-      # Skips yielding source paths that belongs to group, if given.
-      #
-      def each_target_source_path: (Target, Group?) { (Pathname) -> void } -> void
-                                 | (Target, Group?) -> Enumerator[Pathname]
-
-      # Yield source paths that belongs to project
-      #
-      # Skip yielding source paths that belongs to target, if given.
-      #
-      def each_project_source_path: (Target?) { (Pathname) -> void } -> void
-                                  | (Target?) -> Enumerator[Pathname]
-
-      def target_group_for_source_path: (Pathname) -> [Target, Group?]?
-
-      def target_group_for_signature_path: (Pathname) -> [Target, Group?]?
     end
   end
 end

--- a/sig/steep/server/target_group_files.rbs
+++ b/sig/steep/server/target_group_files.rbs
@@ -15,6 +15,8 @@ module Steep
       class PathEnumerator
         @paths: Hash[Pathname, Target | Group]
 
+        type path_group = [Pathname, Target, Group?, Target | Group]
+
         def initialize: () -> void
 
         def empty?: () -> bool
@@ -24,6 +26,8 @@ module Steep
         def []: (Pathname) -> (Target | Group | nil)
 
         def paths: () -> Array[Pathname]
+
+        def registered_path?: (Pathname) -> bool
 
         def each: () { ([Pathname, Target, Group?]) -> void } -> void
                 | () -> Enumerator[[Pathname, Target, Group?]]
@@ -36,26 +40,26 @@ module Steep
 
         # Yields all files from the collection
         #
-        def each_project_path: (?except: Target?) { (Pathname) -> void } -> void
-                            | (?except: Target?) -> Enumerator[Pathname]
+        def each_project_path: (?except: Target?) { (path_group) -> void } -> void
+                            | (?except: Target?) -> Enumerator[path_group]
 
         # Yields files that belongs to the target
         #
         # It also yields files that belongs to the sub-groups of the target.
         # When `except:` is given, files that belongs to the group are skipped.
         #
-        def each_target_path: (Target, ?except: Group?) { (Pathname) -> void } -> void
-                            | (Target, ?except: Group?) -> Enumerator[Pathname]
+        def each_target_path: (Target, ?except: Group?) { (path_group) -> void } -> void
+                            | (Target, ?except: Group?) -> Enumerator[path_group]
 
         # Yields files that belongs to the group or the target
         #
         # If `include_sub_groups: true` is given, it skips files in sub groups of the target.
         # If `include_sub_groups: false` is given (default), it yields files in sub groups of the target.
         #
-        def each_group_path: (Target | Group) { (Pathname) -> void } -> void
-                           | (Target | Group) -> Enumerator[Pathname]
-                           | (Target, ?include_sub_groups: bool) { (Pathname) -> void } -> void
-                           | (Target, ?include_sub_groups: bool) -> Enumerator[Pathname]
+        def each_group_path: (Target | Group) { (path_group) -> void } -> void
+                           | (Target | Group) -> Enumerator[path_group]
+                           | (Target, ?include_sub_groups: bool) { (path_group) -> void } -> void
+                           | (Target, ?include_sub_groups: bool) -> Enumerator[path_group]
 
         # Returns the target of the argument
         #
@@ -79,6 +83,9 @@ module Steep
       attr_reader library_paths: Hash[Symbol, Set[Pathname]]
 
       def initialize: (Project) -> void
+
+      # Returns true if the path is one of the source_paths, inline_paths, or signature_paths
+      def registered_path?: (Pathname) -> bool
 
       # Add path
       #

--- a/sig/steep/server/type_check_controller.rbs
+++ b/sig/steep/server/type_check_controller.rbs
@@ -23,6 +23,7 @@ module Steep
 
         attr_reader work_done_progress: WorkDoneProgress
 
+        # Pair of target name and path
         type target_and_path = [Symbol, Pathname]
 
         # The path of RBS files of libraries
@@ -34,12 +35,16 @@ module Steep
         # The path of Ruby code files
         attr_reader code_paths: Set[target_and_path]
 
+        # The path of inline RBS files
+        attr_reader inline_paths: Set[target_and_path]
+
         # The path of files that is opened by the editor
         attr_reader priority_paths: Set[Pathname]
 
         # The path of files that are type checked already
         attr_reader checked_paths: Set[target_and_path]
 
+        # The time when the request object is created
         attr_reader started_at: Time
 
         # `true` to report the progress to the client
@@ -55,9 +60,18 @@ module Steep
 
         private def uri: (Pathname path) -> URI::File
 
+        # Pair of target name and path string
+        #
         type target_path_string = [String, String]
 
-        type json = { guid: String, library_uris: Array[target_path_string], signature_uris: Array[target_path_string], code_uris: Array[target_path_string], priority_uris: Array[String] }
+        type json = {
+          guid: String,
+          library_uris: Array[target_path_string],
+          signature_uris: Array[target_path_string],
+          code_uris: Array[target_path_string],
+          inline_uris: Array[target_path_string],
+          priority_uris: Array[String]
+        }
 
         def as_json: (assignment: Services::PathAssignment) -> json
 
@@ -99,6 +113,9 @@ module Steep
         def each_unchecked_signature_target_path: () { (target_and_path) -> void } -> void
                                                 | () -> Enumerator[target_and_path]
 
+        def each_unchecked_inline_target_path: () { (target_and_path) -> void } -> void
+                                              | () -> Enumerator[target_and_path]
+
         # Set `#report_progress` and return self, defaults to `true`
         #
         def report_progress!: (?bool) -> self
@@ -109,41 +126,101 @@ module Steep
         private def assigned_uris: (Services::PathAssignment, Set[target_and_path]) -> Array[target_path_string]
       end
 
+      # The group of files that should be type checked/validated
+      type group = Target | Group
+
       attr_reader project: Project
 
-      attr_reader priority_paths: Set[Pathname]
+      # Set of open file paths
+      #
+      attr_reader open_paths: Set[Pathname]
 
-      attr_reader changed_paths: Set[Pathname]
+      # Set of groups that has activated since last type checking request
+      #
+      attr_reader new_active_groups: Set[group]
+
+      # Set of all active groups
+      #
+      attr_reader active_groups: Set[group]
+
+      # Set of paths that content is changed since last type checking request
+      attr_reader dirty_paths: Set[Pathname]
 
       attr_reader files: TargetGroupFiles
 
       def initialize: (project: Project) -> void
 
+      # Load files from commandline_args
+      #
       def load: (command_line_args: Array[String]) { (Hash[String, ChangeBuffer::content]) -> void } -> void
 
-      def push_changes: (Pathname path) -> void
-
-      def update_priority: (open: Pathname) -> void
-                         | (close: Pathname) -> void
-
-      def active_target?: (Target | Group) -> bool
-
-      def push_changes_for_target: (Target | Group) -> void
-
-      # Returns a TypeCheckRequest that contains all paths to be type checked
+      # Mark a path as dirty
       #
-      # This method also resets the controller status by removing everything from `changed_paths`.
+      def add_dirty_path: (Pathname path) -> void
+
+      # Delete everything from changed_paths
       #
-      # * If `include_unchanged` is `true`, all paths are included in the new request.
+      # priority_paths are not updated.
+      #
+      def reset: () -> void
+
+      # Notify a path is opened
+      #
+      # Returns a group if the path is the first open path of the group.
+      #
+      def open_path: (Pathname path) -> void
+
+      # Notify a path is closed
+      #
+      def close_path: (Pathname path) -> void
+
+      # Yields groups (targets) that has open paths
+      #
+      def each_active_group: () { (group) -> void } -> void
+                           | () -> Enumerator[group]
+
+      # Returns true if given group (group or target) includes priority path
+      #
+      def active_group?: (group) -> bool
+
+      # Returns a TypeCheckRequest that contains pending paths
+      #
+      # * This method also resets the controller status
+      # * `progress:` is a `WorkDoneProgress` object to report the progress of the type checking
+      # * Returns `nil` when no type checking is needed
+      #
+      # Resets after making the request.
+      #
+      def make_request: (?guid: String, progress: WorkDoneProgress) -> Request?
+
+      # Returns a TypeCheckRequest that contains all of the paths of the project
+      #
+      # * This method also resets the controller status.
       # * `progress:` is a `WorkDoneProgress` object to report the progress of the type checking.
       #
-      # Returns `nil` when no type checking is needed.
+      # Resets after making the request.
       #
-      def make_request: (?guid: String, ?include_unchanged: bool, progress: WorkDoneProgress) -> Request?
+      def make_all_request: (?guid: String, progress: WorkDoneProgress) -> Request
 
       # Returns a request to type check Ruby code and RBS type signatures of given groups
       #
-      def make_group_request: (Array[String], progress: WorkDoneProgress) -> Request
+      # Removes the specified groups from `new_active_groups` and delete type checked paths from `dirty_paths`.
+      # Raises an exception if the groups are empty.
+      #
+      # A group name can be a target name or a group name.
+      #
+      # * `lib`      => A target name in the project
+      # * `lib.core` => A group name in the project
+      #
+      def make_group_request: (Array[String] groups, ?guid: String, progress: WorkDoneProgress) -> Request
+
+      # Returns true if the group is unreferenced
+      #
+      private def unreferenced?: (group) -> bool
+
+      private def group_of: (Pathname path) -> group?
+
+      private def target_of: (Pathname path) -> Target?
     end
   end
 end

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -78,6 +78,16 @@ module Steep
         def initialize: (guid: String, path: Pathname, target: Project::Target) -> void
       end
 
+      class TypeCheckInlineCodeJob
+        attr_reader guid: String
+
+        attr_reader path: Pathname
+
+        attr_reader target: Project::Target
+
+        def initialize: (guid: String, path: Pathname, target: Project::Target) -> void
+      end
+
       class GotoJob
         type kind = :implementation | :definition | :type_definition
 
@@ -134,6 +144,7 @@ module Steep
                | TypeCheckCodeJob
                | ValidateAppSignatureJob
                | ValidateLibrarySignatureJob
+               | TypeCheckInlineCodeJob
                | GotoJob
                | StatsJob
 

--- a/sig/steep/services/signature_service.rbs
+++ b/sig/steep/services/signature_service.rbs
@@ -13,7 +13,7 @@ module Steep
       attr_reader status: status
 
       class SyntaxErrorStatus
-        attr_reader files: Hash[Pathname, FileStatus]
+        attr_reader files: Hash[Pathname, file_status]
 
         attr_reader changed_paths: Set[Pathname]
 
@@ -25,7 +25,7 @@ module Steep
 
         @constant_resolver: RBS::Resolver::ConstantResolver?
 
-        def initialize: (files: Hash[Pathname, FileStatus], changed_paths: Set[Pathname], diagnostics: Array[Diagnostic::Signature::Base], last_builder: RBS::DefinitionBuilder) -> void
+        def initialize: (files: Hash[Pathname, file_status], changed_paths: Set[Pathname], diagnostics: Array[Diagnostic::Signature::Base], last_builder: RBS::DefinitionBuilder) -> void
 
         def rbs_index: () -> Index::RBSIndex
 
@@ -33,7 +33,7 @@ module Steep
       end
 
       class AncestorErrorStatus
-        attr_reader files: Hash[Pathname, FileStatus]
+        attr_reader files: Hash[Pathname, file_status]
 
         attr_reader changed_paths: Set[Pathname]
 
@@ -45,7 +45,7 @@ module Steep
 
         @constant_resolver: RBS::Resolver::ConstantResolver?
 
-        def initialize: (files: Hash[Pathname, FileStatus], changed_paths: Set[Pathname], diagnostics: Array[Diagnostic::Signature::Base], last_builder: RBS::DefinitionBuilder) -> void
+        def initialize: (files: Hash[Pathname, file_status], changed_paths: Set[Pathname], diagnostics: Array[Diagnostic::Signature::Base], last_builder: RBS::DefinitionBuilder) -> void
 
         def rbs_index: () -> Index::RBSIndex
 
@@ -53,7 +53,7 @@ module Steep
       end
 
       class LoadedStatus
-        attr_reader files: Hash[Pathname, FileStatus]
+        attr_reader files: Hash[Pathname, file_status]
 
         attr_reader builder: RBS::DefinitionBuilder
 
@@ -65,7 +65,7 @@ module Steep
 
         @constant_resolver: RBS::Resolver::ConstantResolver?
 
-        def initialize: (files: Hash[Pathname, FileStatus], builder: RBS::DefinitionBuilder, implicitly_returns_nil: bool) -> void
+        def initialize: (files: Hash[Pathname, file_status], builder: RBS::DefinitionBuilder, implicitly_returns_nil: bool) -> void
 
         def subtyping: () -> Subtyping::Check
 
@@ -76,25 +76,25 @@ module Steep
 
       # A file has one of the three states:
       #
-      # 1. The parsing succeeded and loaded a list of declarations
-      # 2. The content has a syntax error and parsing failed
-      # 3. Other unexpected error
+      # 1. The parsing succeeded and loaded a list of declarations (RBS::Source::RBS)
+      # 2. The content has a syntax error and parsing failed (ParsingError)
+      # 3. Other unexpected error (UnexpectedError)
       #
-      class FileStatus
+      class RBSFileStatus
         attr_reader path: Pathname
 
         attr_reader content: String
 
-        type signature = [RBS::Buffer, Array[RBS::AST::Directives::t], Array[RBS::AST::Declarations::t]]
-
-        attr_reader signature: signature | Diagnostic::Signature::UnexpectedError | RBS::ParsingError
+        attr_reader source: RBS::Source::RBS | Diagnostic::Signature::UnexpectedError | RBS::ParsingError
 
         def initialize: (
           path: Pathname,
           content: String,
-          signature: signature | Diagnostic::Signature::UnexpectedError | RBS::ParsingError
+          source: RBS::Source::RBS | Diagnostic::Signature::UnexpectedError | RBS::ParsingError
         ) -> void
       end
+
+      type file_status = RBSFileStatus | RBS::Source::Ruby
 
       attr_reader implicitly_returns_nil: bool
 
@@ -115,7 +115,7 @@ module Steep
 
       # The Target files
       #
-      def files: () -> Hash[Pathname, FileStatus]
+      def files: () -> Hash[Pathname, file_status]
 
       def pending_changed_paths: () -> Set[Pathname]
 
@@ -129,14 +129,22 @@ module Steep
 
       def current_subtyping: () -> Subtyping::Check?
 
-      def apply_changes: (Hash[Pathname, FileStatus] files, Server::ChangeBuffer::changes changes) -> Hash[Pathname, FileStatus]
+      def apply_changes: (Hash[Pathname, file_status] files, Server::ChangeBuffer::changes changes) -> Hash[Pathname, file_status]
+
+      def load_rbs_file: (Pathname path, String old_content, Array[ContentChange]) -> RBSFileStatus
+
+      def load_ruby_file: (Pathname path, String old_content, Array[ContentChange]) -> RBS::Source::Ruby
+
+      # Returns `true` if `file_status` represents an error status
+      # 
+      def error_file?: (file_status) -> bool
 
       # The entry point to apply the edit to the signatures
       #
       def update: (Server::ChangeBuffer::changes changes) -> void
 
       def update_env: (
-        Hash[Pathname, FileStatus] updated_files,
+        Hash[Pathname, file_status] updated_files,
         paths: Set[Pathname]
       ) -> (RBS::DefinitionBuilder::AncestorBuilder | Array[Diagnostic::Signature::Base])
 

--- a/sig/steep/services/type_check_service.rbs
+++ b/sig/steep/services/type_check_service.rbs
@@ -48,9 +48,11 @@ module Steep
 
       def initialize: (project: Project) -> void
 
+      # Returns the diagnostics of signature files -- RBS files and inline RBS declarations
+      #
+      # The diagnostics are pulled from the signature services.
+      #
       def signature_diagnostics: () -> Hash[Pathname, Array[Diagnostic::Signature::Base]]
-
-      def has_diagnostics?: () -> bool
 
       def diagnostics: () -> Hash[Pathname, Array[Diagnostic::Ruby::Base | Diagnostic::Signature::Base]]
 
@@ -88,13 +90,20 @@ module Steep
 
       def self.type_check: (source: Source, subtyping: Subtyping::Check, constant_resolver: RBS::Resolver::ConstantResolver, cursor: Integer?) -> Typing
 
-      def source_file?: (Pathname path) -> bool
+      # Returns `true` if the path is a source file to be type checked
+      #
+      # Typically, path is a `.rb` file that contains Ruby code, or `.rb` file with inline RBS declarations.
+      #
+      private def source_file?: (Pathname path) -> bool
 
+      # Returns the array of target names that handles given path as a signature file
+      #
+      # Typically, path is a `.rbs` file path or `.rb` path with inline RBS declarations.
+      #
+      # * Path can be an absolute path.
+      # * Returns `nil` if there is no such target
+      #
       def signature_file?: (Pathname path) -> Array[Symbol]?
-
-      def app_signature_file?: (Pathname path) -> Array[Symbol]?
-
-      def lib_signature_file?: (Pathname path) -> bool
     end
   end
 end

--- a/sig/test/lsp_client.rbs
+++ b/sig/test/lsp_client.rbs
@@ -1,53 +1,80 @@
 # Generated from test/lsp_client.rb with RBS::Inline
 
 class LSPClient
-  attr_reader reader: untyped
+  type message = Hash[Symbol, untyped]
 
-  attr_reader writer: untyped
+  @incoming_thread: Thread
 
-  attr_reader current_dir: untyped
+  @next_request_id: Integer
 
-  attr_reader notifications: untyped
+  attr_reader reader: LanguageServer::Protocol::Transport::Io::Reader
 
-  attr_accessor default_timeout: untyped
+  attr_reader writer: LanguageServer::Protocol::Transport::Io::Writer
 
-  attr_reader request_response_table: untyped
+  attr_reader current_dir: Pathname
 
-  attr_reader diagnostics: untyped
+  attr_reader notifications: Array[message]
 
-  attr_reader open_files: untyped
+  attr_accessor default_timeout: Integer
 
-  def initialize: (reader: untyped, writer: untyped, current_dir: untyped) -> untyped
+  attr_reader request_response_table: Hash[Integer, message]
 
-  def get_response: (untyped id, ?timeout: untyped) -> untyped
+  attr_reader diagnostics: Hash[Pathname, Array[Hash[Symbol, untyped]]]
 
-  def flush_notifications: () -> untyped
+  attr_reader open_files: Hash[String, String]
 
-  def join: () -> untyped
+  # @rbs reader: LanguageServer::Protocol::Transport::Io::Reader
+  # @rbs writer: LanguageServer::Protocol::Transport::Io::Writer
+  # @rbs current_dir: Pathname
+  # @rbs return: void
+  def initialize: (reader: LanguageServer::Protocol::Transport::Io::Reader, writer: LanguageServer::Protocol::Transport::Io::Writer, current_dir: Pathname) -> void
 
-  def finally: (?timeout: untyped) -> untyped
+  # @rbs id: Integer
+  # @rbs timeout: untyped
+  # @rbs return: Hash[Symbol, untyped]?
+  def get_response: (Integer id, ?timeout: untyped) -> Hash[Symbol, untyped]?
 
-  def send_request: (method: untyped, params: untyped, ?id: untyped) ?{ (?) -> untyped } -> untyped
+  def flush_notifications: () -> void
 
-  def send_notification: (method: untyped, params: untyped) -> untyped
+  def join: () -> void
 
-  def uri: (untyped path) -> untyped
+  # @rbs (?timeout: Integer) { () -> void } -> void
+  def finally: (?timeout: Integer) { () -> void } -> void
 
-  def open_file: (*untyped paths) -> untyped
+  # @rbs [T] (?id: Integer, method: String, params: message?) { (untyped) -> T } -> T
+  #    | (?id: Integer, method: String, params: message?) -> Integer
+  def send_request: [T] (method: String, params: message?, ?id: Integer) { (untyped) -> T } -> T
+                  | (method: String, params: message?, ?id: Integer) -> Integer
 
-  def close_file: (*untyped paths) -> untyped
+  # @rbs (method: String, params: untyped) -> void
+  def send_notification: (method: String, params: untyped) -> void
 
-  def change_file: (untyped path) -> untyped
+  # @rbs (String) -> String
+  def uri: (String) -> String
 
-  def save_file: (untyped path) -> untyped
+  # @rbs *paths: String
+  def open_file: (*String paths) -> void
 
-  def change_watched_file: (*untyped paths) -> untyped
+  # @rbs *paths: String
+  def close_file: (*String paths) -> untyped
 
-  def workspace_symbol: (?untyped query) ?{ (?) -> untyped } -> untyped
+  # @rbs (String) { (String?) -> String } -> void
+  def change_file: (String) { (String?) -> String } -> void
 
-  def goto_definition: (untyped path, line: untyped, character: untyped) ?{ (?) -> untyped } -> untyped
+  # @rbs (String) -> void
+  def save_file: (String) -> void
 
-  def goto_implementation: (untyped path, line: untyped, character: untyped) ?{ (?) -> untyped } -> untyped
+  # @rbs *path: String
+  def change_watched_file: (*String paths) -> void
 
-  def fresh_request_id: () -> untyped
+  # @rbs (?String query) { (untyped) -> void } -> void
+  def workspace_symbol: (?String query) { (untyped) -> void } -> void
+
+  # @rbs (String path, line: Integer, character: Integer) { (untyped) -> void } -> void
+  def goto_definition: (String path, line: Integer, character: Integer) { (untyped) -> void } -> void
+
+  # @rbs (String path, line: Integer, character: Integer) { (untyped) -> void } -> void
+  def goto_implementation: (String path, line: Integer, character: Integer) { (untyped) -> void } -> void
+
+  def fresh_request_id: () -> Integer
 end

--- a/sig/test/lsp_test.rbs
+++ b/sig/test/lsp_test.rbs
@@ -9,9 +9,11 @@ class LSPTest < Minitest::Test
 
   def langserver_command: (?untyped steepfile) -> untyped
 
-  def start_server: () -> untyped
+  # @rbs () { (LSPClient) -> void } -> void
+  def start_server: () { (LSPClient) -> void } -> void
 
-  def write_file: (untyped path, untyped content) -> untyped
+  # @rbs (String, String) -> void
+  def write_file: (String, String) -> void
 
   def test_edit_files: () -> untyped
 

--- a/sig/test/server/target_group_files_test.rbs
+++ b/sig/test/server/target_group_files_test.rbs
@@ -11,31 +11,16 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
   def default_project: () -> Steep::Project
 
-  def setup_files: (untyped files) -> untyped
+  def test__add_path: () -> untyped
 
-  def test_files__each_library_path: () -> untyped
+  def test__add_library_path: () -> untyped
 
-  def test_files__each_group_signature_path__target: () -> untyped
+  # Returns a default enumerator with `.rb` files
+  def default_enumerator: (untyped project) -> Server::TargetGroupFiles::PathEnumerator
 
-  def test_files__each_group_source_path__target: () -> untyped
+  def test__path_enumerator__each_project_path: () -> untyped
 
-  def test_files__each_group_signature_path__group: () -> untyped
+  def test__path_enumerator__each_target_path: () -> void
 
-  def test_files__each_group_source_path__group: () -> untyped
-
-  def test_files__each_target_signature_path__no_group: () -> untyped
-
-  def test_files__each_target_source_path__no_group: () -> untyped
-
-  def test_files__each_target_signature_path__group: () -> untyped
-
-  def test_files__each_target_source_path__group: () -> untyped
-
-  def test_files__each_project_signature_path__all_target: () -> untyped
-
-  def test_files__each_project_source_path__all_target: () -> untyped
-
-  def test_files__each_project_signature_path__except_target: () -> untyped
-
-  def test_files__each_project_source_path__except_target: () -> untyped
+  def test__path_enumerator__each_group_path: () -> void
 end

--- a/sig/test/server/target_group_files_test.rbs
+++ b/sig/test/server/target_group_files_test.rbs
@@ -9,7 +9,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
   include Steep
 
-  def default_project: () -> untyped
+  def default_project: () -> Steep::Project
 
   def setup_files: (untyped files) -> untyped
 

--- a/sig/test/server/target_group_files_test.rbs
+++ b/sig/test/server/target_group_files_test.rbs
@@ -16,7 +16,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
   def test__add_library_path: () -> untyped
 
   # Returns a default enumerator with `.rb` files
-  def default_enumerator: (untyped project) -> Server::TargetGroupFiles::PathEnumerator
+  def default_enumerator: (untyped project) -> Steep::Server::TargetGroupFiles::PathEnumerator
 
   def test__path_enumerator__each_project_path: () -> untyped
 

--- a/sig/test/server_type_check_controller_test.rbs
+++ b/sig/test/server_type_check_controller_test.rbs
@@ -21,19 +21,17 @@ class ServerTypeCheckControllerTest < Minitest::Test
 
   def test_load__groups: () -> untyped
 
-  def test_push_changes_project_file: () -> untyped
+  def test_add_dirty_path: () -> untyped
 
-  def test_update_priority: () -> untyped
+  def test_open_path: () -> untyped
+
+  def test_close_path: () -> untyped
 
   def test_make_request_empty: () -> untyped
 
-  def test_make_request__include_unchanged: () -> untyped
+  def test_make_all_request: () -> untyped
 
-  def test_make_request__code_changed: () -> untyped
+  def test_make_request: () -> untyped
 
-  def test_make_request__signature_changed: () -> untyped
-
-  def test_make_request__other_group_priority: () -> untyped
-
-  def test_make_request__other_group_priority__unreferenced: () -> untyped
+  def test_make_group_request: () -> untyped
 end

--- a/sig/test/type_check_service_test.rbs
+++ b/sig/test/type_check_service_test.rbs
@@ -46,4 +46,10 @@ class TypeCheckServiceTest < Minitest::Test
   def test_typecheck__ignore_error: () -> untyped
 
   def test_typecheck__ignore_redundant: () -> untyped
+                                      
+  def test_update__inline: () -> untyped
+
+  def test_update__inline__type_error: () -> void
+
+  def test_update__inline__validation_error: () -> void
 end

--- a/sig/test/type_check_worker_test.rbs
+++ b/sig/test/type_check_worker_test.rbs
@@ -21,7 +21,8 @@ class TypeCheckWorkerTest < Minitest::Test
 
   def dirs: () -> untyped
 
-  def run_worker: (untyped worker) -> untyped
+  # @rbs (Server::TypeCheckWorker) { (Thread) -> void } -> void
+  def run_worker: (Server::TypeCheckWorker) { (Thread) -> void } -> void
 
   def shutdown!: () -> untyped
 
@@ -50,6 +51,12 @@ class TypeCheckWorkerTest < Minitest::Test
   def test_handle_job_typecheck_code_diagnostics: () -> untyped
 
   def test_handle_job_typecheck_skip: () -> untyped
+
+  def test_handle_job_typecheck_inline__no_error: () -> untyped
+
+  def test_handle_job_typecheck_inline__implementation_error: () -> untyped
+
+  def test_handle_job_typecheck_inline__type_decl_error: () -> untyped
 
   def test_job_workspace_symbol: () -> untyped
 

--- a/test/lsp_client.rb
+++ b/test/lsp_client.rb
@@ -1,16 +1,30 @@
 class LSPClient
-  attr_reader :reader, :writer, :current_dir
+  # @rbs!
+  #   type message = Hash[Symbol, untyped]
 
-  attr_reader :notifications
+  # @rbs @next_request_id: Integer
+  # @rbs @incoming_thread: Thread
 
-  attr_accessor :default_timeout
+  attr_reader :reader #: LanguageServer::Protocol::Transport::Io::Reader
 
-  attr_reader :request_response_table
+  attr_reader :writer #: LanguageServer::Protocol::Transport::Io::Writer
 
-  attr_reader :diagnostics
+  attr_reader :current_dir #: Pathname
 
-  attr_reader :open_files
+  attr_reader :notifications #: Array[message]
 
+  attr_accessor :default_timeout #: Integer
+
+  attr_reader :request_response_table #: Hash[Integer, message]
+
+  attr_reader :diagnostics #: Hash[Pathname, Array[Hash[Symbol, untyped]]]
+
+  attr_reader :open_files #: Hash[String, String]
+
+  # @rbs reader: LanguageServer::Protocol::Transport::Io::Reader
+  # @rbs writer: LanguageServer::Protocol::Transport::Io::Writer
+  # @rbs current_dir: Pathname
+  # @rbs return: void
   def initialize(reader:, writer:, current_dir:)
     @reader = reader
     @writer = writer
@@ -33,7 +47,7 @@ class LSPClient
           notifications << message
           case message.fetch(:method)
           when "textDocument/publishDiagnostics"
-            path = Steep::PathHelper.to_pathname(message[:params][:uri])
+            path = Steep::PathHelper.to_pathname(message[:params][:uri]) or raise
             path = path.relative_path_from(current_dir)
             diagnostics[path] = message[:params][:diagnostics]
           else
@@ -50,24 +64,29 @@ class LSPClient
     end
   end
 
+  # @rbs id: Integer
+  # @rbs timeout: untyped
+  # @rbs return: Hash[Symbol, untyped]?
   def get_response(id, timeout: default_timeout)
     finally do
       if request_response_table.key?(id)
-        return request_response_table.delete(id)
+        return request_response_table.delete(id) || raise
       end
     end
+    nil
   end
 
-  def flush_notifications()
+  def flush_notifications() #: void
     nots = notifications.dup
     notifications.clear()
     nots
   end
 
-  def join
+  def join #: void
     @incoming_thread.join
   end
 
+  # @rbs (?timeout: Integer) { () -> void } -> void
   def finally(timeout: default_timeout)
     started_at = Time.now
     while Time.now < started_at + timeout
@@ -78,6 +97,8 @@ class LSPClient
     raise "timeout exceeded: #{timeout} seconds"
   end
 
+  # @rbs [T] (?id: Integer, method: String, params: message?) { (untyped) -> T } -> T
+  #    | (?id: Integer, method: String, params: message?) -> Integer
   def send_request(id: fresh_request_id, method:, params:, &block)
     writer.write({ id: id, method: method, params: params })
 
@@ -88,16 +109,19 @@ class LSPClient
     end
   end
 
+  # @rbs (method: String, params: untyped) -> void
   def send_notification(method:, params:)
     writer.write({ method: method, params: params })
   end
 
+  # @rbs (String) -> String
   def uri(path)
     prefix = Gem.win_platform? ? "file:///" : "file://"
     "#{prefix}#{current_dir + path}"
   end
 
-  def open_file(*paths)
+  # @rbs *paths: String
+  def open_file(*paths) #: void
     paths.each do |path|
       content = (current_dir + path).read
       open_files[path] = content
@@ -110,6 +134,7 @@ class LSPClient
     end
   end
 
+  # @rbs *paths: String
   def close_file(*paths)
     paths.each do |path|
       send_notification(
@@ -123,6 +148,7 @@ class LSPClient
     end
   end
 
+  # @rbs (String) { (String?) -> String } -> void
   def change_file(path)
     content = open_files[path]
     content = open_files[path] = yield(content)
@@ -139,6 +165,7 @@ class LSPClient
     )
   end
 
+  # @rbs (String) -> void
   def save_file(path)
     content = open_files.delete(path) or raise
     (current_dir + path).write(content)
@@ -155,8 +182,9 @@ class LSPClient
     change_watched_file(path)
   end
 
-  def change_watched_file(*paths)
-    changes = []
+  # @rbs *path: String
+  def change_watched_file(*paths) #: void
+    changes = [] #: Array[message]
     paths.each do |path|
       path = current_dir + path
 
@@ -175,6 +203,7 @@ class LSPClient
     )
   end
 
+  # @rbs (?String query) { (untyped) -> void } -> void
   def workspace_symbol(query = "", &block)
     send_request(
       method: "workspace/symbol",
@@ -184,6 +213,7 @@ class LSPClient
     end
   end
 
+  # @rbs (String path, line: Integer, character: Integer) { (untyped) -> void } -> void
   def goto_definition(path, line:, character:, &block)
     send_request(
       method: "textDocument/definition",
@@ -196,6 +226,7 @@ class LSPClient
     end
   end
 
+  # @rbs (String path, line: Integer, character: Integer) { (untyped) -> void } -> void
   def goto_implementation(path, line:, character:, &block)
     send_request(
       method: "textDocument/implementation",
@@ -210,7 +241,7 @@ class LSPClient
 
   protected
 
-  def fresh_request_id
+  def fresh_request_id #: Integer
     @next_request_id += 1
   end
 end

--- a/test/lsp_client.rb
+++ b/test/lsp_client.rb
@@ -186,9 +186,9 @@ class LSPClient
   def change_watched_file(*paths) #: void
     changes = [] #: Array[message]
     paths.each do |path|
-      path = current_dir + path
+      absolute_path = current_dir + path
 
-      if path.file?
+      if absolute_path.file?
         # Created (or maybe modified)
         changes << { uri: uri(path), type: 1 }
       else

--- a/test/lsp_test.rb
+++ b/test/lsp_test.rb
@@ -17,6 +17,7 @@ class LSPTest < Minitest::Test
     end
   end
 
+  # @rbs () { (LSPClient) -> void } -> void
   def start_server()
     Open3.popen2(langserver_command(current_dir + "Steepfile")) do |stdin, stdout|
       reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdout)
@@ -29,6 +30,7 @@ class LSPTest < Minitest::Test
     end
   end
 
+  # @rbs (String, String) -> void
   def write_file(path, content)
     (current_dir + path).parent.mkpath
     (current_dir + path).write(content)

--- a/test/lsp_test.rb
+++ b/test/lsp_test.rb
@@ -261,9 +261,8 @@ RUBY
         client.change_watched_file("sig/core/core.rbs")
 
         finally_holds(timeout: 3) do
-          # `core` groups are type checked
           assert_operator client.diagnostics, :key?, Pathname("lib/core/core.rb")
-          refute_operator client.diagnostics, :key?, Pathname("lib/main/main.rb")
+          assert_operator client.diagnostics, :key?, Pathname("lib/main/main.rb")
           assert_operator client.diagnostics, :key?, Pathname("sig/core/core.rbs")
           assert_operator client.diagnostics, :key?, Pathname("sig/main/main.rbs")
           refute_operator client.diagnostics, :key?, Pathname("test/core_test.rb")

--- a/test/lsp_test.rb
+++ b/test/lsp_test.rb
@@ -48,8 +48,7 @@ target :lib do
   end
 
   group :main do
-    check "lib/main"
-    signature "sig/main"
+    check "lib/main", inline: true
   end
 end
 
@@ -73,10 +72,6 @@ RUBY
         class Main
         end
       RUBY
-      write_file("sig/main/main.rbs", <<~RBS)
-        class Main
-        end
-      RBS
       write_file("test/core_test.rb", <<~RUBY)
         class CoreTest
         end
@@ -104,7 +99,6 @@ RUBY
           assert_operator client.diagnostics, :key?, Pathname("lib/core/core.rb")
           refute_operator client.diagnostics, :key?, Pathname("lib/main/main.rb")
           assert_operator client.diagnostics, :key?, Pathname("sig/core/core.rbs")
-          refute_operator client.diagnostics, :key?, Pathname("sig/main/main.rbs")
           refute_operator client.diagnostics, :key?, Pathname("test/core_test.rb")
           refute_operator client.diagnostics, :key?, Pathname("test/main_test.rb")
           refute_operator client.diagnostics, :key?, Pathname("sig/test/test.rbs")
@@ -124,7 +118,6 @@ RUBY
           assert_operator client.diagnostics, :key?, Pathname("lib/core/core.rb")
           refute_operator client.diagnostics, :key?, Pathname("lib/main/main.rb")
           refute_operator client.diagnostics, :key?, Pathname("sig/core/core.rbs")
-          refute_operator client.diagnostics, :key?, Pathname("sig/main/main.rbs")
           refute_operator client.diagnostics, :key?, Pathname("test/core_test.rb")
           refute_operator client.diagnostics, :key?, Pathname("test/main_test.rb")
           refute_operator client.diagnostics, :key?, Pathname("sig/test/test.rbs")
@@ -147,7 +140,6 @@ RUBY
           assert_operator client.diagnostics, :key?, Pathname("lib/core/core.rb")
           assert_operator client.diagnostics, :key?, Pathname("lib/main/main.rb")
           assert_operator client.diagnostics, :key?, Pathname("sig/core/core.rbs")
-          assert_operator client.diagnostics, :key?, Pathname("sig/main/main.rbs")
           refute_operator client.diagnostics, :key?, Pathname("test/core_test.rb")
           refute_operator client.diagnostics, :key?, Pathname("test/main_test.rb")
           refute_operator client.diagnostics, :key?, Pathname("sig/test/test.rbs")
@@ -171,7 +163,6 @@ RUBY
           refute_operator client.diagnostics, :key?, Pathname("lib/core/core.rb")
           refute_operator client.diagnostics, :key?, Pathname("lib/main/main.rb")
           refute_operator client.diagnostics, :key?, Pathname("sig/core/core.rbs")
-          refute_operator client.diagnostics, :key?, Pathname("sig/main/main.rbs")
           assert_operator client.diagnostics, :key?, Pathname("test/core_test.rb")
           assert_operator client.diagnostics, :key?, Pathname("test/main_test.rb")
           assert_operator client.diagnostics, :key?, Pathname("sig/test/test.rbs")

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -53,8 +53,8 @@ end
       )
       master.assign_initialize_params(DEFAULT_CLI_LSP_INITIALIZE_PARAMS.merge(capabilities: { window: { workDoneProgress: true } }))
 
-      master.controller.push_changes current_dir + "lib/customer.rb"
-      master.controller.push_changes current_dir + "lib/account.rb"
+      master.controller.add_dirty_path current_dir + "lib/customer.rb"
+      master.controller.add_dirty_path current_dir + "lib/account.rb"
 
       progress = master.work_done_progress("guid")
       master.start_type_check(last_request: nil, progress: progress, report_progress_threshold: 0, needs_response: true)
@@ -119,8 +119,8 @@ end
       )
       master.assign_initialize_params(DEFAULT_CLI_LSP_INITIALIZE_PARAMS)
 
-      master.controller.push_changes current_dir + "lib/customer.rb"
-      master.controller.push_changes current_dir + "lib/account.rb"
+      master.controller.add_dirty_path current_dir + "lib/customer.rb"
+      master.controller.add_dirty_path current_dir + "lib/account.rb"
 
       progress = master.work_done_progress("guid")
       master.start_type_check(last_request: nil, progress: progress, report_progress_threshold: 0, needs_response: true)
@@ -172,8 +172,8 @@ end
       )
       master.assign_initialize_params(DEFAULT_CLI_LSP_INITIALIZE_PARAMS)
 
-      master.controller.push_changes current_dir + "lib/customer.rb"
-      master.controller.push_changes current_dir + "lib/account.rb"
+      master.controller.add_dirty_path current_dir + "lib/customer.rb"
+      master.controller.add_dirty_path current_dir + "lib/account.rb"
 
       progress = master.work_done_progress("guid")
       master.start_type_check(last_request: nil, progress: progress, report_progress_threshold: 10, needs_response: true)
@@ -218,8 +218,8 @@ end
       )
       master.assign_initialize_params(DEFAULT_CLI_LSP_INITIALIZE_PARAMS.merge(capabilities: { window: { workDoneProgress: true } }))
 
-      master.controller.push_changes current_dir + "lib/customer.rb"
-      master.controller.push_changes current_dir + "lib/account.rb"
+      master.controller.add_dirty_path current_dir + "lib/customer.rb"
+      master.controller.add_dirty_path current_dir + "lib/account.rb"
 
       progress = master.work_done_progress("guid")
       master.start_type_check(last_request: nil, progress: progress, report_progress_threshold: 0, needs_response: true)
@@ -305,8 +305,8 @@ end
       )
       master.assign_initialize_params(DEFAULT_CLI_LSP_INITIALIZE_PARAMS)
 
-      master.controller.push_changes current_dir + "lib/customer.rb"
-      master.controller.push_changes current_dir + "lib/account.rb"
+      master.controller.add_dirty_path current_dir + "lib/customer.rb"
+      master.controller.add_dirty_path current_dir + "lib/account.rb"
 
       progress = master.work_done_progress("guid")
       master.start_type_check(last_request: nil, progress: progress, report_progress_threshold: 0, needs_response: true)
@@ -429,7 +429,7 @@ end
         typecheck_workers: [worker]
       )
 
-      assert_empty master.controller.changed_paths
+      assert_empty master.controller.dirty_paths
 
       master.process_message_from_client(
         {
@@ -450,7 +450,7 @@ end
         assert_equal "textDocument/didChange", job.message[:method]
       end
 
-      assert_operator master.controller.changed_paths, :include?, current_dir + "lib/customer.rb"
+      assert_operator master.controller.dirty_paths, :include?, current_dir + "lib/customer.rb"
     end
   end
 
@@ -477,7 +477,7 @@ end
         typecheck_workers: [worker]
       )
 
-      assert_empty master.controller.changed_paths
+      assert_empty master.controller.dirty_paths
 
       master.process_message_from_client(
         {
@@ -518,7 +518,7 @@ end
         typecheck_workers: [worker]
       )
 
-      assert_empty master.controller.priority_paths
+      assert_empty master.controller.open_paths
 
       master.process_message_from_client(
         {
@@ -531,7 +531,7 @@ end
         }
       )
 
-      assert_operator master.controller.priority_paths, :include?, current_dir + "lib/customer.rb"
+      assert_operator master.controller.open_paths, :include?, current_dir + "lib/customer.rb"
 
       master.process_message_from_client(
         {
@@ -544,7 +544,7 @@ end
         }
       )
 
-      refute_operator master.controller.priority_paths, :include?, current_dir + "lib/customer.rb"
+      refute_operator master.controller.open_paths, :include?, current_dir + "lib/customer.rb"
     end
   end
 
@@ -881,7 +881,7 @@ end
         typecheck_workers: [worker]
       )
 
-      assert_empty master.controller.changed_paths
+      assert_empty master.controller.dirty_paths
 
       master.process_message_from_client(
         {

--- a/test/server/target_group_files_test.rb
+++ b/test/server/target_group_files_test.rb
@@ -142,7 +142,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Pathname("/app/app/cli.rb"),
         Pathname("/app/test/lib_test.rb")
       ],
-      enumerator.each_project_path().to_set
+      enumerator.each_project_path().map { _1[0] }.to_set
     )
 
     project.targets.find { _1.name == :lib }.tap do |target|
@@ -155,7 +155,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/app/cli.rb"),
           Pathname("/app/test/lib_test.rb")
         ],
-        enumerator.each_project_path(except: target).to_set
+        enumerator.each_project_path(except: target).map { _1[0] }.to_set
       )
     end
 
@@ -167,7 +167,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/lib/lib.rb"),
           Pathname("/app/test/lib_test.rb")
         ],
-        enumerator.each_project_path(except: target).to_set
+        enumerator.each_project_path(except: target).map { _1[0] }.to_set
       )
     end
 
@@ -181,7 +181,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/app/main/main.rb"),
           Pathname("/app/app/cli.rb"),
         ],
-        enumerator.each_project_path(except: target).to_set
+        enumerator.each_project_path(except: target).map { _1[0] }.to_set
       )
     end
   end
@@ -197,7 +197,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Set[
           Pathname("/app/lib/lib.rb"),
         ],
-        enumerator.each_target_path(target).to_set
+        enumerator.each_target_path(target).map { _1[0] }.to_set
       )
     end
 
@@ -210,7 +210,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/app/main/main.rb"),
           Pathname("/app/app/cli.rb")
         ],
-        enumerator.each_target_path(target).to_set
+        enumerator.each_target_path(target).map { _1[0] }.to_set
       )
 
       target.groups.find { _1.name == :server }.tap do |group|
@@ -221,7 +221,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
             Pathname("/app/app/main/main.rb"),
             Pathname("/app/app/cli.rb")
           ],
-          enumerator.each_target_path(target, except: group).to_set
+          enumerator.each_target_path(target, except: group).map { _1[0] }.to_set
         )
       end
 
@@ -233,7 +233,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
             Pathname("/app/app/server/server.rb"),
             Pathname("/app/app/cli.rb")
           ],
-          enumerator.each_target_path(target, except: group).to_set
+          enumerator.each_target_path(target, except: group).map { _1[0] }.to_set
         )
       end
     end
@@ -245,7 +245,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Set[
           Pathname("/app/test/lib_test.rb"),
         ],
-        enumerator.each_target_path(target).to_set
+        enumerator.each_target_path(target).map { _1[0] }.to_set
       )
     end
   end

--- a/test/server/target_group_files_test.rb
+++ b/test/server/target_group_files_test.rb
@@ -28,6 +28,8 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
         check "app/cli.rb"
         signature "sig/app/cli.rbs"
+
+        check "app/version.rb", inline: true
       end
 
       target :test do
@@ -40,275 +42,282 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     project
   end
 
-  def setup_files(files)
+  def test__add_path()
+    files = Server::TargetGroupFiles.new(default_project())
+
+    files.add_path(Pathname("/app/lib/lib.rb"))
+    files.add_path(Pathname("/app/app/cli.rb"))
+    files.add_path(Pathname("/app/test/lib_test.rb"))
+
+    files.add_path(Pathname("/app/sig/lib/lib.rbs"))
+    files.add_path(Pathname("/app/sig/app/cli.rbs"))
+    files.add_path(Pathname("/app/sig/test/lib_test.rbs"))
+
+    files.add_path(Pathname("/app/app/version.rb"))
+
+    assert_equal(
+      Set[
+        Pathname("/app/lib/lib.rb"),
+        Pathname("/app/app/cli.rb"),
+        Pathname("/app/test/lib_test.rb")
+      ],
+      files.source_paths.paths.to_set
+    )
+
+    assert_equal(
+      Set[
+        Pathname("/app/sig/lib/lib.rbs"),
+        Pathname("/app/sig/app/cli.rbs"),
+        Pathname("/app/sig/test/lib_test.rbs")
+      ],
+      files.signature_paths.paths.to_set
+    )
+
+    assert_equal(
+      Set[
+        Pathname("/app/app/version.rb")
+      ],
+      files.inline_paths.paths.to_set
+    )
+  end
+
+  def test__add_library_path
+    project = default_project
+    files = Server::TargetGroupFiles.new(project)
+
     files.project.targets.each do |target|
       files.add_library_path(target, Pathname("/rbs/core/object.rbs"))
       files.add_library_path(target, Pathname("/rbs/core/string.rbs"))
     end
     files.add_library_path(files.project.targets.find { _1.name == :test }, Pathname("/rbs/stdlib/test_unit.rbs"))
 
-    files.add_path(Pathname("/app/lib/lib.rb"))
-    files.add_path(Pathname("/app/app/server/server.rb"))
-    files.add_path(Pathname("/app/app/main/main.rb"))
-    files.add_path(Pathname("/app/app/cli.rb"))
-    files.add_path(Pathname("/app/app/version.rb"))
-    files.add_path(Pathname("/app/test/lib_test.rb"))
-
-    files.add_path(Pathname("/app/sig/lib/lib.rbs"))
-    files.add_path(Pathname("/app/sig/app/server/server.rbs"))
-    files.add_path(Pathname("/app/sig/app/main/main.rbs"))
-    files.add_path(Pathname("/app/sig/app/cli.rbs"))
-    files.add_path(Pathname("/app/sig/test/lib_test.rbs"))
-  end
-
-  def test_files__each_library_path
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
     assert_equal Set[Pathname("/rbs/core/object.rbs"), Pathname("/rbs/core/string.rbs")], files.each_library_path(project.targets.find { _1.name == :lib }).to_set
     assert_equal Set[Pathname("/rbs/core/object.rbs"), Pathname("/rbs/core/string.rbs")], files.each_library_path(project.targets.find { _1.name == :app }).to_set
     assert_equal Set[Pathname("/rbs/core/object.rbs"), Pathname("/rbs/core/string.rbs"), Pathname("/rbs/stdlib/test_unit.rbs")], files.each_library_path(project.targets.find { _1.name == :test }).to_set
   end
 
-  def test_files__each_group_signature_path__target
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/lib/lib.rbs")], files.signature_paths.each_group_path(target).to_set
-    end
-    project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_group_path(target).to_set
-    end
-    project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/test/lib_test.rbs")], files.signature_paths.each_group_path(target).to_set
-    end
-  end
-
-  def test_files__each_group_source_path__target
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
+  # Returns a default enumerator with `.rb` files
+  #
+  def default_enumerator(project) #: Server::TargetGroupFiles::PathEnumerator
+    enumerator = Server::TargetGroupFiles::PathEnumerator.new
 
     project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/lib/lib.rb")], files.source_paths.each_group_path(target).to_set
+      target or raise
+      enumerator[Pathname("/app/lib/lib.rb")] = target
     end
+
     project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/app/cli.rb")], files.source_paths.each_group_path(target).to_set
+      target or raise
+
+      target.groups.find { _1.name == :server }.tap do |group|
+        group or raise
+        enumerator[Pathname("/app/app/server/server.rb")] = group
+      end
+
+      target.groups.find { _1.name == :main }.tap do |group|
+        group or raise
+        enumerator[Pathname("/app/app/main/main.rb")] = group
+      end
+
+      enumerator[Pathname("/app/app/cli.rb")] = target
     end
+
     project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/test/lib_test.rb")], files.source_paths.each_group_path(target).to_set
+      target or raise
+      enumerator[Pathname("/app/test/lib_test.rb")] = target
     end
+
+    enumerator
   end
 
-  def test_files__each_group_signature_path__group
+  def test__path_enumerator__each_project_path
     project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :app }.tap do |target|
-      target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/server/server.rbs")], files.signature_paths.each_group_path(group).to_set
-      end
-      target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/main/main.rbs")], files.signature_paths.each_group_path(group).to_set
-      end
-    end
-  end
-
-  def test_files__each_group_source_path__group
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :app }.tap do |target|
-      target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/app/server/server.rb")], files.source_paths.each_group_path(group).to_set
-      end
-      target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/app/main/main.rb")], files.source_paths.each_group_path(group).to_set
-      end
-    end
-  end
-
-  def test_files__each_target_signature_path__no_group
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/lib/lib.rbs")], files.signature_paths.each_target_path(target).to_set
-    end
-    project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_target_path(target).to_set
-    end
-    project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/test/lib_test.rbs")], files.signature_paths.each_target_path(target).to_set
-    end
-  end
-
-  def test_files__each_target_source_path__no_group
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/lib/lib.rb")], files.source_paths.each_target_path(target).to_set
-    end
-    project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.source_paths.each_target_path(target).to_set
-    end
-    project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/test/lib_test.rb")], files.source_paths.each_target_path(target).to_set
-    end
-  end
-
-  def test_files__each_target_signature_path__group
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :app }.tap do |target|
-      target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_target_path(target, except: group).to_set
-      end
-      target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_target_path(target, except: group).to_set
-      end
-    end
-  end
-
-  def test_files__each_target_source_path__group
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :app }.tap do |target|
-      target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.source_paths.each_target_path(target, except: group).to_set
-      end
-      target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/cli.rb")], files.source_paths.each_target_path(target, except: group).to_set
-      end
-    end
-  end
-
-  def test_files__each_project_signature_path__all_target
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    assert_equal(
-      Set[
-        Pathname("/app/sig/lib/lib.rbs"),
-        Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs"),
-        Pathname("/app/sig/test/lib_test.rbs")
-      ],
-      files.signature_paths.each_project_path().to_set
-    )
-  end
-
-  def test_files__each_project_source_path__all_target
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
+    enumerator = default_enumerator(project)
 
     assert_equal(
       Set[
         Pathname("/app/lib/lib.rb"),
-        Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb"),
+        Pathname("/app/app/server/server.rb"),
+        Pathname("/app/app/main/main.rb"),
+        Pathname("/app/app/cli.rb"),
         Pathname("/app/test/lib_test.rb")
       ],
-      files.source_paths.each_project_path().to_set
+      enumerator.each_project_path().to_set
     )
-  end
-
-  def test_files__each_project_signature_path__except_target
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
 
     project.targets.find { _1.name == :lib }.tap do |target|
+      target or raise
+
       assert_equal(
         Set[
-          Pathname("/app/sig/app/server/server.rbs"),
-          Pathname("/app/sig/app/main/main.rbs"),
-          Pathname("/app/sig/app/cli.rbs"),
-          Pathname("/app/sig/test/lib_test.rbs")
-        ],
-        files.signature_paths.each_project_path(except: target).to_set
-      )
-    end
-
-    project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal(
-        Set[
-          Pathname("/app/sig/lib/lib.rbs"),
-          Pathname("/app/sig/test/lib_test.rbs")
-        ],
-        files.signature_paths.each_project_path(except: target).to_set
-      )
-    end
-
-    project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal(
-        Set[
-          Pathname("/app/sig/lib/lib.rbs"),
-          Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")
-        ],
-        files.signature_paths.each_project_path(except: target).to_set
-      )
-    end
-  end
-
-  def test_files__each_project_source_path__except_target
-    project = default_project()
-
-    files = Server::TargetGroupFiles.new(project)
-    setup_files(files)
-
-    project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal(
-        Set[
-          Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb"),
+          Pathname("/app/app/server/server.rb"),
+          Pathname("/app/app/main/main.rb"),
+          Pathname("/app/app/cli.rb"),
           Pathname("/app/test/lib_test.rb")
         ],
-        files.source_paths.each_project_path(except: target).to_set
+        enumerator.each_project_path(except: target).to_set
       )
     end
 
     project.targets.find { _1.name == :app }.tap do |target|
+      target or raise
+
       assert_equal(
         Set[
           Pathname("/app/lib/lib.rb"),
           Pathname("/app/test/lib_test.rb")
         ],
-        files.source_paths.each_project_path(except: target).to_set
+        enumerator.each_project_path(except: target).to_set
       )
     end
 
     project.targets.find { _1.name == :test }.tap do |target|
+      target or raise
+
       assert_equal(
         Set[
           Pathname("/app/lib/lib.rb"),
-          Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")
+          Pathname("/app/app/server/server.rb"),
+          Pathname("/app/app/main/main.rb"),
+          Pathname("/app/app/cli.rb"),
         ],
-        files.source_paths.each_project_path(except: target).to_set
+        enumerator.each_project_path(except: target).to_set
       )
     end
   end
+
+  def test__path_enumerator__each_target_path #: void
+    project = default_project()
+    enumerator = default_enumerator(project)
+
+    project.targets.find { _1.name == :lib }.tap do |target|
+      target or raise
+
+      assert_equal(
+        Set[
+          Pathname("/app/lib/lib.rb"),
+        ],
+        enumerator.each_target_path(target).to_set
+      )
+    end
+
+    project.targets.find { _1.name == :app }.tap do |target|
+      target or raise
+
+      assert_equal(
+        Set[
+          Pathname("/app/app/server/server.rb"),
+          Pathname("/app/app/main/main.rb"),
+          Pathname("/app/app/cli.rb")
+        ],
+        enumerator.each_target_path(target).to_set
+      )
+
+      target.groups.find { _1.name == :server }.tap do |group|
+        group or raise
+
+        assert_equal(
+          Set[
+            Pathname("/app/app/main/main.rb"),
+            Pathname("/app/app/cli.rb")
+          ],
+          enumerator.each_target_path(target, except: group).to_set
+        )
+      end
+
+      target.groups.find { _1.name == :main }.tap do |group|
+        group or raise
+
+        assert_equal(
+          Set[
+            Pathname("/app/app/server/server.rb"),
+            Pathname("/app/app/cli.rb")
+          ],
+          enumerator.each_target_path(target, except: group).to_set
+        )
+      end
+    end
+
+    project.targets.find { _1.name == :test }.tap do |target|
+      target or raise
+
+      assert_equal(
+        Set[
+          Pathname("/app/test/lib_test.rb"),
+        ],
+        enumerator.each_target_path(target).to_set
+      )
+    end
+  end
+
+  def test__path_enumerator__each_group_path #: void
+    project = default_project()
+    enumerator = default_enumerator(project)
+
+    project.targets.find { _1.name == :lib }.tap do |target|
+      target or raise
+
+      assert_equal(
+        Set[
+          Pathname("/app/lib/lib.rb"),
+        ],
+        enumerator.each_group_path(target).to_set
+      )
+    end
+
+    project.targets.find { _1.name == :app }.tap do |target|
+      target or raise
+
+      assert_equal(
+        Set[
+          Pathname("/app/app/cli.rb")
+        ],
+        enumerator.each_group_path(target).to_set
+      )
+
+      assert_equal(
+        Set[
+          Pathname("/app/app/server/server.rb"),
+          Pathname("/app/app/main/main.rb"),
+          Pathname("/app/app/cli.rb")
+        ],
+        enumerator.each_group_path(target, include_sub_groups: true).to_set
+      )
+
+      target.groups.find { _1.name == :server }.tap do |group|
+        group or raise
+
+        assert_equal(
+          Set[
+            Pathname("/app/app/server/server.rb"),
+          ],
+          enumerator.each_group_path(group).to_set
+        )
+      end
+
+      target.groups.find { _1.name == :main }.tap do |group|
+        group or raise
+
+        assert_equal(
+          Set[
+            Pathname("/app/app/main/main.rb"),
+          ],
+          enumerator.each_group_path(group).to_set
+        )
+      end
+    end
+
+    project.targets.find { _1.name == :test }.tap do |target|
+      target or raise
+
+      assert_equal(
+        Set[
+          Pathname("/app/test/lib_test.rb"),
+        ],
+        enumerator.each_group_path(target).to_set
+      )
+    end
+  end
+
+
 end

--- a/test/server/target_group_files_test.rb
+++ b/test/server/target_group_files_test.rb
@@ -261,7 +261,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Set[
           Pathname("/app/lib/lib.rb"),
         ],
-        enumerator.each_group_path(target).to_set
+        enumerator.each_group_path(target).map { _1[0] }.to_set
       )
     end
 
@@ -272,7 +272,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Set[
           Pathname("/app/app/cli.rb")
         ],
-        enumerator.each_group_path(target).to_set
+        enumerator.each_group_path(target).map { _1[0] }.to_set
       )
 
       assert_equal(
@@ -281,7 +281,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/app/main/main.rb"),
           Pathname("/app/app/cli.rb")
         ],
-        enumerator.each_group_path(target, include_sub_groups: true).to_set
+        enumerator.each_group_path(target, include_sub_groups: true).map { _1[0] }.to_set
       )
 
       target.groups.find { _1.name == :server }.tap do |group|
@@ -291,7 +291,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Set[
             Pathname("/app/app/server/server.rb"),
           ],
-          enumerator.each_group_path(group).to_set
+          enumerator.each_group_path(group).map { _1[0] }.to_set
         )
       end
 
@@ -302,7 +302,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Set[
             Pathname("/app/app/main/main.rb"),
           ],
-          enumerator.each_group_path(group).to_set
+          enumerator.each_group_path(group).map { _1[0] }.to_set
         )
       end
     end
@@ -314,7 +314,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Set[
           Pathname("/app/test/lib_test.rb"),
         ],
-        enumerator.each_group_path(target).to_set
+        enumerator.each_group_path(target).map { _1[0] }.to_set
       )
     end
   end

--- a/test/server/target_group_files_test.rb
+++ b/test/server/target_group_files_test.rb
@@ -7,7 +7,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
   include Steep
 
-  def default_project()
+  def default_project() #: Steep::Project
     project = Project.new(steepfile_path: Pathname("/app/Steepfile"))
     Project::DSL.eval(project) do
       target :lib do
@@ -79,13 +79,13 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     setup_files(files)
 
     project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/lib/lib.rbs")], files.each_group_signature_path(target).to_set
+      assert_equal Set[Pathname("/app/sig/lib/lib.rbs")], files.signature_paths.each_group_path(target).to_set
     end
     project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.each_group_signature_path(target).to_set
+      assert_equal Set[Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_group_path(target).to_set
     end
     project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/test/lib_test.rbs")], files.each_group_signature_path(target).to_set
+      assert_equal Set[Pathname("/app/sig/test/lib_test.rbs")], files.signature_paths.each_group_path(target).to_set
     end
   end
 
@@ -96,13 +96,13 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     setup_files(files)
 
     project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/lib/lib.rb")], files.each_group_source_path(target).to_set
+      assert_equal Set[Pathname("/app/lib/lib.rb")], files.source_paths.each_group_path(target).to_set
     end
     project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.each_group_source_path(target).to_set
+      assert_equal Set[Pathname("/app/app/cli.rb")], files.source_paths.each_group_path(target).to_set
     end
     project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/test/lib_test.rb")], files.each_group_source_path(target).to_set
+      assert_equal Set[Pathname("/app/test/lib_test.rb")], files.source_paths.each_group_path(target).to_set
     end
   end
 
@@ -114,10 +114,10 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
     project.targets.find { _1.name == :app }.tap do |target|
       target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/server/server.rbs")], files.each_group_signature_path(group).to_set
+        assert_equal Set[Pathname("/app/sig/app/server/server.rbs")], files.signature_paths.each_group_path(group).to_set
       end
       target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/main/main.rbs")], files.each_group_signature_path(group).to_set
+        assert_equal Set[Pathname("/app/sig/app/main/main.rbs")], files.signature_paths.each_group_path(group).to_set
       end
     end
   end
@@ -130,10 +130,10 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
     project.targets.find { _1.name == :app }.tap do |target|
       target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/app/server/server.rb")], files.each_group_source_path(group).to_set
+        assert_equal Set[Pathname("/app/app/server/server.rb")], files.source_paths.each_group_path(group).to_set
       end
       target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/app/main/main.rb")], files.each_group_source_path(group).to_set
+        assert_equal Set[Pathname("/app/app/main/main.rb")], files.source_paths.each_group_path(group).to_set
       end
     end
   end
@@ -145,13 +145,13 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     setup_files(files)
 
     project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/lib/lib.rbs")], files.each_target_signature_path(target, nil).to_set
+      assert_equal Set[Pathname("/app/sig/lib/lib.rbs")], files.signature_paths.each_target_path(target).to_set
     end
     project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.each_target_signature_path(target, nil).to_set
+      assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_target_path(target).to_set
     end
     project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/sig/test/lib_test.rbs")], files.each_target_signature_path(target, nil).to_set
+      assert_equal Set[Pathname("/app/sig/test/lib_test.rbs")], files.signature_paths.each_target_path(target).to_set
     end
   end
 
@@ -162,13 +162,13 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     setup_files(files)
 
     project.targets.find { _1.name == :lib }.tap do |target|
-      assert_equal Set[Pathname("/app/lib/lib.rb")], files.each_target_source_path(target, nil).to_set
+      assert_equal Set[Pathname("/app/lib/lib.rb")], files.source_paths.each_target_path(target).to_set
     end
     project.targets.find { _1.name == :app }.tap do |target|
-      assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.each_target_source_path(target, nil).to_set
+      assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.source_paths.each_target_path(target).to_set
     end
     project.targets.find { _1.name == :test }.tap do |target|
-      assert_equal Set[Pathname("/app/test/lib_test.rb")], files.each_target_source_path(target, nil).to_set
+      assert_equal Set[Pathname("/app/test/lib_test.rb")], files.source_paths.each_target_path(target).to_set
     end
   end
 
@@ -180,10 +180,10 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
     project.targets.find { _1.name == :app }.tap do |target|
       target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.each_target_signature_path(target, group).to_set
+        assert_equal Set[Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_target_path(target, except: group).to_set
       end
       target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/cli.rbs")], files.each_target_signature_path(target, group).to_set
+        assert_equal Set[Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/cli.rbs")], files.signature_paths.each_target_path(target, except: group).to_set
       end
     end
   end
@@ -196,10 +196,10 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
 
     project.targets.find { _1.name == :app }.tap do |target|
       target.groups.find { _1.name == :server }.tap do |group|
-        assert_equal Set[Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.each_target_source_path(target, group).to_set
+        assert_equal Set[Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")], files.source_paths.each_target_path(target, except: group).to_set
       end
       target.groups.find { _1.name == :main }.tap do |group|
-        assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/cli.rb")], files.each_target_source_path(target, group).to_set
+        assert_equal Set[Pathname("/app/app/server/server.rb"), Pathname("/app/app/cli.rb")], files.source_paths.each_target_path(target, except: group).to_set
       end
     end
   end
@@ -216,7 +216,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs"),
         Pathname("/app/sig/test/lib_test.rbs")
       ],
-      files.each_project_signature_path(nil).to_set
+      files.signature_paths.each_project_path().to_set
     )
   end
 
@@ -232,7 +232,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
         Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb"),
         Pathname("/app/test/lib_test.rb")
       ],
-      files.each_project_source_path(nil).to_set
+      files.source_paths.each_project_path().to_set
     )
   end
 
@@ -245,18 +245,22 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     project.targets.find { _1.name == :lib }.tap do |target|
       assert_equal(
         Set[
-          Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")
+          Pathname("/app/sig/app/server/server.rbs"),
+          Pathname("/app/sig/app/main/main.rbs"),
+          Pathname("/app/sig/app/cli.rbs"),
+          Pathname("/app/sig/test/lib_test.rbs")
         ],
-        files.each_project_signature_path(target).to_set
+        files.signature_paths.each_project_path(except: target).to_set
       )
     end
 
     project.targets.find { _1.name == :app }.tap do |target|
       assert_equal(
         Set[
-          Pathname("/app/sig/lib/lib.rbs")
+          Pathname("/app/sig/lib/lib.rbs"),
+          Pathname("/app/sig/test/lib_test.rbs")
         ],
-        files.each_project_signature_path(target).to_set
+        files.signature_paths.each_project_path(except: target).to_set
       )
     end
 
@@ -266,7 +270,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/sig/lib/lib.rbs"),
           Pathname("/app/sig/app/server/server.rbs"), Pathname("/app/sig/app/main/main.rbs"), Pathname("/app/sig/app/cli.rbs")
         ],
-        files.each_project_signature_path(target).to_set
+        files.signature_paths.each_project_path(except: target).to_set
       )
     end
   end
@@ -280,18 +284,20 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
     project.targets.find { _1.name == :lib }.tap do |target|
       assert_equal(
         Set[
-          Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")
+          Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb"),
+          Pathname("/app/test/lib_test.rb")
         ],
-        files.each_project_source_path(target).to_set
+        files.source_paths.each_project_path(except: target).to_set
       )
     end
 
     project.targets.find { _1.name == :app }.tap do |target|
       assert_equal(
         Set[
-          Pathname("/app/lib/lib.rb")
+          Pathname("/app/lib/lib.rb"),
+          Pathname("/app/test/lib_test.rb")
         ],
-        files.each_project_source_path(target).to_set
+        files.source_paths.each_project_path(except: target).to_set
       )
     end
 
@@ -301,7 +307,7 @@ class Steep::Server::TargetGroupFilesTest < Minitest::Test
           Pathname("/app/lib/lib.rb"),
           Pathname("/app/app/server/server.rb"), Pathname("/app/app/main/main.rb"), Pathname("/app/app/cli.rb")
         ],
-        files.each_project_source_path(target).to_set
+        files.source_paths.each_project_path(except: target).to_set
       )
     end
   end

--- a/test/server_type_check_controller_test.rb
+++ b/test/server_type_check_controller_test.rb
@@ -32,9 +32,9 @@ end
       assert_equal Set[], controller.priority_paths
       assert_equal Set[], controller.changed_paths
 
-      assert_equal({}, controller.files.library_paths)
-      assert_equal({}, controller.files.source_paths)
-      assert_equal({}, controller.files.signature_paths)
+      assert_predicate controller.files.library_paths, :empty?
+      assert_predicate controller.files.source_paths, :empty?
+      assert_predicate controller.files.signature_paths, :empty?
     end
   end
 
@@ -64,8 +64,8 @@ end
       controller.load(command_line_args: []) {}
 
       assert_equal [:lib], controller.files.library_paths.keys
-      assert_equal Set[current_dir + "lib/customer.rb"], controller.files.source_paths.keys.to_set
-      assert_equal Set[current_dir + "sig/customer.rbs"], controller.files.signature_paths.keys.to_set
+      assert_equal Set[current_dir + "lib/customer.rb"], controller.files.source_paths.paths.to_set
+      assert_equal Set[current_dir + "sig/customer.rbs"], controller.files.signature_paths.paths.to_set
     end
   end
 
@@ -96,8 +96,8 @@ end
       controller.load(command_line_args: []) {}
 
       assert_equal [:lib], controller.files.library_paths.keys
-      assert_equal Set[current_dir + "lib/customer.rb", current_dir + "lib/core.rb"], controller.files.source_paths.keys.to_set
-      assert_equal Set[current_dir + "sig/customer.rbs", current_dir + "sig/core.rbs"], controller.files.signature_paths.keys.to_set
+      assert_equal Set[current_dir + "lib/customer.rb", current_dir + "lib/core.rb"], controller.files.source_paths.paths.to_set
+      assert_equal Set[current_dir + "sig/customer.rbs", current_dir + "sig/core.rbs"], controller.files.signature_paths.paths.to_set
     end
   end
 
@@ -127,8 +127,8 @@ end
       controller.push_changes(current_dir + "sig/customer.rbs")
       controller.push_changes(current_dir + "test/customer_test.rb")
 
-      assert_equal Set[current_dir + "lib/customer.rb"], controller.files.source_paths.keys.to_set
-      assert_equal Set[current_dir + "sig/customer.rbs"], controller.files.signature_paths.keys.to_set
+      assert_equal Set[current_dir + "lib/customer.rb"], controller.files.source_paths.paths.to_set
+      assert_equal Set[current_dir + "sig/customer.rbs"], controller.files.signature_paths.paths.to_set
 
       assert_equal Set[current_dir + "lib/customer.rb", current_dir + "sig/customer.rbs"],
                    controller.changed_paths
@@ -421,7 +421,7 @@ end
 
       controller.update_priority(open: current_dir + "lib/app/customer_service.rb")
       controller.make_request(progress: nil)
-      
+
       controller.push_changes(current_dir + "sig/core/customer.rbs")
       request = controller.make_request(progress: nil)
 

--- a/test/server_type_check_request_test.rb
+++ b/test/server_type_check_request_test.rb
@@ -22,6 +22,7 @@ class ServerTypeCheckRequestTest < Minitest::Test
       request.library_paths << [:lib, RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs"]
       request.signature_paths << [:lib, current_dir + "sig/user.rbs"]
       request.code_paths << [:lib, current_dir + "lib/user.rb"]
+      request.inline_paths << [:lib, current_dir + "lib/inline.rb"]
 
       json = request.as_json(assignment: Services::PathAssignment.all)
 
@@ -31,6 +32,7 @@ class ServerTypeCheckRequestTest < Minitest::Test
           library_uris: [["lib", "#{file_scheme}#{RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs"}"]],
           signature_uris: [["lib", "#{file_scheme}#{current_dir + "sig/user.rbs"}"]],
           code_uris: [["lib", "#{file_scheme}#{current_dir + "lib/user.rb"}"]],
+          inline_uris: [["lib", "#{file_scheme}#{current_dir + "lib/inline.rb"}"]],
           priority_uris: []
         },
         json
@@ -45,6 +47,7 @@ class ServerTypeCheckRequestTest < Minitest::Test
       request.library_paths << [:lib, RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs"]
       request.signature_paths << [:lib, current_dir + "sig/user.rbs"]
       request.code_paths << [:lib, current_dir + "lib/user.rb"]
+      request.inline_paths << [:lib, current_dir + "lib/inline.rb"]
 
       json = request.as_json(assignment: Services::PathAssignment.new(max_index: 1, index: 1))
 
@@ -54,6 +57,7 @@ class ServerTypeCheckRequestTest < Minitest::Test
           library_uris: [],
           signature_uris: [],
           code_uris: [],
+          inline_uris: [],
           priority_uris: []
         },
         json
@@ -69,17 +73,21 @@ class ServerTypeCheckRequestTest < Minitest::Test
       request.library_paths << [:lib, RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs"]
       request.signature_paths << [:lib, current_dir + "sig/user.rbs"]
       request.code_paths << [:lib, current_dir + "lib/user.rb"]
+      request.inline_paths << [:lib, current_dir + "lib/inline.rb"]
 
       assert_equal request.percentage, 0
       assert_equal request.each_target_path.to_set, request.each_unchecked_target_path.to_set
 
       request.checked(RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs", target)
-      assert_equal request.percentage, 33
+      assert_equal request.percentage, 25
 
       request.checked(current_dir + "sig/user.rbs", target)
-      assert_equal request.percentage, 66
+      assert_equal request.percentage, 50
 
       request.checked(current_dir + "lib/user.rb", target)
+      assert_equal request.percentage, 75
+
+      request.checked(current_dir + "lib/inline.rb", target)
       assert_equal request.percentage, 100
 
       assert_empty request.each_unchecked_target_path.to_a

--- a/test/signature_controller_test.rb
+++ b/test/signature_controller_test.rb
@@ -214,7 +214,7 @@ RBS
 class A
 end
 RBS
-      assert_instance_of RBS::AST::Declarations::Class, file.signature[2][0]
+      assert_instance_of RBS::AST::Declarations::Class, file.source.declarations[0]
     end
 
     {}.tap do |changes|


### PR DESCRIPTION
This PR implements inline type declaration support on services.

* `SignatureService`, `TypeCheckService`, and other dependencies are updated to support inline type declaration
* `TypeCheck` custom LSP method now includes `inline_paths` that includes Ruby scripts with inline type declarations