### PR TITLE
Fix empty comment error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ruby/rbs.git
-  revision: 346fcae5dc1ad3c6c1af45a24e3dcce2837cff82
+  revision: 3363d74ae36d97872afcc3cc049162528e0bb3b7
   branch: master
   specs:
     rbs (4.0.0.dev.4)

--- a/sample/Steepfile
+++ b/sample/Steepfile
@@ -3,6 +3,7 @@ D = Steep::Diagnostic
 target :lib do
   signature "sig"
 
+  check "lib/inline.rb", inline: true
   check "lib"                       # Directory name
 
   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting

--- a/sample/lib/inline.rb
+++ b/sample/lib/inline.rb
@@ -1,0 +1,12 @@
+class Foo
+  # @rbs (Integer, Integer) -> String
+  def foo(x, y)
+    (x + y).to_s
+  end
+end
+
+
+foo = Foo.new
+foo.foo(1, 2)
+foo.foo(1, "2")
+foo.foo(1, 2, "3")

--- a/sig/test/signature_controller_test.rbs
+++ b/sig/test/signature_controller_test.rbs
@@ -28,4 +28,12 @@ class SignatureServiceTest < Minitest::Test
   def test_const_decls: () -> untyped
 
   def test_global_decls: () -> untyped
+
+  def test__inline__update: () -> untyped
+
+  def test__inline__update_syntax_error1: () -> untyped
+
+  def test__inline__update_syntax_error2: () -> untyped
+
+  def test__inline__update_empty_comment: () -> untyped
 end

--- a/test/signature_controller_test.rb
+++ b/test/signature_controller_test.rb
@@ -380,4 +380,25 @@ RUBY
       assert_nil definition.methods[:foo]
     end
   end
+
+  def test__inline__update_empty_comment
+    service = SignatureService.load_from(environment_loader, implicitly_returns_nil: true)
+
+    assert_instance_of SignatureService::LoadedStatus, service.status
+
+    {}.tap do |changes|
+      changes[Pathname("lib/foo.rb")] = [
+        ContentChange.new(range: nil, text: <<RUBY)
+class Hello
+  #
+  def foo
+  end
+end
+RUBY
+      ]
+      service.update(changes)
+    end
+
+    assert_instance_of SignatureService::LoadedStatus, service.status
+  end
 end


### PR DESCRIPTION
That issue was essentially fixed in RBS (https://github.com/ruby/rbs/pull/2551).