### PR TITLE
Fix ancestor error reporting and silent failing

### DIFF
--- a/sig/steep/services/signature_service.rbs
+++ b/sig/steep/services/signature_service.rbs
@@ -41,11 +41,17 @@ module Steep
 
         attr_reader last_builder: RBS::DefinitionBuilder
 
+        attr_reader implicitly_returns_nil: bool
+
         @rbs_index: Index::RBSIndex?
+
+        @subtyping: Subtyping::Check?
 
         @constant_resolver: RBS::Resolver::ConstantResolver?
 
-        def initialize: (files: Hash[Pathname, file_status], changed_paths: Set[Pathname], diagnostics: Array[Diagnostic::Signature::Base], last_builder: RBS::DefinitionBuilder) -> void
+        def initialize: (files: Hash[Pathname, file_status], changed_paths: Set[Pathname], diagnostics: Array[Diagnostic::Signature::Base], last_builder: RBS::DefinitionBuilder, implicitly_returns_nil: bool) -> void
+
+        def subtyping: () -> Subtyping::Check
 
         def rbs_index: () -> Index::RBSIndex
 

--- a/smoke/standard-error-inheritance/Steepfile
+++ b/smoke/standard-error-inheritance/Steepfile
@@ -1,0 +1,8 @@
+target :test do
+  check "*.rb"
+  signature "*.rbs"
+
+  implicitly_returns_nil! true
+
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
+end

--- a/smoke/standard-error-inheritance/test.rb
+++ b/smoke/standard-error-inheritance/test.rb
@@ -1,0 +1,5 @@
+# @type var foo: Foo
+foo = (_ = nil)
+
+# This should error - Foo doesn't have method 'baz'
+foo.baz

--- a/smoke/standard-error-inheritance/test.rbs
+++ b/smoke/standard-error-inheritance/test.rbs
@@ -1,0 +1,13 @@
+module X509
+  class RequestError < StandardError
+  end
+end
+
+module Errno
+  class ECONNRESET < StandardError
+  end
+end
+
+class Foo
+  def bar: () -> String
+end

--- a/smoke/standard-error-inheritance/test_expectations.yml
+++ b/smoke/standard-error-inheritance/test_expectations.yml
@@ -1,0 +1,25 @@
+---
+- file: test.rb
+  diagnostics:
+  - range:
+      start:
+        line: 5
+        character: 4
+      end:
+        line: 5
+        character: 7
+    severity: ERROR
+    message: Type `::Foo` does not have method `baz`
+    code: Ruby::NoMethod
+- file: test.rbs
+  diagnostics:
+  - range:
+      start:
+        line: 7
+        character: 2
+      end:
+        line: 8
+        character: 5
+    severity: ERROR
+    message: Different superclasses are specified for `::Errno::ECONNRESET`
+    code: RBS::SuperclassMismatch


### PR DESCRIPTION
Fix: Report ancestor errors even when they occur in core library files
When RBS files contain classes that cause ancestor errors (like superclass
mismatches when reopening core modules), Steep would fail to report these
errors because their diagnostic locations pointed to core library files
rather than user code.

The bug occurred in two scenarios:

1. When validating signature files, ancestor errors were filtered by file
   path, hiding errors whose locations pointed to core library files.

2. When building the RBS environment with ancestor errors, the old
   DefinitionBuilder (without user-defined classes) was used instead of
   the new one, causing "Unknown name for build_instance" errors.

Changes:
- lib/steep/services/type_check_service.rb: Report all ancestor errors
  without filtering by path, since they affect the entire environment
- lib/steep/services/signature_service.rb: Use the newly created
  DefinitionBuilder (with user classes) when creating AncestorErrorStatus
- lib/steep/diagnostic/signature.rb: Prefer user file locations over
  core library locations when reporting superclass mismatch errors
- Add smoke test to prevent regression

Fixes the issue where type checking would silently fail when reopening
core modules like Errno with different superclass hierarchies.