### PR TITLE
Fix array literal type inference with union tuple hint

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1762,13 +1762,18 @@ module Steep
               if hint
                 tuples = select_flatten_types(hint) {|type| type.is_a?(AST::Types::Tuple) } #: Array[AST::Types::Tuple]
                 unless tuples.empty?
+                  fallback_pair = nil #: Pair?
                   tuples.each do |tuple|
                     typing.new_child() do |child_typing|
                       if pair = with_new_typing(child_typing).try_tuple_type(node, tuple)
-                        return pair.with(constr: pair.constr.save_typing)
+                        if pair.constr.check_relation(sub_type: pair.type, super_type: tuple).success?
+                          return pair.with(constr: pair.constr.save_typing)
+                        end
+                        fallback_pair ||= pair.with(constr: pair.constr.save_typing)
                       end
                     end
                   end
+                  return fallback_pair if fallback_pair
                 end
               end
 

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -4465,4 +4465,34 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_tuple_type_with_if_branch
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          module M
+            def test_if: (bool flag) -> (["yes", "ok"] | ["no", "error"])
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          module M
+            def test_if(flag)
+              if flag
+                ['yes', 'ok']
+              else
+                ['no', 'error']
+              end
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
resolve https://github.com/soutaro/steep/issues/2095

## Summary

When an array literal is type-checked against a hint that is a union of tuple types (e.g. `["yes", "ok"] | ["no", "error"]`), the type checker was incorrectly inferring `[::String, ::String]` instead of the correct specific tuple type.

## Root Cause

`#try_tuple_type` returns a `Pair` even when the inferred type does not match the given tuple hint. The first non-nil pair was accepted unconditionally, so `["no", "error"]` tried against hint `["yes", "ok"]` produced `[::String, ::String]`, which was accepted instead of trying the next hint `["no", "error"]`.

This behavior was introduced in #359 (More tuple types through hint), which deliberately removed the subtype check to support type variable hints like `[A, B]` (issue #328). The unconditional acceptance was a side effect.

## Fix

Reintroduce subtype validation against each individual tuple in the union. If a candidate passes the check, return it immediately. If no candidate passes, fall back to the first candidate rather than exiting the tuple-matching path entirely.

**Why the fallback is necessary:** without it, a mismatched annotation like `[1, ""] #: [1, "", bool]` would silently fall through to `try_array_type` and infer `[::Integer, ::String]` without reporting any error. The fallback ensures the mismatch is still surfaced as a `FalseAssertion` diagnostic.

**Why issue #328 is not regressed:** for type variable hints like `[A, B]`, `check_relation([::Integer, ::String] <: [A, B])` succeeds, so the `return` path is taken directly and the fallback is never needed.
