### PR TITLE
Add -e flag to steep check for type checking arbitrary expressions

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -127,6 +127,7 @@ BANNER
         OptionParser.new do |opts|
           opts.banner = <<BANNER
 Usage: steep check [options] [paths]
+       steep check [options] -e 'expr' [-e 'expr' ...]
 
 Description:
     Type check the program.
@@ -138,6 +139,9 @@ Options:
 BANNER
 
           handle_steepfile_option(opts, command)
+          opts.on("-e", "--expression=EXPRESSION", "Type check a Ruby expression (may be specified multiple times)") do |expr|
+            command.expressions << expr
+          end
           opts.on("--with-expectations[=PATH]", "Type check with expectations saved in PATH (or steep_expectations.yml)") do |path|
             command.with_expectations_path = Pathname(path || "steep_expectations.yml")
           end
@@ -198,6 +202,10 @@ BANNER
         setup_jobs_for_ci(command.jobs_option)
 
         command.command_line_patterns.push(*argv)
+
+        unless command.expressions.empty? || argv.empty?
+          abort "Cannot specify both -e and file paths"
+        end
       end.run
     end
 

--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -17,6 +17,7 @@ module Steep
       attr_accessor :validate_project_signatures
       attr_accessor :validate_library_signatures
       attr_accessor :formatter
+      attr_reader :expressions
 
       include Utils::DriverHelper
 
@@ -32,6 +33,7 @@ module Steep
         @validate_project_signatures = false
         @validate_library_signatures = false
         @formatter = 'code'
+        @expressions = []
       end
 
       def active_group?(group)
@@ -52,6 +54,10 @@ module Steep
 
       def run
         project = load_config()
+
+        unless expressions.empty?
+          return run_expressions(project)
+        end
 
         stdout.puts Rainbow("# Type checking files:").bold
         stdout.puts
@@ -204,6 +210,63 @@ module Steep
       rescue Errno::EPIPE => error
         stdout.puts Rainbow("Steep shutdown with an error: #{error.inspect}").red.bold
         return 1
+      end
+
+      def run_expressions(project)
+        target = project.targets.first or raise "No targets configured"
+
+        stdout.puts Rainbow("# Type checking expression:").bold
+        stdout.puts
+
+        loader = Project::Target.construct_env_loader(options: target.options, project: project)
+        signature_service = Services::SignatureService.load_from(loader, implicitly_returns_nil: target.implicitly_returns_nil)
+        subtyping = signature_service.current_subtyping or raise "Failed to build subtyping"
+
+        lsp_formatter = Diagnostic::LSPFormatter.new(target.code_diagnostics_config)
+        total = 0
+
+        expressions.each_with_index do |expr, index|
+          expr_path = Pathname(expressions.size > 1 ? "(expression:#{index})" : "(expression)")
+
+          begin
+            source = Source.parse(expr, path: expr_path, factory: subtyping.factory)
+          rescue ::Parser::SyntaxError => exn
+            stdout.puts Rainbow("Syntax error in #{expr_path}: #{exn.message}").red.bold
+            total += 1
+            next
+          end
+
+          typing = Services::TypeCheckService.type_check(
+            source: source,
+            subtyping: subtyping,
+            constant_resolver: signature_service.latest_constant_resolver,
+            cursor: nil
+          )
+
+          diagnostics = typing.errors.filter_map { |error| lsp_formatter.format(error) }
+          diagnostics.select! { |d| keep_diagnostic?(d, severity_level: severity_level) }
+
+          unless diagnostics.empty?
+            buffer = RBS::Buffer.new(name: expr_path, content: expr)
+            printer = DiagnosticPrinter.new(buffer: buffer, stdout: stdout, formatter: self.formatter)
+
+            diagnostics.each do |diag|
+              printer.print(diag)
+              stdout.puts
+            end
+
+            total += diagnostics.size
+          end
+        end
+
+        if total == 0
+          emoji = %w(🫖 🫖 🫖 🫖 🫖 🫖 🫖 🫖 🍵 🧋 🧉).sample
+          stdout.puts Rainbow("No type error detected. #{emoji}").green.bold
+          0
+        else
+          stdout.puts Rainbow("Detected #{total} #{"problem".pluralize(total)} from #{expressions.size} #{"expression".pluralize(expressions.size)}").red.bold
+          1
+        end
       end
 
       def load_files(files, target, group, params:)

--- a/sig/steep/drivers/check.rbs
+++ b/sig/steep/drivers/check.rbs
@@ -29,11 +29,15 @@ module Steep
 
       attr_accessor formatter: ("code" | "github")
 
+      attr_reader expressions: Array[String]
+
       include Utils::DriverHelper
 
       def initialize: (stdout: IO, stderr: IO) -> void
 
       def run: () -> Integer
+
+      def run_expressions: (Project) -> Integer
 
       def print_expectations: (project: Project, all_files: Array[Pathname], expectations_path: Pathname, notifications: Array[untyped]) -> Integer
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -822,4 +822,50 @@ GEMFILE
       end
     end
   end
+
+  def test_check_expression_success
+    stdout, status = sh(*steep, "check", "-e", "1 + 2")
+
+    assert_predicate status, :success?, stdout
+    assert_match(/No type error detected\./, stdout)
+  end
+
+  def test_check_expression_failure
+    stdout, status = sh(*steep, "check", "-e", '123 + "ABC"')
+
+    refute_predicate status, :success?, stdout
+    assert_match(/Ruby::UnresolvedOverloading/, stdout)
+    assert_match(/Detected 1 problem from 1 expression/, stdout)
+  end
+
+  def test_check_multiple_expressions
+
+    stdout, status = sh(*steep, "check", "-e", '123 + "ABC"', "-e", "1 + 2", "-e", '"hello" + 3')
+
+    refute_predicate status, :success?, stdout
+    assert_match(/Detected 2 problems from 3 expressions/, stdout)
+  end
+
+  def test_check_expression_with_paths_error
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "."
+end
+      EOF
+
+      (current_dir + "foo.rb").write("1 + 2")
+
+      _, status = sh(*steep, "check", "-e", "1 + 2", "foo.rb")
+
+      refute_predicate status, :success?
+    end
+  end
+
+  def test_check_expression_syntax_error
+    stdout, status = sh(*steep, "check", "-e", "def foo(")
+
+    refute_predicate status, :success?, stdout
+    assert_match(/Syntax error/, stdout)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -518,15 +518,15 @@ module ShellHelper
   end
 
   def sh(*command, **opts)
-    Open3.capture2(env_vars, *command, chdir: current_dir.to_s, **opts)
+    Open3.capture2(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd, **opts)
   end
 
   def sh3(*command)
-    Open3.capture3(env_vars, *command, chdir: current_dir.to_s)
+    Open3.capture3(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd)
   end
 
   def sh2e(*command)
-    Open3.capture2e(env_vars, *command, chdir: current_dir.to_s)
+    Open3.capture2e(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd)
   end
 
   def sh!(*command, **opts)


### PR DESCRIPTION
## Summary

Adds a `-e` option to `steep check` that type checks Ruby expressions directly without needing files on disk, similar to `ruby -e`.

## Usage

```bash
# Single expression
steep check -e '123 + "ABC"'

# Multiple expressions
steep check -e '1 + 2' -e '"hello" + 3'
```

## Details

- Multiple `-e` flags can be specified to check several expressions at once
- Mixing `-e` with file path arguments is not allowed and produces an error
- The implementation bypasses the LSP worker architecture and performs type checking directly in-process using the project's signature environment, making it fast and lightweight
- Includes tests for success, failure, multiple expressions, syntax errors, and mutual exclusivity with file paths
- Updated RBS signatures