### PR TITLE
Remove unused `mutex_m` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,6 @@ PATH
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
       parser (>= 3.2)
       rainbow (>= 2.2.2, < 4.0)
       rbs (~> 4.0.0.dev)
@@ -81,7 +80,6 @@ GEM
       minitest (> 5.3)
     minitest-slow_test (0.2.0)
       minitest (>= 5.0)
-    mutex_m (0.3.0)
     parser (3.3.10.2)
       ast (~> 2.4.1)
       racc

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -52,5 +52,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "strscan", ">= 1.0.0"
   spec.add_runtime_dependency "csv", ">= 3.0.9"
   spec.add_runtime_dependency "uri", ">= 0.12.0"
-  spec.add_runtime_dependency "mutex_m", ">= 0.3.0"
 end


### PR DESCRIPTION
Steep does not use it. Likely it was added for active_support, which did not declare it for a while but that is not the case anymore (it actually removed its usage of the library)