### PR TITLE
Remove activesupport dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     steep (2.0.0.dev)
-      activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -21,35 +20,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     ast (2.4.3)
-    base64 (0.3.0)
-    bigdecimal (4.1.0)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
     csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    drb (2.2.3)
     erb (6.0.2)
     ffi (1.17.4)
     fileutils (1.8.0)
-    i18n (1.14.8)
-      concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     irb (1.17.0)
       pp (>= 0.6.0)
@@ -103,13 +83,11 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     tsort (0.2.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
-    vernier (1.5.0)
+    vernier (1.10.0)
 
 PLATFORMS
   ruby

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -2,7 +2,6 @@ require "steep/version"
 
 require "pathname"
 require "parser/ruby33"
-require "active_support"
 require "logger"
 require "rainbow"
 require "listen"
@@ -13,7 +12,6 @@ require "stringio"
 require 'uri'
 require "yaml"
 require "securerandom"
-require "base64"
 require "time"
 require 'socket'
 
@@ -24,6 +22,7 @@ require "rbs"
 
 require "steep/path_helper"
 require "steep/located_value"
+require "steep/tagged_logging"
 require "steep/thread_waiter"
 require "steep/equatable"
 require "steep/method_name"
@@ -177,19 +176,7 @@ module Steep
   end
 
   def self.new_logger(output, prev_level)
-    logger = Logger.new(output)
-    logger.formatter = proc do |severity, datetime, progname, msg|
-      # @type var severity: String
-      # @type var datetime: Time
-      # @type var progname: untyped
-      # @type var msg: untyped
-      # @type block: String
-      "#{datetime.strftime('%Y-%m-%d %H:%M:%S.%L')}: #{severity}: #{msg}\n"
-    end
-    ActiveSupport::TaggedLogging.new(logger).tap do |logger|
-      logger.push_tags "Steep #{VERSION}"
-      logger.level = prev_level || Logger::ERROR
-    end
+    TaggedLogging.new(output, level: prev_level || Logger::ERROR)
   end
 
   def self.log_output

--- a/lib/steep/server/base_worker.rb
+++ b/lib/steep/server/base_worker.rb
@@ -38,11 +38,11 @@ module Steep
       end
 
       def run
-        tags = Steep.logger.formatter.current_tags.dup
+        tags = Steep.logger.current_tags.dup
         thread = Thread.new do
           Thread.current.abort_on_exception = true
 
-          Steep.logger.formatter.push_tags(*tags)
+          Steep.logger.push_tags(*tags)
           Steep.logger.tagged "background" do
             while job = queue.pop
               case job

--- a/lib/steep/server/change_buffer.rb
+++ b/lib/steep/server/change_buffer.rb
@@ -29,7 +29,8 @@ module Steep
           push_buffer do |changes|
             input.each do |filename, content|
               if content.is_a?(Hash)
-                content = Base64.decode64(content[:text]).force_encoding(Encoding::UTF_8)
+                base64_decoded = content[:text].unpack1("m") #: String
+                content = base64_decoded.force_encoding(Encoding::UTF_8)
               end
               changes[Pathname(filename.to_s)] = [Services::ContentChange.new(text: content)]
             end

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -207,14 +207,14 @@ module Steep
 
       def start
         Steep.logger.tagged "master" do
-          tags = Steep.logger.formatter.current_tags.dup
+          tags = Steep.logger.current_tags.dup
 
           # @type var worker_threads: Array[Thread]
           worker_threads = []
 
           if interaction_worker
             worker_threads << Thread.new do
-              Steep.logger.formatter.push_tags(*tags, "from-worker@interaction")
+              Steep.logger.push_tags(*tags, "from-worker@interaction")
               interaction_worker.reader.read do |message|
                 job_queue << ReceiveMessageJob.new(source: interaction_worker, message: message)
               end
@@ -223,7 +223,7 @@ module Steep
 
           typecheck_workers.each do |worker|
             worker_threads << Thread.new do
-              Steep.logger.formatter.push_tags(*tags, "from-worker@#{worker.name}")
+              Steep.logger.push_tags(*tags, "from-worker@#{worker.name}")
               worker.reader.read do |message|
                 job_queue << ReceiveMessageJob.new(source: worker, message: message)
               end
@@ -238,7 +238,7 @@ module Steep
           end
 
           write_thread = Thread.new do
-            Steep.logger.formatter.push_tags(*tags)
+            Steep.logger.push_tags(*tags)
             Steep.logger.tagged "write" do
               while job = write_queue.deq
                 # @type var job: SendMessageJob
@@ -257,7 +257,7 @@ module Steep
           end
 
           loop_thread = Thread.new do
-            Steep.logger.formatter.push_tags(*tags)
+            Steep.logger.push_tags(*tags)
             Steep.logger.tagged "main" do
               while job = job_queue.deq
                 case job
@@ -408,7 +408,8 @@ module Steep
                     if content.valid_encoding?
                       content
                     else
-                      { text: Base64.encode64(content), binary: true }
+                      base64_encoded = [content].pack("m")
+                      { text: base64_encoded, binary: true }
                     end
                   end
                   broadcast_notification(CustomMethods::FileLoad.notification({ content: input }))
@@ -900,8 +901,8 @@ module Steep
                   end
 
                   Thread.new do
-                    tags = Steep.logger.formatter.current_tags.dup
-                    Steep.logger.formatter.push_tags(*tags, "from-worker@#{new_worker.name}")
+                    tags = Steep.logger.current_tags.dup
+                    Steep.logger.push_tags(*tags, "from-worker@#{new_worker.name}")
                     new_worker.reader.read do |message|
                       job_queue << ReceiveMessageJob.new(source: new_worker, message: message)
                     end

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -145,9 +145,11 @@ module Steep
 
             worker = self.class.new(project: project, reader: reader, writer: writer, assignment: assignment, commandline_args: commandline_args, io_socket: nil, buffered_changes: buffered_changes, service: service)
 
-            tags = Steep.logger.formatter.current_tags.dup
-            tags[tags.find_index("typecheck:typecheck@0")] = "typecheck:typecheck@#{index}-reforked"
-            Steep.logger.formatter.push_tags(tags)
+            tags = Steep.logger.current_tags.dup
+            if (index = tags.find_index("typecheck:typecheck@0"))
+              tags[index] = "typecheck:typecheck@#{index}-reforked"
+            end
+            Steep.logger.push_tags(*tags)
             worker.run()
 
             raise "unreachable"

--- a/lib/steep/tagged_logging.rb
+++ b/lib/steep/tagged_logging.rb
@@ -1,0 +1,39 @@
+module Steep
+  # A basic implementation of ActiveSupport::TaggedLogging.
+  # Might be able to be replaced by plain logger in the future.
+  # https://github.com/ruby/logger/pull/132
+  class TaggedLogging < Logger
+    def initialize(...)
+      super
+      self.formatter = proc do |severity, datetime, progname, msg|
+        # @type var severity: String
+        # @type var datetime: Time
+        # @type var progname: untyped
+        # @type var msg: untyped
+        # @type block: String
+        "#{datetime.strftime('%Y-%m-%d %H:%M:%S.%L')}: #{severity}: #{formatted_tags} #{msg}\n"
+      end
+      @thread_key = "steep_tagged_logging_tags:#{object_id}"
+      current_tags << "Steep #{VERSION}"
+    end
+
+    def tagged(tag)
+      current_tags << tag
+      yield
+    ensure
+      current_tags.pop
+    end
+
+    def current_tags
+      Thread.current[@thread_key] ||= []
+    end
+
+    def push_tags(*tags)
+      current_tags.concat(tags)
+    end
+
+    def formatted_tags
+      current_tags.map { |tag| "[#{tag}]" }.join(" ")
+    end
+  end
+end

--- a/sig/shims/tagged_logging.rbs
+++ b/sig/shims/tagged_logging.rbs
@@ -1,6 +1,0 @@
-module ActiveSupport::TaggedLogging
-  def tagged: [A] (*String) { () -> A } -> A
-            | ...
-
-  def formatter: () -> Formatter
-end

--- a/sig/steep.rbs
+++ b/sig/steep.rbs
@@ -6,11 +6,11 @@ module Steep
   # The *main* process has the logger.
   # The *worker* processes disables the logging through this.
   #
-  def self.ui_logger: () -> (Logger & ActiveSupport::TaggedLogging)
+  def self.ui_logger: () -> (Steep::TaggedLogging)
 
-  def self.logger: () -> (Logger & ActiveSupport::TaggedLogging)
+  def self.logger: () -> (Steep::TaggedLogging)
 
-  def self.new_logger: (IO output, Integer? prev_level) -> (Logger & ActiveSupport::TaggedLogging)
+  def self.new_logger: (IO output, Integer? prev_level) -> (Steep::TaggedLogging)
 
   attr_accessor self.log_output: IO
 
@@ -20,9 +20,9 @@ module Steep
 
   def self.can_fork?: () -> boolish
 
-  self.@logger: (Logger & ActiveSupport::TaggedLogging)?
+  self.@logger: (Steep::TaggedLogging)?
 
-  self.@ui_logger: (Logger & ActiveSupport::TaggedLogging)?
+  self.@ui_logger: (Steep::TaggedLogging)?
 
   class Sampler
     type sample = [String, Float]

--- a/sig/steep/tagged_logging.rbs
+++ b/sig/steep/tagged_logging.rbs
@@ -1,0 +1,13 @@
+module Steep
+  class TaggedLogging < ::Logger
+    @thread_key: String
+
+    def tagged: [T] (String tag) { () -> T } -> T
+
+    def current_tags: () -> Array[String]
+
+    def push_tags: (*String tags) -> Array[String]
+
+    def formatted_tags: () -> String
+  end
+end

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2.0'
 
   spec.add_runtime_dependency "parser", ">= 3.2"
-  spec.add_runtime_dependency "activesupport", ">= 5.1"
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.17.0.4", "< 4.0"


### PR DESCRIPTION
Only the tagged logger remained and its relatively easy to replace.

I tested this by comparing the output during tests and it seems to produce identical log messages.

Followup to https://github.com/soutaro/steep/pull/2153