### PR TITLE
Fix ancestor error diagnostics reporting in library RBS files

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -944,6 +944,33 @@ module Steep
         end
       end
 
+      class LibraryRBSError < Base
+        attr_reader :error
+
+        def initialize(error:, location:)
+          @error = error
+          super(node: nil, location: location)
+        end
+
+        def header_line
+          "Type checking failed due to error in library RBS file"
+        end
+
+        def detail_lines
+          lines = [] #: Array[String]
+          lines << error.header_line
+          if error.location
+            lines << "(#{error.location.buffer.name.to_s}:#{error.location.start_line}:#{error.location.start_column})"
+          end
+
+          if detail = error.detail_lines
+            lines << "" << detail
+          end
+
+          lines.join("\n")
+        end
+      end
+
       class InvalidIgnoreComment < Base
         attr_reader :comment
 
@@ -1093,6 +1120,7 @@ module Steep
             MethodParameterMismatch => :error,
             MethodReturnTypeAnnotationMismatch => :hint,
             MultipleAssignmentConversionError => :hint,
+            LibraryRBSError => :error,
             NoMethod => :error,
             ProcHintIgnored => :hint,
             ProcTypeExpected => :hint,
@@ -1221,6 +1249,7 @@ module Steep
             MethodParameterMismatch => :warning,
             MethodReturnTypeAnnotationMismatch => nil,
             MultipleAssignmentConversionError => nil,
+            LibraryRBSError => :error,
             NoMethod => :information,
             ProcHintIgnored => nil,
             ProcTypeExpected => nil,

--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -128,17 +128,7 @@ module Steep
             service.status.diagnostics.group_by {|diag| diag.location&.buffer&.name&.to_s }.each do |path_string, diagnostics|
               if path_string
                 path = Pathname(path_string)
-                if signature_diagnostics.key?(path)
-                  signature_diagnostics[path].push(*diagnostics)
-                else
-                  # Diagnostics with locations in library/env files don't match any
-                  # user file path. Attach them to one of the changed paths so they
-                  # are not silently lost. (See #2176)
-                  anchor = service.status.changed_paths.min_by(&:to_s)
-                  if anchor && signature_diagnostics.key?(anchor)
-                    signature_diagnostics[anchor].push(*diagnostics)
-                  end
-                end
+                signature_diagnostics.fetch(path).push(*diagnostics)
               end
             end
           when SignatureService::LoadedStatus
@@ -285,11 +275,22 @@ module Steep
               # Report them on source files so the user knows type checking is broken. (#2176)
               case signature_service.status
               when SignatureService::SyntaxErrorStatus, SignatureService::AncestorErrorStatus
-                library_diagnostics = signature_service.status.diagnostics.select do |diag|
+                library_errors = signature_service.status.diagnostics.select do |diag|
                   diag_path = diag.location && Pathname(diag.location.buffer.name)
-                  diag_path && !signature_service.status.files.key?(diag_path)
+                  diag_path &&
+                    signature_service.env_rbs_paths.include?(diag_path) &&
+                    !signature_service.status.files.key?(diag_path)
                 end
-                library_diagnostics unless library_diagnostics.empty?
+
+                unless library_errors.empty?
+                  text = source_files.fetch(path).content
+                  buffer = RBS::Buffer.new(name: path, content: text)
+                  location = RBS::Location.new(buffer: buffer, start_pos: 0, end_pos: text.size)
+
+                  library_errors.map do |error|
+                    Diagnostic::Ruby::LibraryRBSError.new(error: error, location: location)
+                  end
+                end
               end
             end
           end

--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -125,10 +125,25 @@ module Steep
 
           case service.status
           when SignatureService::SyntaxErrorStatus, SignatureService::AncestorErrorStatus
+            orphan_diagnostics = [] #: Array[Diagnostic::Signature::Base]
+
             service.status.diagnostics.group_by {|diag| diag.location&.buffer&.name&.to_s }.each do |path_string, diagnostics|
               if path_string
                 path = Pathname(path_string)
-                signature_diagnostics.fetch(path).push(*diagnostics)
+                if signature_diagnostics.key?(path)
+                  signature_diagnostics[path].push(*diagnostics)
+                else
+                  orphan_diagnostics.concat(diagnostics)
+                end
+              end
+            end
+
+            # Diagnostics with locations in library/env files don't match any user
+            # file path. Attach them to a changed path so they're not lost. (See #2176)
+            unless orphan_diagnostics.empty?
+              anchor = service.status.changed_paths.min_by(&:to_s)
+              if anchor && signature_diagnostics.key?(anchor)
+                signature_diagnostics[anchor].push(*orphan_diagnostics)
               end
             end
           when SignatureService::LoadedStatus
@@ -191,6 +206,21 @@ module Steep
               diagnostics = service.status.diagnostics.select do |diag|
                 diag.location or raise
                 Pathname(diag.location.buffer.name) == path
+              end
+
+              # Diagnostics with locations in library/env files won't match any user
+              # file path and would be silently dropped. Attach them to one of the
+              # changed paths so they remain visible to the user. (See #2176)
+              orphan_diagnostics = service.status.diagnostics.select do |diag|
+                diag_path = diag.location && Pathname(diag.location.buffer.name)
+                diag_path && diag_path != path && !service.status.files.key?(diag_path)
+              end
+
+              unless orphan_diagnostics.empty?
+                anchor = service.status.changed_paths.min_by(&:to_s)
+                if path == anchor
+                  diagnostics.concat(orphan_diagnostics)
+                end
               end
 
             when SignatureService::LoadedStatus

--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -125,25 +125,20 @@ module Steep
 
           case service.status
           when SignatureService::SyntaxErrorStatus, SignatureService::AncestorErrorStatus
-            orphan_diagnostics = [] #: Array[Diagnostic::Signature::Base]
-
             service.status.diagnostics.group_by {|diag| diag.location&.buffer&.name&.to_s }.each do |path_string, diagnostics|
               if path_string
                 path = Pathname(path_string)
                 if signature_diagnostics.key?(path)
                   signature_diagnostics[path].push(*diagnostics)
                 else
-                  orphan_diagnostics.concat(diagnostics)
+                  # Diagnostics with locations in library/env files don't match any
+                  # user file path. Attach them to one of the changed paths so they
+                  # are not silently lost. (See #2176)
+                  anchor = service.status.changed_paths.min_by(&:to_s)
+                  if anchor && signature_diagnostics.key?(anchor)
+                    signature_diagnostics[anchor].push(*diagnostics)
+                  end
                 end
-              end
-            end
-
-            # Diagnostics with locations in library/env files don't match any user
-            # file path. Attach them to a changed path so they're not lost. (See #2176)
-            unless orphan_diagnostics.empty?
-              anchor = service.status.changed_paths.min_by(&:to_s)
-              if anchor && signature_diagnostics.key?(anchor)
-                signature_diagnostics[anchor].push(*orphan_diagnostics)
               end
             end
           when SignatureService::LoadedStatus
@@ -197,31 +192,11 @@ module Steep
             case service.status
             when SignatureService::SyntaxErrorStatus
               diagnostics = service.status.diagnostics.select do |diag|
-                diag.location or raise
-                Pathname(diag.location.buffer.name) == path &&
-                  (diag.is_a?(Diagnostic::Signature::SyntaxError) || diag.is_a?(Diagnostic::Signature::UnexpectedError))
+                diag.is_a?(Diagnostic::Signature::SyntaxError) || diag.is_a?(Diagnostic::Signature::UnexpectedError)
               end
 
             when SignatureService::AncestorErrorStatus
-              diagnostics = service.status.diagnostics.select do |diag|
-                diag.location or raise
-                Pathname(diag.location.buffer.name) == path
-              end
-
-              # Diagnostics with locations in library/env files won't match any user
-              # file path and would be silently dropped. Attach them to one of the
-              # changed paths so they remain visible to the user. (See #2176)
-              orphan_diagnostics = service.status.diagnostics.select do |diag|
-                diag_path = diag.location && Pathname(diag.location.buffer.name)
-                diag_path && diag_path != path && !service.status.files.key?(diag_path)
-              end
-
-              unless orphan_diagnostics.empty?
-                anchor = service.status.changed_paths.min_by(&:to_s)
-                if path == anchor
-                  diagnostics.concat(orphan_diagnostics)
-                end
-              end
+              diagnostics = service.status.diagnostics.dup
 
             when SignatureService::LoadedStatus
               validator = Signature::Validator.new(checker: service.current_subtyping || raise)

--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -192,11 +192,16 @@ module Steep
             case service.status
             when SignatureService::SyntaxErrorStatus
               diagnostics = service.status.diagnostics.select do |diag|
-                diag.is_a?(Diagnostic::Signature::SyntaxError) || diag.is_a?(Diagnostic::Signature::UnexpectedError)
+                diag.location or raise
+                Pathname(diag.location.buffer.name) == path &&
+                  (diag.is_a?(Diagnostic::Signature::SyntaxError) || diag.is_a?(Diagnostic::Signature::UnexpectedError))
               end
 
             when SignatureService::AncestorErrorStatus
-              diagnostics = service.status.diagnostics.dup
+              diagnostics = service.status.diagnostics.select do |diag|
+                diag.location or raise
+                Pathname(diag.location.buffer.name) == path
+              end
 
             when SignatureService::LoadedStatus
               validator = Signature::Validator.new(checker: service.current_subtyping || raise)
@@ -274,6 +279,18 @@ module Steep
               source_files[path] = file
 
               file.diagnostics
+            else
+              # Signature loading failed. If the errors originate from library RBS files,
+              # they won't be reported by validate_signature (which filters by user file path).
+              # Report them on source files so the user knows type checking is broken. (#2176)
+              case signature_service.status
+              when SignatureService::SyntaxErrorStatus, SignatureService::AncestorErrorStatus
+                library_diagnostics = signature_service.status.diagnostics.select do |diag|
+                  diag_path = diag.location && Pathname(diag.location.buffer.name)
+                  diag_path && !signature_service.status.files.key?(diag_path)
+                end
+                library_diagnostics unless library_diagnostics.empty?
+              end
             end
           end
         end

--- a/manual/ruby-diagnostics.md
+++ b/manual/ruby-diagnostics.md
@@ -667,6 +667,45 @@ test.rb:1:0: [error] Invalid ignore comment
 | - | - | - | - | - |
 | error | warning | warning | warning | - |
 
+<a name='Ruby::LibraryRBSError'></a>
+## Ruby::LibraryRBSError
+
+Type checking failed because of errors in library RBS files.
+
+This diagnostic is reported on source files when RBS signatures from library or standard library
+have validation errors, such as superclass mismatches. Each error is reported as a separate diagnostic.
+
+### RBS
+
+```rbs
+class Integer < String
+end
+```
+
+### Ruby code
+
+```ruby
+1 + 2
+```
+
+### Diagnostic
+
+```
+a.rb:1:0: [error] Type checking failed due to error in library RBS file
+│ Different superclasses are specified for `::Integer`
+│ Diagnostic ID: Ruby::LibraryRBSError
+│
+└ 1 + 2
+  ~~~~~
+```
+
+
+### Severity
+
+| all_error | strict | default | lenient | silent |
+| - | - | - | - | - |
+| error | error | error | error | - |
+
 <a name='Ruby::MethodArityMismatch'></a>
 ## Ruby::MethodArityMismatch
 

--- a/sig/steep/diagnostic/ruby.rbs
+++ b/sig/steep/diagnostic/ruby.rbs
@@ -1675,6 +1675,41 @@ module Steep
         def initialize: (error: Signature::Base, node: Parser::AST::Node, location: location) -> void
       end
 
+      # Type checking failed because of errors in library RBS files.
+      #
+      # This diagnostic is reported on source files when RBS signatures from library or standard library
+      # have validation errors, such as superclass mismatches. Each error is reported as a separate diagnostic.
+      #
+      # ### RBS
+      #
+      # ```rbs
+      # class Integer < String
+      # end
+      # ```
+      #
+      # ### Ruby code
+      #
+      # ```ruby
+      # 1 + 2
+      # ```
+      #
+      # ### Diagnostic
+      #
+      # ```
+      # a.rb:1:0: [error] Type checking failed due to error in library RBS file
+      # │ Different superclasses are specified for `::Integer`
+      # │ Diagnostic ID: Ruby::LibraryRBSError
+      # │
+      # └ 1 + 2
+      #   ~~~~~
+      # ```
+      #
+      class LibraryRBSError < Base
+        attr_reader error: Signature::Base
+
+        def initialize: (error: Signature::Base, location: location) -> void
+      end
+
       # `steep:ignore` comment is invalid.
       #
       # ### Ruby code

--- a/sig/test/cli_test.rbs
+++ b/sig/test/cli_test.rbs
@@ -84,4 +84,6 @@ class CLITest < Minitest::Test
   def test_check_expression_with_paths_error: () -> untyped
 
   def test_check_expression_syntax_error: () -> untyped
+
+  def test_check_library_rbs_error: () -> untyped
 end

--- a/sig/test/type_check_service_test.rbs
+++ b/sig/test/type_check_service_test.rbs
@@ -62,4 +62,8 @@ class TypeCheckServiceTest < Minitest::Test
   def test_update__inline__inheritance_generic_missing_type_args: () -> untyped
 
   def test_update__inline__instance_variable_duplication: () -> untyped
+
+  def test_typecheck_source__ancestor_error_with_library_location: () -> untyped
+
+  def test_typecheck_source__ancestor_error_with_user_file_location: () -> untyped
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -928,4 +928,36 @@ end
     refute_predicate status, :success?, stdout
     assert_match(/Syntax error/, stdout)
   end
+
+  def test_check_library_rbs_error
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "a.rb"
+  signature "a.rbs"
+  configure_code_diagnostics(Steep::Diagnostic::Ruby.all_error)
+end
+      EOF
+
+      (current_dir + "a.rbs").write(<<~RBS)
+        class Integer < String
+        end
+
+        class Float < Rational
+        end
+      RBS
+
+      (current_dir + "a.rb").write(<<~RUBY)
+        1 + 2
+      RUBY
+
+      stdout, status = sh(*steep, "check")
+
+      refute_predicate status, :success?, stdout
+      assert_match(/Ruby::LibraryRBSError/, stdout)
+      assert_match(/Different superclasses are specified for `::Integer`.*core\/integer\.rbs/m, stdout)
+      assert_match(/Different superclasses are specified for `::Float`.*core\/float\.rbs/m, stdout)
+      assert_match(/Detected 2 problems from 1 file/, stdout)
+    end
+  end
 end

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -840,13 +840,13 @@ RUBY
       sig_service = service.signature_services[:core]
       assert_instance_of Services::SignatureService::AncestorErrorStatus, sig_service.status
 
-      # typecheck_source should return the library-originated diagnostics
-      # so they are reported on the source file
+      # typecheck_source should return LibraryRBSError diagnostics for each signature error
       diagnostics = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
       refute_nil diagnostics, "Library-originated diagnostics should be reported on source files"
-      refute_empty diagnostics
       assert_any!(diagnostics) do |error|
-        assert_instance_of Diagnostic::Signature::SuperclassMismatch, error
+        assert_instance_of Diagnostic::Ruby::LibraryRBSError, error
+        assert_equal Pathname("lib/core.rb"), Pathname(error.location.buffer.name)
+        assert_instance_of Diagnostic::Signature::SuperclassMismatch, error.error
       end
     end
   end
@@ -881,27 +881,4 @@ RUBY
     end
   end
 
-  def test_signature_diagnostics__ancestor_error_with_library_location
-    # Regression test for #2176: signature_diagnostics should include
-    # diagnostics from AncestorErrorStatus even when locations are in library files
-    service = Services::TypeCheckService.new(project: project)
-    service.update(changes: reset_changes)
-
-    {
-      Pathname("sig/core.rbs") => [ContentChange.string(<<RBS)],
-class Integer < String
-end
-RBS
-    }.tap do |changes|
-      service.update(changes: changes)
-
-      sig_service = service.signature_services[:core]
-      assert_instance_of Services::SignatureService::AncestorErrorStatus, sig_service.status
-
-      # signature_diagnostics should not crash with KeyError and should include the diagnostics
-      all_diagnostics = service.signature_diagnostics
-      has_error = all_diagnostics.values.any? { |diags| !diags.empty? }
-      assert has_error, "Ancestor error diagnostics should be present in signature_diagnostics"
-    end
-  end
 end

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -814,4 +814,59 @@ RUBY
       end
     end
   end
+
+  def test_validate_signature__ancestor_error_with_library_location
+    # Regression test for #2176: When conflicting RBS signatures cause
+    # AncestorErrorStatus and the error location points to a library file,
+    # the diagnostics should still be reported (not silently dropped).
+    service = Services::TypeCheckService.new(project: project)
+    service.update(changes: reset_changes)
+
+    {
+      # Integer is declared as `class Integer < Numeric` in the core library.
+      # Redefining it with a different superclass causes SuperclassMismatchError
+      # whose location points to the library file, not the user's file.
+      Pathname("sig/core.rbs") => [ContentChange.string(<<RBS)],
+class Integer < String
+end
+RBS
+    }.tap do |changes|
+      service.update(changes: changes)
+
+      sig_service = service.signature_services[:core]
+      assert_instance_of Services::SignatureService::AncestorErrorStatus, sig_service.status
+
+      # validate_signature should return the ancestor error diagnostics
+      # even though the error's location is in a library file
+      diagnostics = service.validate_signature(path: Pathname("sig/core.rbs"), target: project.targets.find { _1.name == :core })
+      refute_empty diagnostics, "Ancestor error diagnostics should not be silently dropped when location is in library file"
+      assert_any!(diagnostics) do |error|
+        assert_instance_of Diagnostic::Signature::SuperclassMismatch, error
+      end
+    end
+  end
+
+  def test_signature_diagnostics__ancestor_error_with_library_location
+    # Regression test for #2176: signature_diagnostics should include
+    # diagnostics from AncestorErrorStatus even when locations are in library files
+    service = Services::TypeCheckService.new(project: project)
+    service.update(changes: reset_changes)
+
+    {
+      Pathname("sig/core.rbs") => [ContentChange.string(<<RBS)],
+class Integer < String
+end
+RBS
+    }.tap do |changes|
+      service.update(changes: changes)
+
+      sig_service = service.signature_services[:core]
+      assert_instance_of Services::SignatureService::AncestorErrorStatus, sig_service.status
+
+      # signature_diagnostics should not crash with KeyError and should include the diagnostics
+      all_diagnostics = service.signature_diagnostics
+      has_error = all_diagnostics.values.any? { |diags| !diags.empty? }
+      assert has_error, "Ancestor error diagnostics should be present in signature_diagnostics"
+    end
+  end
 end

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -815,10 +815,11 @@ RUBY
     end
   end
 
-  def test_validate_signature__ancestor_error_with_library_location
+  def test_typecheck_source__ancestor_error_with_library_location
     # Regression test for #2176: When conflicting RBS signatures cause
     # AncestorErrorStatus and the error location points to a library file,
-    # the diagnostics should still be reported (not silently dropped).
+    # typecheck_source should report the errors on source files so the user
+    # knows type checking is broken.
     service = Services::TypeCheckService.new(project: project)
     service.update(changes: reset_changes)
 
@@ -830,19 +831,53 @@ RUBY
 class Integer < String
 end
 RBS
+      Pathname("lib/core.rb") => [ContentChange.string(<<RUBY)],
+1 + 2
+RUBY
     }.tap do |changes|
       service.update(changes: changes)
 
       sig_service = service.signature_services[:core]
       assert_instance_of Services::SignatureService::AncestorErrorStatus, sig_service.status
 
-      # validate_signature should return the ancestor error diagnostics
-      # even though the error's location is in a library file
-      diagnostics = service.validate_signature(path: Pathname("sig/core.rbs"), target: project.targets.find { _1.name == :core })
-      refute_empty diagnostics, "Ancestor error diagnostics should not be silently dropped when location is in library file"
+      # typecheck_source should return the library-originated diagnostics
+      # so they are reported on the source file
+      diagnostics = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      refute_nil diagnostics, "Library-originated diagnostics should be reported on source files"
+      refute_empty diagnostics
       assert_any!(diagnostics) do |error|
         assert_instance_of Diagnostic::Signature::SuperclassMismatch, error
       end
+    end
+  end
+
+  def test_typecheck_source__ancestor_error_with_user_file_location
+    # When the error location is in a user's RBS file (not a library file),
+    # typecheck_source should NOT report it on source files — validate_signature
+    # will handle it.
+    service = Services::TypeCheckService.new(project: project)
+    service.update(changes: reset_changes)
+
+    {
+      Pathname("sig/core.rbs") => [ContentChange.string(<<RBS)],
+class Hello
+end
+
+module Hello
+end
+RBS
+      Pathname("lib/core.rb") => [ContentChange.string(<<RUBY)],
+1 + 2
+RUBY
+    }.tap do |changes|
+      service.update(changes: changes)
+
+      sig_service = service.signature_services[:core]
+      assert_instance_of Services::SignatureService::AncestorErrorStatus, sig_service.status
+
+      # Error is in a user file, so typecheck_source should not report it
+      diagnostics = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      assert_nil diagnostics
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #2176 — When library/stdlib RBS files have validation errors (e.g. superclass mismatches), type checking silently failed with no diagnostics shown to users.

## Changes

- **`LibraryRBSError` now holds a single error** instead of an array, so each library error is reported as an individual diagnostic with its own message and library file path
- **`typecheck_source`** maps each library-originated signature error to a separate `LibraryRBSError` diagnostic on the source file being checked
- **`detail_lines`** delegates to the underlying error, showing the error message and the library file location (e.g. `core/integer.rbs:95:0`)
- **Removed `signature_diagnostics` fallback** that tried to anchor library diagnostics to user file paths — `typecheck_source` now handles this correctly
- **Added documentation** for `LibraryRBSError` in the RBS signature file

## Example output

```
a.rb:1:0: [error] Type checking failed due to error in library RBS file
│ Different superclasses are specified for `::Integer`
│ (core/integer.rbs:95:0)
│
│ Diagnostic ID: Ruby::LibraryRBSError
│
└ 1 + 2
  ~~~~~

a.rb:1:0: [error] Type checking failed due to error in library RBS file
│ Different superclasses are specified for `::Float`
│ (core/float.rbs:255:0)
│
│ Diagnostic ID: Ruby::LibraryRBSError
│
└ 1 + 2
  ~~~~~
```