### PR TITLE
Add RBS signature generation and validation workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -74,4 +77,24 @@ jobs:
         bin/setup
         bundle exec ruby bin/generate-diagnostics-docs.rb
         git diff --exit-code HEAD -- manual
+  test_rbs_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "4.0"
+        bundler: none
+    - name: Fix permission
+      run: |
+        gem env gemdir
+        chmod 775 `gem env gemdir`/gems
+    - name: Check generated RBS files are up to date
+      run: |
+        git config --global --add safe.directory /__w/steep/steep
+        ruby -v
+        gem install bundler
+        bin/setup
+        bundle exec rake rbs:generate
+        git diff --exit-code HEAD -- sig/test
 

--- a/sig/test/daemon_test.rbs
+++ b/sig/test/daemon_test.rbs
@@ -1,0 +1,45 @@
+# Generated from test/daemon_test.rb with RBS::Inline
+
+class DaemonTest < Minitest::Test
+  include ShellHelper
+
+  include TestHelper
+
+  def dirs: () -> untyped
+
+  def envs: () -> untyped
+
+  def steep: () -> untyped
+
+  def setup: () -> untyped
+
+  def teardown: () -> untyped
+
+  def test_daemon_socket_path: () -> untyped
+
+  def test_daemon_not_running_initially: () -> untyped
+
+  def test_start_returns_false_when_not_supported: () -> untyped
+
+  def test_server_command_returns_error_when_not_supported: () -> untyped
+
+  def test_start_server_command: () -> untyped
+
+  def test_start_server_when_already_running: () -> untyped
+
+  def test_stop_server_when_not_running: () -> untyped
+
+  def test_check_with_daemon: () -> untyped
+
+  def test_check_falls_back_without_daemon: () -> untyped
+
+  def test_daemon_detects_file_changes: () -> untyped
+
+  def test_restart_server_command: () -> untyped
+
+  def test_server_help: () -> untyped
+
+  def test_check_waits_for_daemon_warmup: () -> untyped
+
+  def test_check_with_no_daemon_flag: () -> untyped
+end

--- a/sig/test/goto_service_test.rbs
+++ b/sig/test/goto_service_test.rbs
@@ -56,6 +56,8 @@ class GotoServiceTest < Minitest::Test
 
   def test_class_constant__inline: () -> untyped
 
+  def test_definition__inline__const_assign_without_annotation: () -> untyped
+
   def test_new_method_impl: () -> untyped
 
   def test_method_block: () -> untyped

--- a/sig/test/interaction_worker_test.rbs
+++ b/sig/test/interaction_worker_test.rbs
@@ -48,5 +48,7 @@ class InteractionWorkerTest < Minitest::Test
 
   def test_handle_completion_request: () -> untyped
 
+  def test_handle_completion_request_inline: () -> untyped
+
   def test_completion_on_signature: () -> untyped
 end

--- a/sig/test/type_construction_test.rbs
+++ b/sig/test/type_construction_test.rbs
@@ -859,6 +859,8 @@ class TypeConstructionTest < Minitest::Test
 
   def test_empty_yield: () -> untyped
 
+  def test_yield_with_untyped_method_type: () -> untyped
+
   def test_self_type_binding_proc_with_type_declaration: () -> untyped
 
   def test_self_type_binding_proc_with_annotation: () -> untyped


### PR DESCRIPTION
## Summary
This PR adds automated RBS (Ruby Signature) file generation and validation to the CI/CD pipeline, ensuring that generated type signature files remain up-to-date with their corresponding test implementations.

## Key Changes
- **New RBS signatures**: Added `sig/test/daemon_test.rbs` with type signatures for the `DaemonTest` class and all its test methods
- **Updated RBS signatures**: Regenerated signatures for existing test files:
  - `sig/test/goto_service_test.rbs`: Added `test_definition__inline__const_assign_without_annotation` method signature
  - `sig/test/interaction_worker_test.rbs`: Added `test_handle_completion_request_inline` method signature
  - `sig/test/type_construction_test.rbs`: Added `test_yield_with_untyped_method_type` method signature
- **CI workflow enhancement**: Added new `rbs_check` job to GitHub Actions that:
  - Runs on Ubuntu latest with Ruby 4.0
  - Generates RBS signatures via `bundle exec rake rbs:generate`
  - Validates that generated signatures match committed files using `git diff --exit-code`
  - Ensures type signatures stay synchronized with test implementations

## Implementation Details
The RBS signatures are generated from inline type annotations in the test files using `RBS::Inline`. The new CI job prevents regressions by failing if generated signatures diverge from what's committed, maintaining consistency between test code and their type declarations.

https://claude.ai/code/session_01UVhqNk2UTVCCM8UimJZRqR