### PR TITLE
Allow draft PRs to skip milestone requirement

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -2,7 +2,7 @@ name: Check milestone
 
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled, milestoned, demilestoned, synchronize]
+    types: [opened, edited, labeled, unlabeled, milestoned, demilestoned, synchronize, converted_to_draft, ready_for_review]
 
 permissions:
   contents: read
@@ -36,6 +36,7 @@ jobs:
             const pr = context.payload.pull_request;
             const milestone = pr.milestone;
             const labels = pr.labels.map(l => l.name);
+            const isDraft = pr.draft;
 
             const version = '${{ steps.version.outputs.version }}';
             const major = '${{ steps.version.outputs.major }}';
@@ -43,6 +44,10 @@ jobs:
             const patch = parseInt('${{ steps.version.outputs.patch }}', 10);
 
             if (!milestone) {
+              if (isDraft) {
+                core.info('Draft PR without milestone – OK');
+                return;
+              }
               if (labels.includes('no-milestone')) {
                 core.info('No milestone set, but no-milestone label is present – OK');
                 return;
@@ -53,7 +58,7 @@ jobs:
               return;
             }
 
-            if (labels.includes('no-milestone')) {
+            if (!isDraft && labels.includes('no-milestone')) {
               core.setFailed(
                 'Milestone is set but "no-milestone" label is present. Remove the label or the milestone.'
               );


### PR DESCRIPTION
## Summary
Updated the milestone check workflow to allow draft pull requests to bypass the milestone requirement, while still enforcing the check for ready-for-review PRs.

## Key Changes
- Added `converted_to_draft` and `ready_for_review` to the workflow trigger types to detect draft status changes
- Extracted the `isDraft` property from the pull request payload
- Modified the milestone validation logic to:
  - Allow draft PRs without a milestone to pass the check
  - Only enforce the "no-milestone" label conflict check for non-draft PRs
- This enables developers to keep PRs in draft status without needing to set a milestone, while ensuring milestones are properly assigned before marking a PR as ready for review

## Implementation Details
The changes maintain backward compatibility by only affecting the behavior for draft PRs. Ready-for-review PRs continue to follow the existing milestone requirements.

https://claude.ai/code/session_01N9Ah9LvddSiMWZbmcYeCuw