### PR TITLE
Add missing RBS definition for test_ensure_annotation

### DIFF
--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -131,6 +131,8 @@ class TypeCheckTest < Minitest::Test
 
   def test_rescue_assignment: () -> untyped
 
+  def test_ensure_annotation: () -> untyped
+
   def test_defined?: () -> untyped
 
   def test_string_match: () -> untyped


### PR DESCRIPTION
## Summary
- Add missing RBS definition for `test_ensure_annotation` in `sig/test/type_check_test.rbs`, generated by `rake rbs:generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)