### PR TITLE
Add `steep query definition NAME` command

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -618,13 +618,16 @@ BANNER
               The user interface and output format may change without deprecation.
 
           Available subcommands:
-              hover     Get hover information (type, documentation) for a position
+              hover      Get hover information (type, documentation) for a position
+              definition Get the definition(s) of a class, type alias, constant, or method name
 
           Options:
               --help    Show this help message
 
           Examples:
               steep query hover lib/foo.rb:10:5
+              steep query definition RBS::Location
+              steep query definition RBS::Parser.parse_signature
         HELP
         return 0
       end
@@ -680,9 +683,40 @@ BANNER
         end
 
         Drivers::Query.new(stdout: stdout, stderr: stderr).run_hover(locations: locations)
+      when "definition"
+        OptionParser.new do |opts|
+          opts.banner = <<BANNER
+Usage: steep query definition [options] NAME [NAME ...]
+
+Description:
+    Get the definition(s) of the specified name(s).
+    Connects to the running Steep daemon and returns both RBS declarations and
+    Ruby definitions as JSONL (one JSON object per line for each queried name).
+
+    NAME can be one of:
+      * A class, module, interface, type alias, or constant (e.g., RBS::Location)
+      * An instance method (e.g., RBS::Parser#parse_type)
+      * A singleton method (e.g., RBS::Parser.parse_signature)
+
+Note:
+    This is an experimental command.
+    The user interface and output format may change without deprecation.
+
+Options:
+BANNER
+          handle_logging_options opts
+        end.parse!(argv)
+
+        if argv.empty?
+          stderr.puts "Error: Missing NAME argument"
+          stderr.puts "  Usage: steep query definition NAME [NAME ...]"
+          return 1
+        end
+
+        Drivers::Query.new(stdout: stdout, stderr: stderr).run_definition(names: argv.dup)
       else
         stderr.puts "Unknown query subcommand: #{subcommand}"
-        stderr.puts "  available subcommands: hover"
+        stderr.puts "  available subcommands: hover, definition"
         1
       end
     end

--- a/lib/steep/drivers/query.rb
+++ b/lib/steep/drivers/query.rb
@@ -47,6 +47,31 @@ module Steep
         1
       end
 
+      # @rbs names: Array[String]
+      # @rbs return: Integer
+      def run_definition(names:)
+        unless Daemon.running?
+          stderr.puts "Error: Steep daemon is not running. Start it with `steep server start`."
+          return 1
+        end
+
+        names.each do |name|
+          request = {
+            id: SecureRandom.uuid,
+            method: Server::CustomMethods::Query__Definition::METHOD,
+            params: { name: name }
+          }
+
+          result = send_request(request)
+          stdout.puts JSON.generate({ name: name, result: result })
+        end
+
+        0
+      rescue Errno::ECONNREFUSED, Errno::ENOENT => e
+        stderr.puts "Error: Failed to connect to Steep daemon: #{e.message}"
+        1
+      end
+
       private
 
       def to_absolute_path(path)

--- a/lib/steep/server/custom_methods.rb
+++ b/lib/steep/server/custom_methods.rb
@@ -84,6 +84,18 @@ module Steep
           { id: id, result: result }
         end
       end
+
+      module Query__Definition
+        METHOD = "$/steep/query/definition"
+
+        def self.request(id, params)
+          { method: METHOD, id: id, params: params }
+        end
+
+        def self.response(id, result)
+          { id: id, result: result }
+        end
+      end
     end
   end
 end

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -632,6 +632,38 @@ module Steep
             )
           end
 
+        when CustomMethods::Query__Definition::METHOD
+          params = message[:params] #: CustomMethods::Query__Definition::params
+          result_controller << group_request do |group|
+            typecheck_workers.each do |worker|
+              group << send_request(method: CustomMethods::Query__Definition::METHOD, params: params, worker: worker)
+            end
+
+            group.on_completion do |handlers|
+              kind = "unknown" #: CustomMethods::Query__Definition::kind
+              locations = [] #: Array[CustomMethods::Query__Definition::location]
+
+              handlers.each do |handler|
+                result = handler.result #: CustomMethods::Query__Definition::result
+                next unless result
+
+                if kind == "unknown"
+                  kind = result[:kind]
+                end
+                locations.concat(result[:locations])
+              end
+
+              locations.uniq!
+
+              enqueue_write_job SendMessageJob.to_client(
+                message: CustomMethods::Query__Definition.response(
+                  message[:id],
+                  { name: params[:name], kind: kind, locations: locations }
+                )
+              )
+            end
+          end
+
         when CustomMethods::TypeCheck::METHOD
           id = message[:id]
           params = message[:params] #: CustomMethods::TypeCheck::params

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -7,6 +7,7 @@ module Steep
 
       WorkspaceSymbolJob = _ = Struct.new(:query, :id, keyword_init: true)
       StatsJob = _ = Struct.new(:id, keyword_init: true)
+      QueryDefinitionJob = _ = Struct.new(:id, :name, keyword_init: true)
       StartTypeCheckJob = _ = Struct.new(:guid, :changes, keyword_init: true)
       TypeCheckCodeJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
       ValidateAppSignatureJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
@@ -108,6 +109,9 @@ module Steep
         when CustomMethods::TypeCheck__Start::METHOD
           params = request[:params] #: CustomMethods::TypeCheck__Start::params
           enqueue_typecheck_jobs(params)
+        when CustomMethods::Query__Definition::METHOD
+          params = request[:params] #: CustomMethods::Query__Definition::params
+          queue << QueryDefinitionJob.new(id: request[:id], name: params[:name])
         when "textDocument/definition"
           queue << GotoJob.definition(id: request[:id], params: request[:params])
         when "textDocument/implementation"
@@ -299,6 +303,10 @@ module Steep
             id: job.id,
             result: goto(job)
           )
+        when QueryDefinitionJob
+          writer.write(
+            CustomMethods::Query__Definition.response(job.id, query_definition_result(job.name))
+          )
         end
       end
 
@@ -348,6 +356,58 @@ module Steep
             stats << calculator.calc_stats(target, file: file)
           end
         end
+      end
+
+      def query_definition_result(name_string)
+        name = Services::GotoService.parse_name(name_string)
+
+        kind =
+          case name
+          when RBS::TypeName
+            "type_name"
+          when InstanceMethodName
+            "instance_method"
+          when SingletonMethodName
+            "singleton_method"
+          else
+            "unknown"
+          end #: CustomMethods::Query__Definition::kind
+
+        locations = [] #: Array[CustomMethods::Query__Definition::location]
+
+        if name
+          goto_service = Services::GotoService.new(type_check: service, assignment: assignment)
+          goto_service.query_definition(name).each do |loc|
+            case loc
+            when RBS::Location
+              path = Pathname(loc.buffer.name)
+              source = "rbs" #: CustomMethods::Query__Definition::source
+              if path.extname == ".rb"
+                source = "ruby" #: CustomMethods::Query__Definition::source
+              end
+              path = project.absolute_path(path)
+              locations << {
+                uri: Steep::PathHelper.to_uri(path).to_s,
+                range: loc.as_lsp_range,
+                source: source
+              }
+            else
+              path = Pathname(loc.source_buffer.name)
+              path = project.absolute_path(path)
+              locations << {
+                uri: Steep::PathHelper.to_uri(path).to_s,
+                range: loc.as_lsp_range,
+                source: "ruby"
+              }
+            end
+          end
+        end
+
+        {
+          name: name_string,
+          kind: kind,
+          locations: locations
+        }
       end
 
       def goto(job)

--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -33,6 +33,126 @@ module Steep
         type_check.project
       end
 
+      # Parses a string representing a class/type/constant/method name into a query value.
+      #
+      # Supported formats:
+      #
+      # * `RBS::Location`                   -- type name (class, module, interface, type alias, class/module alias, or constant)
+      # * `::RBS::Location`                 -- type name, fully qualified
+      # * `RBS::Parser#parse_type`          -- instance method
+      # * `RBS::Parser.parse_signature`     -- singleton method
+      #
+      # Returns `nil` when the given string cannot be parsed as any of the above.
+      #
+      def self.parse_name(name_string)
+        return nil if name_string.nil? || name_string.empty?
+
+        if index = name_string.index("#")
+          type_part = name_string[0...index] or return nil
+          method_part = name_string[(index + 1)..] or return nil
+          return nil if type_part.empty? || method_part.empty?
+
+          type_name = parse_type_name(type_part) or return nil
+          InstanceMethodName.new(type_name: type_name, method_name: method_part.to_sym)
+        elsif index = find_singleton_method_dot(name_string)
+          type_part = name_string[0...index] or return nil
+          method_part = name_string[(index + 1)..] or return nil
+          return nil if type_part.empty? || method_part.empty?
+
+          type_name = parse_type_name(type_part) or return nil
+          SingletonMethodName.new(type_name: type_name, method_name: method_part.to_sym)
+        else
+          parse_type_name(name_string)
+        end
+      rescue RBS::ParsingError, StandardError
+        nil
+      end
+
+      # Finds the index of a `.` that separates a type from a singleton method name.
+      #
+      # Returns the index of the last `.` that is *not* followed by another `.` (to avoid
+      # matching the empty string) and that is not part of `::`. Returns `nil` if none is found.
+      #
+      def self.find_singleton_method_dot(string)
+        index = string.length - 1
+        while index > 0
+          char = string[index]
+          if char == "."
+            prev = string[index - 1]
+            if prev != "." && prev != ":"
+              return index
+            end
+          end
+          index -= 1
+        end
+        nil
+      end
+
+      def self.parse_type_name(string)
+        string = "::#{string}" unless string.start_with?("::")
+        RBS::TypeName.parse(string)
+      rescue RBS::ParsingError, StandardError
+        nil
+      end
+
+      # Returns array of locations that is a response to a *Query definition* request.
+      #
+      # Unlike `#definition`, this method takes a parsed name value instead of a source position.
+      # The caller is expected to parse the name via `.parse_name` before calling this method.
+      #
+      # Each returned entry is either an `RBS::Location` (for RBS declarations) or a
+      # `Parser::Source::Range` (for Ruby source locations).
+      #
+      def query_definition(name)
+        locations = [] #: Array[target_loc]
+
+        case name
+        when RBS::TypeName
+          # `constant_definition_in_rbs` covers classes, modules, class/module aliases,
+          # and plain constants (via `env.constant_entry`).
+          constant_definition_in_rbs(name, locations: locations)
+          constant_definition_in_ruby(name, locations: locations)
+          # Additional lookups for declarations that are not reachable via `env.constant_entry`.
+          interface_and_type_alias_locations(name, locations: locations)
+        when InstanceMethodName, SingletonMethodName
+          method_locations(name, in_ruby: true, in_rbs: true, locations: locations)
+        end
+
+        locations.filter_map do |target, loc|
+          case loc
+          when RBS::Location
+            if assignment =~ [target, loc.name]
+              loc
+            end
+          else
+            loc
+          end
+        end.uniq
+      end
+
+      def interface_and_type_alias_locations(name, locations:)
+        project.targets.each do |target|
+          signature = type_check.signature_services.fetch(target.name)
+          env = signature.latest_env
+
+          if entry = env.interface_decls[name]
+            decl = entry.decl
+            if loc = decl.location
+              locations << [target, loc[:name]]
+            end
+          end
+
+          if entry = env.type_alias_decls[name]
+            decl = entry.decl
+            if loc = decl.location
+              locations << [target, loc[:name]]
+            end
+          end
+        end
+
+        locations
+      end
+
       def implementation(path:, line:, column:)
         locations = [] #: Array[target_loc]
 

--- a/sig/steep/drivers/query.rbs
+++ b/sig/steep/drivers/query.rbs
@@ -11,6 +11,8 @@ module Steep
 
       def run_hover: (locations: Array[[String, Integer, Integer]]) -> Integer
 
+      def run_definition: (names: Array[String]) -> Integer
+
       private
 
       def to_absolute_path: (String path) -> Pathname?

--- a/sig/steep/server/custom_methods.rbs
+++ b/sig/steep/server/custom_methods.rbs
@@ -137,6 +137,39 @@ module Steep
 
         def self.response: (String id, result) -> untyped
       end
+
+      # Request to resolve the definition(s) of a name (class, module, type alias, constant, or method)
+      #
+      # Used by `steep query definition NAME`. The master broadcasts the request to every
+      # typecheck worker; each worker returns the locations it knows about and the master
+      # merges and deduplicates the results.
+      #
+      module Query__Definition
+        METHOD: String
+
+        type params = {
+          name: String
+        }
+
+        type source = "rbs" | "ruby"
+
+        type location = {
+          uri: String,
+          range: {
+            start: { line: Integer, character: Integer },
+            end: { line: Integer, character: Integer }
+          },
+          source: source
+        }
+
+        type kind = "type_name" | "instance_method" | "singleton_method" | "unknown"
+
+        type result = { name: String, kind: kind, locations: Array[location] }
+
+        def self.request: (String id, params) -> untyped
+
+        def self.response: (String id, result) -> untyped
+      end
     end
   end
 end

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -88,6 +88,14 @@ module Steep
         def initialize: (guid: String, path: Pathname, target: Project::Target) -> void
       end
 
+      class QueryDefinitionJob
+        attr_reader id: String
+
+        attr_reader name: String
+
+        def initialize: (id: String, name: String) -> void
+      end
+
       class GotoJob
         type kind = :implementation | :definition | :type_definition
 
@@ -147,6 +155,7 @@ module Steep
                | TypeCheckInlineCodeJob
                | GotoJob
                | StatsJob
+               | QueryDefinitionJob
 
       def handle_job: (job) -> void
 
@@ -157,6 +166,8 @@ module Steep
       def stats_result: () -> Array[StatsCalculator::stats]
 
       def goto: (GotoJob job) -> Array[untyped]
+
+      def query_definition_result: (String name_string) -> CustomMethods::Query__Definition::result
     end
   end
 end

--- a/sig/steep/services/goto_service.rbs
+++ b/sig/steep/services/goto_service.rbs
@@ -60,6 +60,10 @@ module Steep
 
       type query = ConstantQuery | MethodQuery | TypeNameQuery
 
+      # Parsed result of a name string given to `steep query definition NAME`.
+      #
+      type name = TypeName | InstanceMethodName | SingletonMethodName
+
       type loc = Location[bot, bot] | Parser::Source::Range
 
       type target_loc = [Project::Target, loc]
@@ -79,6 +83,24 @@ module Steep
       # Returns array of locations that is a response to a *Go to definition* request
       #
       def definition: (path: Pathname, line: Integer, column: Integer) -> Array[loc]
+
+      # Parses a name string (like `RBS::Location` or `RBS::Parser.parse_signature`) into a query value.
+      #
+      # Returns `nil` if the string cannot be parsed.
+      #
+      def self.parse_name: (String?) -> name?
+
+      # Finds the index of the last `.` that separates a type name from a singleton method name.
+      def self.find_singleton_method_dot: (String) -> Integer?
+
+      # Parses a type name string into a `RBS::TypeName`. Returns `nil` on parse failure.
+      def self.parse_type_name: (String) -> TypeName?
+
+      # Returns array of locations for the given name.
+      #
+      # Used by `steep query definition NAME`.
+      #
+      def query_definition: (name) -> Array[loc]
 
       # Returns array of locations that is a response to a *Go to type-definition* request
       #
@@ -105,6 +127,8 @@ module Steep
       def method_locations: (method_name, in_ruby: bool, in_rbs: bool, locations: Array[target_loc]) -> Array[target_loc]
 
       def type_name_locations: (TypeName name, ?locations: Array[target_loc]) -> Array[target_loc]
+
+      def interface_and_type_alias_locations: (TypeName name, locations: Array[target_loc]) -> Array[target_loc]
     end
   end
 end

--- a/sig/test/cli_test.rbs
+++ b/sig/test/cli_test.rbs
@@ -99,5 +99,11 @@ class CLITest < Minitest::Test
 
   def test_query_hover_multiple_locations: () -> untyped
 
+  def test_query_definition_missing_argument: () -> untyped
+
+  def test_query_definition_help: () -> untyped
+
+  def test_query_definition_returns_result: () -> untyped
+
   def test_check_library_rbs_error: () -> untyped
 end

--- a/sig/test/goto_service_test.rbs
+++ b/sig/test/goto_service_test.rbs
@@ -71,4 +71,22 @@ class GotoServiceTest < Minitest::Test
   def test_go_to_type_definition2: () -> untyped
 
   def test_go_to_definition_class_alias: () -> untyped
+
+  def test_parse_name_type_name: () -> untyped
+
+  def test_parse_name_instance_method: () -> untyped
+
+  def test_parse_name_singleton_method: () -> untyped
+
+  def test_parse_name_returns_nil_for_empty: () -> untyped
+
+  def test_query_definition_class: () -> untyped
+
+  def test_query_definition_type_alias: () -> untyped
+
+  def test_query_definition_interface: () -> untyped
+
+  def test_query_definition_method: () -> untyped
+
+  def test_query_definition_constant: () -> untyped
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1041,6 +1041,95 @@ end
     end
   end
 
+  def test_query_definition_missing_argument
+    in_tmpdir do
+      _, stderr, status = sh3(*steep, "query", "definition")
+      refute_predicate status, :success?
+      assert_match(/Missing NAME argument/, stderr)
+    end
+  end
+
+  def test_query_definition_help
+    in_tmpdir do
+      stdout, status = sh(*steep, "query", "definition", "--help")
+      assert_predicate status, :success?
+      assert_match(/NAME/, stdout)
+    end
+  end
+
+  def test_query_definition_returns_result
+    skip "fork() is not available on this platform" unless Steep.can_fork?
+
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+  signature "foo.rbs"
+end
+      EOF
+
+      (current_dir + "foo.rbs").write(<<~RBS)
+        class Foo
+          def greet: () -> String
+        end
+      RBS
+
+      (current_dir + "foo.rb").write(<<~RUBY)
+        class Foo
+          def greet
+            "hi"
+          end
+        end
+      RUBY
+
+      sh!(*steep, "server", "start", err: [:child, :out])
+
+      begin
+        # Run check first to populate source index for Ruby definitions
+        _, status = sh(*steep, "check")
+        assert_predicate status, :success?
+
+        stdout, status = sh(*steep, "query", "definition", "Foo")
+        assert_predicate status, :success?
+
+        result = JSON.parse(stdout.lines.first, symbolize_names: true)
+        assert_equal "Foo", result[:name]
+        assert_equal "type_name", result[:result][:kind]
+
+        locations = result[:result][:locations]
+        rbs_loc = locations.find { |l| l[:uri].end_with?("foo.rbs") }
+        assert rbs_loc, "Expected RBS location for Foo in foo.rbs"
+        assert_equal({ start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }, rbs_loc[:range])
+        assert_equal "rbs", rbs_loc[:source]
+
+        rb_loc = locations.find { |l| l[:uri].end_with?("foo.rb") }
+        assert rb_loc, "Expected Ruby location for Foo in foo.rb"
+        assert_equal({ start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }, rb_loc[:range])
+        assert_equal "ruby", rb_loc[:source]
+
+        stdout, status = sh(*steep, "query", "definition", "Foo#greet")
+        assert_predicate status, :success?
+
+        result = JSON.parse(stdout.lines.first, symbolize_names: true)
+        assert_equal "Foo#greet", result[:name]
+        assert_equal "instance_method", result[:result][:kind]
+
+        locations = result[:result][:locations]
+        rbs_loc = locations.find { |l| l[:uri].end_with?("foo.rbs") }
+        assert rbs_loc, "Expected RBS location for Foo#greet in foo.rbs"
+        assert_equal({ start: { line: 1, character: 6 }, end: { line: 1, character: 11 } }, rbs_loc[:range])
+        assert_equal "rbs", rbs_loc[:source]
+
+        rb_loc = locations.find { |l| l[:uri].end_with?("foo.rb") }
+        assert rb_loc, "Expected Ruby location for Foo#greet in foo.rb"
+        assert_equal({ start: { line: 1, character: 6 }, end: { line: 1, character: 11 } }, rb_loc[:range])
+        assert_equal "ruby", rb_loc[:source]
+      ensure
+        sh(*steep, "server", "stop", err: [:child, :out])
+      end
+    end
+  end
+
   def test_check_library_rbs_error
     in_tmpdir do
       (current_dir + "Steepfile").write(<<-EOF)

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -1039,4 +1039,152 @@ x = nil #: MyString?
       assert locs.find {|loc| loc.source == "NilClass" }
     end
   end
+
+  def test_parse_name_type_name
+    Services::GotoService.parse_name("RBS::Location").tap do |name|
+      assert_instance_of RBS::TypeName, name
+      assert_equal RBS::TypeName.parse("::RBS::Location"), name
+    end
+
+    Services::GotoService.parse_name("::Customer").tap do |name|
+      assert_instance_of RBS::TypeName, name
+      assert_equal RBS::TypeName.parse("::Customer"), name
+    end
+
+    Services::GotoService.parse_name("_Each").tap do |name|
+      assert_instance_of RBS::TypeName, name
+      assert_equal RBS::TypeName.parse("::_Each"), name
+    end
+  end
+
+  def test_parse_name_instance_method
+    Services::GotoService.parse_name("RBS::Parser#parse_type").tap do |name|
+      assert_instance_of Steep::InstanceMethodName, name
+      assert_equal RBS::TypeName.parse("::RBS::Parser"), name.type_name
+      assert_equal :parse_type, name.method_name
+    end
+  end
+
+  def test_parse_name_singleton_method
+    Services::GotoService.parse_name("RBS::Parser.parse_signature").tap do |name|
+      assert_instance_of Steep::SingletonMethodName, name
+      assert_equal RBS::TypeName.parse("::RBS::Parser"), name.type_name
+      assert_equal :parse_signature, name.method_name
+    end
+  end
+
+  def test_parse_name_returns_nil_for_empty
+    assert_nil Services::GotoService.parse_name("")
+    assert_nil Services::GotoService.parse_name(nil)
+  end
+
+  def test_query_definition_class
+    type_check = type_check_service do |changes|
+      changes[Pathname("sig/customer.rbs")] = [ContentChange.string(<<~RBS)]
+        class Customer
+          VERSION: String
+        end
+      RBS
+      changes[Pathname("lib/customer.rb")] = [ContentChange.string(<<~RUBY)]
+        class Customer
+          VERSION = "0.1.0"
+        end
+      RUBY
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("Customer") or raise
+    service.query_definition(name).tap do |locs|
+      refute_empty locs
+      # One location from the RBS file
+      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
+      # One location from the Ruby file
+      assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+    end
+  end
+
+  def test_query_definition_type_alias
+    type_check = type_check_service do |changes|
+      changes[Pathname("sig/types.rbs")] = [ContentChange.string(<<~RBS)]
+        type name_or_id = String | Integer
+      RBS
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("name_or_id") or raise
+    service.query_definition(name).tap do |locs|
+      refute_empty locs
+      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("types.rbs") }
+    end
+  end
+
+  def test_query_definition_interface
+    type_check = type_check_service do |changes|
+      changes[Pathname("sig/interface.rbs")] = [ContentChange.string(<<~RBS)]
+        interface _MyInterface
+          def foo: () -> void
+        end
+      RBS
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("_MyInterface") or raise
+    service.query_definition(name).tap do |locs|
+      refute_empty locs
+      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("interface.rbs") }
+    end
+  end
+
+  def test_query_definition_method
+    type_check = type_check_service do |changes|
+      changes[Pathname("sig/customer.rbs")] = [ContentChange.string(<<~RBS)]
+        class Customer
+          def greet: () -> String
+        end
+      RBS
+      changes[Pathname("lib/customer.rb")] = [ContentChange.string(<<~RUBY)]
+        class Customer
+          def greet
+            "hi"
+          end
+        end
+      RUBY
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("Customer#greet") or raise
+    service.query_definition(name).tap do |locs|
+      refute_empty locs
+      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
+      assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+    end
+  end
+
+  def test_query_definition_constant
+    type_check = type_check_service do |changes|
+      changes[Pathname("sig/customer.rbs")] = [ContentChange.string(<<~RBS)]
+        class Customer
+          VERSION: String
+        end
+      RBS
+      changes[Pathname("lib/customer.rb")] = [ContentChange.string(<<~RUBY)]
+        class Customer
+          VERSION = "0.1.0"
+        end
+      RUBY
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("Customer::VERSION") or raise
+    service.query_definition(name).tap do |locs|
+      refute_empty locs
+      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
+      assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+    end
+  end
 end


### PR DESCRIPTION
Extends `steep query` with a `definition` subcommand that resolves a
class / module / type alias / interface / constant / method name to its
definition locations. Both the RBS declarations and the Ruby source
definitions are returned so that editors and CLI tools can jump to the
real implementation from a name alone.

A new `$/steep/query/definition` custom LSP method is added. The master
broadcasts the request to every typecheck worker; each worker resolves
the name via a new `GotoService#definition_for_name` helper (which in
turn reuses `constant_definition_in_rbs`/`_in_ruby`, `method_locations`
and a new lookup for interfaces and type aliases) and returns the
locations it is responsible for. The master merges and de-duplicates the
results before replying to the client.

Class and module aliases are handled through `env.constant_entry`, which
already knows how to return `ClassAliasEntry`/`ModuleAliasEntry` with
the `new_name` location; constant assignments in Ruby are picked up via
the source index. Names that cannot be parsed or resolved return an
empty `locations` array with `kind: "unknown"`.