### PR TITLE
Make steep query hover input 0-origin

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -625,7 +625,7 @@ BANNER
               --help    Show this help message
 
           Examples:
-              steep query hover lib/foo.rb:10:5
+              steep query hover lib/foo.rb:9:4
               steep query definition RBS::Location
               steep query definition RBS::Parser.parse_signature
         HELP
@@ -643,7 +643,7 @@ Description:
     Connects to the running Steep daemon and returns type information as JSONL
     (one JSON object per line for each queried position).
 
-    FILE:LINE:COL - File path with 1-based line and column numbers.
+    FILE:LINE:COL - File path with 0-based line and column numbers (LSP convention).
 
 Note:
     This is an experimental command.
@@ -666,18 +666,13 @@ BANNER
           match = location.match(/\A(.+):(\d+):(\d+)\z/)
           unless match
             stderr.puts "Error: Invalid format: #{location}"
-            stderr.puts "  Expected format: FILE:LINE:COL (e.g., lib/foo.rb:10:5)"
+            stderr.puts "  Expected format: FILE:LINE:COL (e.g., lib/foo.rb:9:4)"
             return 1
           end
 
           path = match[1] or raise
           line = match[2].to_i
           column = match[3].to_i
-
-          if line < 1 || column < 1
-            stderr.puts "Error: LINE and COL must be positive integers (1-based)"
-            return 1
-          end
 
           locations << [path, line, column]
         end

--- a/lib/steep/drivers/query.rb
+++ b/lib/steep/drivers/query.rb
@@ -33,7 +33,7 @@ module Steep
             method: "textDocument/hover",
             params: {
               textDocument: { uri: uri },
-              position: { line: line - 1, character: column - 1 }
+              position: { line: line, character: column }
             }
           }
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1017,13 +1017,13 @@ end
 
       begin
         finally_holds(timeout: 30) do
-          stdout, status = sh(*steep, "query", "hover", "foo.rb:2:1")
+          stdout, status = sh(*steep, "query", "hover", "foo.rb:1:0")
           assert_predicate status, :success?
 
           result = JSON.parse(stdout.lines.first, symbolize_names: true)
           assert_equal "foo.rb", result[:file]
-          assert_equal 2, result[:line]
-          assert_equal 1, result[:column]
+          assert_equal 1, result[:line]
+          assert_equal 0, result[:column]
           assert result[:result], "Expected hover result"
         end
       ensure
@@ -1051,7 +1051,7 @@ end
 
       begin
         finally_holds(timeout: 30) do
-          stdout, status = sh(*steep, "query", "hover", "foo.rb:2:1", "foo.rb:2:5")
+          stdout, status = sh(*steep, "query", "hover", "foo.rb:1:0", "foo.rb:1:4")
           assert_predicate status, :success?
 
           lines = stdout.lines


### PR DESCRIPTION
Input LINE:COL was documented as 1-based, but the range in the response
JSON is 0-based (LSP convention). Align the CLI input to 0-based so
input and output agree. The command is experimental and primarily used
by coding agents, so matching the LSP convention is clearer.

https://claude.ai/code/session_01CCWBNpki5VdxYv9yZdkJQj