### PR TITLE
Return LocationLink for definition jumps and query definition

### DIFF
--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -347,6 +347,24 @@ module Steep
         initialize_params.dig(:capabilities, :workspace, :didChangeWatchedFiles, :dynamicRegistration) || false
       end
 
+      # Whether the client declared `linkSupport` for the given goto-style LSP method.
+      #
+      # When `true`, the server emits `LocationLink` (with `targetRange` and
+      # `targetSelectionRange`) for the response. When `false`, we downgrade to plain
+      # `Location` and populate `range` with the name range for backwards compatibility.
+      #
+      def link_support?(lsp_method)
+        initialize_params or raise "`initialize` request is not receiged yet"
+        capability_key =
+          case lsp_method
+          when "textDocument/definition" then :definition
+          when "textDocument/implementation" then :implementation
+          when "textDocument/typeDefinition" then :typeDefinition
+          else return false
+          end
+        initialize_params.dig(:capabilities, :textDocument, capability_key, :linkSupport) ? true : false
+      end
+
       def process_message_from_client(message)
         Steep.logger.info "Processing message from client: method=#{message[:method]}, id=#{message[:id]}"
         id = message[:id]
@@ -607,18 +625,33 @@ module Steep
 
         when "textDocument/definition", "textDocument/implementation", "textDocument/typeDefinition"
           if path = pathname(message[:params][:textDocument][:uri])
+            method = message[:method]
             result_controller << group_request do |group|
               typecheck_workers.each do |worker|
-                group << send_request(method: message[:method], params: message[:params], worker: worker)
+                group << send_request(method: method, params: message[:params], worker: worker)
               end
 
               group.on_completion do |handlers|
                 links = handlers.flat_map(&:result)
                 links.uniq!
+                # Workers always return `LocationLink` shape. Downgrade to plain
+                # `Location` (with the name range) when the client did not declare
+                # `linkSupport` capability, per LSP spec.
+                result =
+                  if link_support?(method)
+                    links
+                  else
+                    links.map do |link|
+                      {
+                        uri: link[:targetUri],
+                        range: link[:targetSelectionRange]
+                      }
+                    end
+                  end
                 enqueue_write_job SendMessageJob.to_client(
                   message: {
                     id: message[:id],
-                    result: links
+                    result: result
                   }
                 )
               end

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -377,29 +377,30 @@ module Steep
 
         if name
           goto_service = Services::GotoService.new(type_check: service, assignment: assignment)
-          goto_service.query_definition(name).each do |loc|
-            case loc
+          goto_service.query_definition(name).each do |def_loc|
+            target_range = def_loc.target_range
+            selection_range = def_loc.target_selection_range
+
+            case target_range
             when RBS::Location
-              path = Pathname(loc.buffer.name)
+              path = Pathname(target_range.buffer.name)
               source = "rbs" #: CustomMethods::Query__Definition::source
               if path.extname == ".rb"
                 source = "ruby" #: CustomMethods::Query__Definition::source
               end
               path = project.absolute_path(path)
-              locations << {
-                uri: Steep::PathHelper.to_uri(path).to_s,
-                range: loc.as_lsp_range,
-                source: source
-              }
             else
-              path = Pathname(loc.source_buffer.name)
+              path = Pathname(target_range.source_buffer.name)
+              source = "ruby" #: CustomMethods::Query__Definition::source
               path = project.absolute_path(path)
-              locations << {
-                uri: Steep::PathHelper.to_uri(path).to_s,
-                range: loc.as_lsp_range,
-                source: "ruby"
-              }
             end
+
+            locations << {
+              uri: Steep::PathHelper.to_uri(path).to_s,
+              targetRange: target_range.as_lsp_range,
+              targetSelectionRange: selection_range.as_lsp_range,
+              source: source
+            }
           end
         end
 
@@ -416,7 +417,7 @@ module Steep
         column = job.params[:position][:character]
 
         goto_service = Services::GotoService.new(type_check: service, assignment: assignment)
-        locations =
+        def_locations =
           case
           when job.definition?
             goto_service.definition(path: path, line: line, column: column)
@@ -428,20 +429,26 @@ module Steep
             raise
           end
 
-        locations.map do |loc|
+        def_locations.map do |def_loc|
+          target_range = def_loc.target_range
+          selection_range = def_loc.target_selection_range
+
           path =
-            case loc
+            case target_range
             when RBS::Location
-              Pathname(loc.buffer.name)
+              Pathname(target_range.buffer.name)
             else
-              Pathname(loc.source_buffer.name)
+              Pathname(target_range.source_buffer.name)
             end
 
           path = project.absolute_path(path)
 
+          # Always emit `LocationLink` shape from the worker; the master downgrades to
+          # `Location` for clients that did not declare `linkSupport` capability.
           {
-            uri: Steep::PathHelper.to_uri(path).to_s,
-            range: loc.as_lsp_range
+            targetUri: Steep::PathHelper.to_uri(path).to_s,
+            targetRange: target_range.as_lsp_range,
+            targetSelectionRange: selection_range.as_lsp_range
           }
         end
       end

--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -22,6 +22,14 @@ module Steep
       class TypeNameQuery < Struct.new(:name, keyword_init: true)
       end
 
+      # A pair of locations describing a definition, mirroring LSP's `LocationLink`:
+      #
+      # * `target_range` -- the full declaration range (`class Foo ... end`)
+      # * `target_selection_range` -- the identifier (name) range (`Foo`)
+      #
+      class DefinitionLocation < Struct.new(:target_range, :target_selection_range, keyword_init: true)
+      end
+
       attr_reader :type_check, :assignment
 
       def initialize(type_check:, assignment:)
@@ -95,13 +103,14 @@ module Steep
         nil
       end
 
-      # Returns array of locations that is a response to a *Query definition* request.
+      # Returns array of `DefinitionLocation` values that is a response to a *Query definition* request.
       #
       # Unlike `#definition`, this method takes a parsed name value instead of a source position.
       # The caller is expected to parse the name via `.parse_name` before calling this method.
       #
-      # Each returned entry is either an `RBS::Location` (for RBS declarations) or a
-      # `Parser::Source::Range` (for Ruby source locations).
+      # Each entry carries a `target_range` (the full declaration) and a `target_selection_range`
+      # (the identifier/name range). The wrapped location objects are either `RBS::Location` values
+      # (for RBS declarations) or `Parser::Source::Range` values (for Ruby source locations).
       #
       def query_definition(name)
         locations = [] #: Array[target_loc]
@@ -118,16 +127,7 @@ module Steep
           method_locations(name, in_ruby: true, in_rbs: true, locations: locations)
         end
 
-        locations.filter_map do |target, loc|
-          case loc
-          when RBS::Location
-            if assignment =~ [target, loc.name]
-              loc
-            end
-          else
-            loc
-          end
-        end.uniq
+        filter_assigned_locations(locations)
       end
 
       def interface_and_type_alias_locations(name, locations:)
@@ -138,14 +138,14 @@ module Steep
           if entry = env.interface_decls[name]
             decl = entry.decl
             if loc = decl.location
-              locations << [target, loc[:name]]
+              locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
             end
           end
 
           if entry = env.type_alias_decls[name]
             decl = entry.decl
             if loc = decl.location
-              locations << [target, loc[:name]]
+              locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
             end
           end
         end
@@ -199,16 +199,7 @@ module Steep
         # Drop un-assigned paths here.
         # The path assignment makes sense only for `.rbs` files, because un-assigned `.rb` files are already skipped since they are not type checked.
         #
-        locations.filter_map do |target, loc|
-          case loc
-          when RBS::Location
-            if assignment =~ [target, loc.name]
-              loc
-            end
-          else
-            loc
-          end
-        end.uniq
+        filter_assigned_locations(locations)
       end
 
       def type_definition(path:, line:, column:)
@@ -234,14 +225,24 @@ module Steep
           type_name_locations(name, locations: locations)
         end
 
-        locations.filter_map do |target, loc|
-          case loc
+        filter_assigned_locations(locations)
+      end
+
+      # Filter entries whose RBS-based `target_range` is not assigned to the given target,
+      # and drop the `target` component, returning only the `DefinitionLocation` values.
+      #
+      # Used by `definition`, `type_definition`, and `query_definition` to ensure we only
+      # emit results whose `.rbs` source files belong to the querying target.
+      #
+      def filter_assigned_locations(locations)
+        locations.filter_map do |target, def_loc|
+          case def_loc.target_range
           when RBS::Location
-            if assignment =~ [target, loc.name]
-              loc
+            if assignment =~ [target, def_loc.target_range.name]
+              def_loc
             end
           else
-            loc
+            def_loc
           end
         end.uniq
       end
@@ -486,11 +487,11 @@ module Steep
           when RBS::Environment::ConstantEntry
             case decl = entry.decl
             when RBS::AST::Declarations::Constant
-              if entry.decl.location
-                locations << [target, entry.decl.location[:name]]
+              if loc = entry.decl.location
+                locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
               end
             when RBS::AST::Ruby::Declarations::ConstantDecl
-              locations << [target, entry.decl.name_location]
+              locations << [target, DefinitionLocation.new(target_range: entry.decl.location, target_selection_range: entry.decl.name_location)]
             else
               raise "Unknown declaration: #{entry.decl.inspect}"
             end
@@ -498,22 +499,22 @@ module Steep
             entry.each_decl do |decl|
               case decl
               when RBS::AST::Declarations::Base
-                if decl.location
-                  locations << [target, decl.location[:name]]
+                if loc = decl.location
+                  locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
                 end
               when RBS::AST::Ruby::Declarations::ClassDecl, RBS::AST::Ruby::Declarations::ModuleDecl
-                locations << [target, decl.name_location]
+                locations << [target, DefinitionLocation.new(target_range: decl.location, target_selection_range: decl.name_location)]
               else
                 raise "Unknown declaration: #{decl.inspect}"
               end
             end
           when RBS::Environment::ClassAliasEntry, RBS::Environment::ModuleAliasEntry
             if entry.decl.is_a?(RBS::AST::Declarations::Base)
-              if entry.decl.location
-                locations << [target, entry.decl.location[:new_name]]
+              if loc = entry.decl.location
+                locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:new_name])]
               end
             else
-              locations << [target, entry.decl.name_location]
+              locations << [target, DefinitionLocation.new(target_range: entry.decl.location, target_selection_range: entry.decl.name_location)]
             end
           end
         end
@@ -529,16 +530,17 @@ module Steep
             entry.definitions.each do |node|
               case node.type
               when :const
-                locations << [target, node.location.expression]
+                expr = node.location.expression
+                locations << [target, DefinitionLocation.new(target_range: expr, target_selection_range: expr)]
               when :casgn
                 parent = node.children[0]
-                location =
+                name_range =
                   if parent
                     parent.location.expression.join(node.location.name)
                   else
                     node.location.name
                   end
-                locations << [target, location]
+                locations << [target, DefinitionLocation.new(target_range: node.location.expression, target_selection_range: name_range)]
               end
             end
           end
@@ -563,10 +565,8 @@ module Steep
 
               entry.definitions.each do |node|
                 case node.type
-                when :def
-                  locations << [target, node.location.name]
-                when :defs
-                  locations << [target, node.location.name]
+                when :def, :defs
+                  locations << [target, DefinitionLocation.new(target_range: node.location.expression, target_selection_range: node.location.name)]
                 end
               end
             end
@@ -590,19 +590,19 @@ module Steep
             entry.declarations.each do |decl|
               case decl
               when RBS::AST::Members::MethodDefinition
-                if decl.location
-                  locations << [target, decl.location[:name]]
+                if loc = decl.location
+                  locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
                 end
               when RBS::AST::Members::Alias
-                if decl.location
-                  locations << [target, decl.location[:new_name]]
+                if loc = decl.location
+                  locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:new_name])]
                 end
               when RBS::AST::Members::AttrAccessor, RBS::AST::Members::AttrReader, RBS::AST::Members::AttrWriter
-                if decl.location
-                  locations << [target, decl.location[:name]]
+                if loc = decl.location
+                  locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
                 end
               when RBS::AST::Ruby::Members::DefMember
-                locations << [target, decl.name_location]
+                locations << [target, DefinitionLocation.new(target_range: decl.location, target_selection_range: decl.name_location)]
               end
             end
           end
@@ -620,17 +620,17 @@ module Steep
           entry.declarations.each do |decl|
             case decl
             when RBS::AST::Declarations::Class, RBS::AST::Declarations::Module, RBS::AST::Declarations::Interface, RBS::AST::Declarations::TypeAlias
-              if decl.location
-                locations << [target, decl.location[:name]]
+              if loc = decl.location
+                locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:name])]
               end
             when RBS::AST::Declarations::AliasDecl
-              if decl.location
-                locations << [target, decl.location[:new_name]]
+              if loc = decl.location
+                locations << [target, DefinitionLocation.new(target_range: loc, target_selection_range: loc[:new_name])]
               end
             when RBS::AST::Ruby::Declarations::ClassDecl, RBS::AST::Ruby::Declarations::ModuleDecl
-              locations << [target, decl.name_location]
+              locations << [target, DefinitionLocation.new(target_range: decl.location, target_selection_range: decl.name_location)]
             when RBS::AST::Ruby::Declarations::ClassModuleAliasDecl
-              locations << [target, decl.name_location]
+              locations << [target, DefinitionLocation.new(target_range: decl.location, target_selection_range: decl.name_location)]
             else
               raise
             end

--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -530,8 +530,19 @@ module Steep
             entry.definitions.each do |node|
               case node.type
               when :const
-                expr = node.location.expression
-                locations << [target, DefinitionLocation.new(target_range: expr, target_selection_range: expr)]
+                # For a class/module definition, `source_index` stores the `:const`
+                # name node only. Walk up the AST to find the enclosing `:class`
+                # or `:module` so `target_range` can cover the full declaration.
+                name_loc = node.location.expression
+                enclosing_nodes = typing.source.find_nodes(line: name_loc.line, column: name_loc.column) || []
+                enclosing = enclosing_nodes.find do |n|
+                  (n.type == :class || n.type == :module) && n.children[0].equal?(node)
+                end
+                if enclosing
+                  locations << [target, DefinitionLocation.new(target_range: enclosing.location.expression, target_selection_range: name_loc)]
+                else
+                  locations << [target, DefinitionLocation.new(target_range: name_loc, target_selection_range: name_loc)]
+                end
               when :casgn
                 parent = node.children[0]
                 name_range =

--- a/sig/steep/server/custom_methods.rbs
+++ b/sig/steep/server/custom_methods.rbs
@@ -153,12 +153,22 @@ module Steep
 
         type source = "rbs" | "ruby"
 
+        type lsp_range = {
+          start: { line: Integer, character: Integer },
+          end: { line: Integer, character: Integer }
+        }
+
+        # Mirrors LSP's `LocationLink`:
+        #
+        # * `targetRange`          -- the full declaration range (`class Foo ... end`)
+        # * `targetSelectionRange` -- the identifier (name) range (`Foo`)
+        #
+        # Coding agents that want the full definition body should use `targetRange`.
+        #
         type location = {
           uri: String,
-          range: {
-            start: { line: Integer, character: Integer },
-            end: { line: Integer, character: Integer }
-          },
+          targetRange: lsp_range,
+          targetSelectionRange: lsp_range,
           source: source
         }
 

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -195,6 +195,11 @@ module Steep
       #
       def work_done_progress_supported?: () -> bool
 
+      # Returns `true` if the client declared `linkSupport` for the goto-style LSP method, meaning
+      # the server may respond with `LocationLink[]` instead of `Location[]`.
+      #
+      def link_support?: (String lsp_method) -> bool
+
       def process_message_from_client: (untyped message) -> void
 
       def process_message_from_worker: (untyped message, worker: WorkerProcess) -> void

--- a/sig/steep/services/goto_service.rbs
+++ b/sig/steep/services/goto_service.rbs
@@ -66,7 +66,20 @@ module Steep
 
       type loc = Location[bot, bot] | Parser::Source::Range
 
-      type target_loc = [Project::Target, loc]
+      # A pair of locations describing a definition, mirroring LSP's `LocationLink`:
+      #
+      # * `target_range` -- the full declaration range
+      # * `target_selection_range` -- the identifier (name) range
+      #
+      class DefinitionLocation
+        attr_reader target_range: loc
+
+        attr_reader target_selection_range: loc
+
+        def initialize: (target_range: loc, target_selection_range: loc) -> void
+      end
+
+      type target_loc = [Project::Target, DefinitionLocation]
 
       attr_reader type_check: TypeCheckService
 
@@ -76,13 +89,13 @@ module Steep
 
       def project: () -> Project
 
-      # Returns array of locations that is a response to a *Go to implementation* request
+      # Returns array of definition locations that is a response to a *Go to implementation* request
       #
-      def implementation: (path: Pathname, line: Integer, column: Integer) -> Array[loc]
+      def implementation: (path: Pathname, line: Integer, column: Integer) -> Array[DefinitionLocation]
 
-      # Returns array of locations that is a response to a *Go to definition* request
+      # Returns array of definition locations that is a response to a *Go to definition* request
       #
-      def definition: (path: Pathname, line: Integer, column: Integer) -> Array[loc]
+      def definition: (path: Pathname, line: Integer, column: Integer) -> Array[DefinitionLocation]
 
       # Parses a name string (like `RBS::Location` or `RBS::Parser.parse_signature`) into a query value.
       #
@@ -96,17 +109,22 @@ module Steep
       # Parses a type name string into a `RBS::TypeName`. Returns `nil` on parse failure.
       def self.parse_type_name: (String) -> TypeName?
 
-      # Returns array of locations for the given name.
+      # Returns array of definition locations for the given name.
       #
       # Used by `steep query definition NAME`.
       #
-      def query_definition: (name) -> Array[loc]
+      def query_definition: (name) -> Array[DefinitionLocation]
 
-      # Returns array of locations that is a response to a *Go to type-definition* request
+      # Returns array of definition locations that is a response to a *Go to type-definition* request
       #
-      def type_definition: (path: Pathname, line: Integer, column: Integer) -> Array[loc]
+      def type_definition: (path: Pathname, line: Integer, column: Integer) -> Array[DefinitionLocation]
 
       private
+
+      # Drops un-assigned entries (those whose RBS target files are not bound to the querying
+      # target) and strips the target component.
+      #
+      def filter_assigned_locations: (Array[target_loc]) -> Array[DefinitionLocation]
 
       # Returns a set of queries
       def query_at: (path: Pathname, line: Integer, column: Integer) -> Array[query]

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1127,12 +1127,16 @@ end
         locations = result[:result][:locations]
         rbs_loc = locations.find { |l| l[:uri].end_with?("foo.rbs") }
         assert rbs_loc, "Expected RBS location for Foo in foo.rbs"
-        assert_equal({ start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }, rbs_loc[:range])
+        # Selection range: just the class name "Foo"
+        assert_equal({ start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }, rbs_loc[:targetSelectionRange])
+        # Target range: the whole class declaration (`class Foo ... end`)
+        assert_equal({ start: { line: 0, character: 0 }, end: { line: 2, character: 3 } }, rbs_loc[:targetRange])
         assert_equal "rbs", rbs_loc[:source]
 
         rb_loc = locations.find { |l| l[:uri].end_with?("foo.rb") }
         assert rb_loc, "Expected Ruby location for Foo in foo.rb"
-        assert_equal({ start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }, rb_loc[:range])
+        assert_equal({ start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }, rb_loc[:targetSelectionRange])
+        assert_equal({ start: { line: 0, character: 0 }, end: { line: 4, character: 3 } }, rb_loc[:targetRange])
         assert_equal "ruby", rb_loc[:source]
 
         stdout, status = sh(*steep, "query", "definition", "Foo#greet")
@@ -1145,12 +1149,17 @@ end
         locations = result[:result][:locations]
         rbs_loc = locations.find { |l| l[:uri].end_with?("foo.rbs") }
         assert rbs_loc, "Expected RBS location for Foo#greet in foo.rbs"
-        assert_equal({ start: { line: 1, character: 6 }, end: { line: 1, character: 11 } }, rbs_loc[:range])
+        # Selection range: just the method name "greet"
+        assert_equal({ start: { line: 1, character: 6 }, end: { line: 1, character: 11 } }, rbs_loc[:targetSelectionRange])
+        # Target range: the whole `def greet: () -> String` line
+        assert_equal({ start: { line: 1, character: 2 }, end: { line: 1, character: 25 } }, rbs_loc[:targetRange])
         assert_equal "rbs", rbs_loc[:source]
 
         rb_loc = locations.find { |l| l[:uri].end_with?("foo.rb") }
         assert rb_loc, "Expected Ruby location for Foo#greet in foo.rb"
-        assert_equal({ start: { line: 1, character: 6 }, end: { line: 1, character: 11 } }, rb_loc[:range])
+        assert_equal({ start: { line: 1, character: 6 }, end: { line: 1, character: 11 } }, rb_loc[:targetSelectionRange])
+        # Target range: `def greet\n    "hi"\n  end` (lines 1-3)
+        assert_equal({ start: { line: 1, character: 2 }, end: { line: 3, character: 5 } }, rb_loc[:targetRange])
         assert_equal "ruby", rb_loc[:source]
       ensure
         sh(*steep, "server", "stop", err: [:child, :out])

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -417,9 +417,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "Customer", loc.source
-        assert_equal 1, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "Customer", loc.target_selection_range.source
+        assert_equal 1, loc.target_selection_range.line
       end
     end
 
@@ -429,9 +429,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "Customer", loc.source
-        assert_equal 1, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "Customer", loc.target_selection_range.source
+        assert_equal 1, loc.target_selection_range.start_line
       end
     end
 
@@ -441,9 +441,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "::Customer2", loc.source
-        assert_equal 2, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "::Customer2", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.line
       end
     end
 
@@ -453,9 +453,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "::Customer2", loc.source
-        assert_equal 2, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "::Customer2", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.start_line
       end
     end
 
@@ -465,9 +465,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "NAME", loc.source
-        assert_equal 5, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "NAME", loc.target_selection_range.source
+        assert_equal 5, loc.target_selection_range.line
       end
     end
 
@@ -477,9 +477,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "Customer::NAME", loc.source
-        assert_equal 6, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "Customer::NAME", loc.target_selection_range.source
+        assert_equal 6, loc.target_selection_range.start_line
       end
     end
   end
@@ -523,16 +523,16 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "foo", loc.source
-        assert_equal 2, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "foo", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.start_line
       end
 
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "foo", loc.source
-        assert_equal 2, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "foo", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.line
       end
     end
 
@@ -542,9 +542,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "bar", loc.source
-        assert_equal 4, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "bar", loc.target_selection_range.source
+        assert_equal 4, loc.target_selection_range.start_line
       end
     end
 
@@ -554,9 +554,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "baz", loc.source
-        assert_equal 6, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "baz", loc.target_selection_range.source
+        assert_equal 6, loc.target_selection_range.start_line
       end
     end
 
@@ -566,9 +566,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "find", loc.source
-        assert_equal 5, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "find", loc.target_selection_range.source
+        assert_equal 5, loc.target_selection_range.line
       end
     end
 
@@ -578,9 +578,9 @@ RUBY
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "find", loc.source
-        assert_equal 12, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "find", loc.target_selection_range.source
+        assert_equal 12, loc.target_selection_range.start_line
       end
     end
   end
@@ -633,17 +633,17 @@ RBS
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "Customer", loc.source
-        assert_equal 1, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "Customer", loc.target_selection_range.source
+        assert_equal 1, loc.target_selection_range.start_line
       end
 
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "Customer", loc.source
-        assert_equal 5, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "Customer", loc.target_selection_range.source
+        assert_equal 5, loc.target_selection_range.start_line
       end
     end
 
@@ -653,9 +653,9 @@ RBS
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "loc", loc.source
-        assert_equal 2, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "loc", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.start_line
       end
     end
 
@@ -665,9 +665,9 @@ RBS
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "_Base", loc.source
-        assert_equal 6, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "_Base", loc.target_selection_range.source
+        assert_equal 6, loc.target_selection_range.start_line
       end
     end
   end
@@ -688,9 +688,9 @@ RBS
       assert_any!(locs) do |target, loc|
         assert_equal :lib, target.name
 
-        assert_instance_of RBS::Location, loc
-        assert_equal "Hello", loc.source
-        assert_equal 1, loc.start_line
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "Hello", loc.target_selection_range.source
+        assert_equal 1, loc.target_selection_range.start_line
       end
     end
   end
@@ -721,27 +721,27 @@ RBS
 
     service.definition(path: dir + "lib/test.rb", line: 1, column: 6).tap do |locs|
       assert_any!(locs) do |loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "initialize", loc.source
-        assert_equal 2, loc.start_line
-        assert_equal Pathname("sig/a.rbs"), loc.buffer.name
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "initialize", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.start_line
+        assert_equal Pathname("sig/a.rbs"), loc.target_selection_range.buffer.name
       end
     end
 
     service.definition(path: dir + "lib/test.rb", line: 2, column: 6).tap do |locs|
       assert_any!(locs) do |loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "initialize", loc.source
-        assert_equal Pathname("basic_object.rbs"), Pathname(loc.buffer.name).basename
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "initialize", loc.target_selection_range.source
+        assert_equal Pathname("basic_object.rbs"), Pathname(loc.target_selection_range.buffer.name).basename
       end
     end
 
     service.definition(path: dir + "lib/test.rb", line: 3, column: 6).tap do |locs|
       assert_any!(locs) do |loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "new", loc.source
-        assert_equal 9, loc.start_line
-        assert_equal Pathname("sig/a.rbs"), loc.buffer.name
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "new", loc.target_selection_range.source
+        assert_equal 9, loc.target_selection_range.start_line
+        assert_equal Pathname("sig/a.rbs"), loc.target_selection_range.buffer.name
       end
     end
   end
@@ -760,10 +760,10 @@ RBS
 
     service.method_locations(MethodName("::Foo#hello"), in_ruby: false, in_rbs: true, locations: []).tap do |result|
       assert_any!(result) do |_target, loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "hello", loc.source
-        assert_equal 2, loc.start_line
-        assert_equal Pathname("inline/a.rb"), loc.buffer.name
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "hello", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.start_line
+        assert_equal Pathname("inline/a.rb"), loc.target_selection_range.buffer.name
       end
     end
   end
@@ -784,10 +784,10 @@ RBS
 
     service.definition(path: dir + "inline/a.rb", line: 6, column: 6).tap do |locs|
       assert_any!(locs) do |loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "initialize", loc.source
-        assert_equal 2, loc.start_line
-        assert_equal Pathname("inline/a.rb"), loc.buffer.name
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "initialize", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.start_line
+        assert_equal Pathname("inline/a.rb"), loc.target_selection_range.buffer.name
       end
     end
   end
@@ -808,10 +808,10 @@ RBS
 
     service.definition(path: dir + "inline/a.rb", line: 6, column: 1).tap do |locs|
       assert_any!(locs) do |loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "Foo", loc.source
-        assert_equal 1, loc.start_line
-        assert_equal Pathname("inline/a.rb"), loc.buffer.name
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "Foo", loc.target_selection_range.source
+        assert_equal 1, loc.target_selection_range.start_line
+        assert_equal Pathname("inline/a.rb"), loc.target_selection_range.buffer.name
       end
     end
   end
@@ -842,9 +842,9 @@ RUBY
     # Cursor on `foo` call inside `bar` method (line 13, column 4)
     service.definition(path: dir + "inline/a.rb", line: 13, column: 6).tap do |locs|
       assert_any!(locs) do |loc|
-        assert_instance_of RBS::Location, loc
-        assert_equal "foo", loc.source
-        assert_equal Pathname("inline/a.rb"), loc.buffer.name
+        assert_instance_of RBS::Location, loc.target_selection_range
+        assert_equal "foo", loc.target_selection_range.source
+        assert_equal Pathname("inline/a.rb"), loc.target_selection_range.buffer.name
       end
     end
   end
@@ -882,17 +882,17 @@ RBS
 
     service.implementation(path: dir + "lib/test.rb", line: 12, column: 6).tap do |locs|
       assert_any!(locs, size: 1) do |loc|
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "initialize", loc.source
-        assert_equal 2, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "initialize", loc.target_selection_range.source
+        assert_equal 2, loc.target_selection_range.line
       end
     end
 
     service.implementation(path: dir + "lib/test.rb", line: 13, column: 6).tap do |locs|
       assert_any!(locs, size: 1) do |loc|
-        assert_instance_of Parser::Source::Range, loc
-        assert_equal "new", loc.source
-        assert_equal 7, loc.line
+        assert_instance_of Parser::Source::Range, loc.target_selection_range
+        assert_equal "new", loc.target_selection_range.source
+        assert_equal 7, loc.target_selection_range.line
       end
     end
   end
@@ -909,7 +909,7 @@ RBS
 
     service.definition(path: dir + "lib/test.rb", line: 1, column: 4).tap do |locs|
       assert_any!(locs, size: 1) do |loc|
-        assert_equal Pathname("array.rbs"), Pathname(loc.buffer.name).basename
+        assert_equal Pathname("array.rbs"), Pathname(loc.target_selection_range.buffer.name).basename
       end
     end
   end
@@ -927,7 +927,7 @@ RBS
 
     service.definition(path: dir + "lib/test.rb", line: 2, column: 8).tap do |locs|
       assert_any!(locs, size: 1) do |loc|
-        assert_equal Pathname("nil_class.rbs"), Pathname(loc.buffer.name).basename
+        assert_equal Pathname("nil_class.rbs"), Pathname(loc.target_selection_range.buffer.name).basename
       end
     end
   end
@@ -953,7 +953,7 @@ RUBY
     a.assign!([:lib, Pathname("sig/b.rbs")], 1)
     Services::GotoService.new(type_check: type_check, assignment: a).tap do |service|
       service.definition(path: dir + "lib/customer.rb", line: 1, column: 10).tap do |locs|
-        assert_equal [Pathname("sig/a.rbs")], locs.map(&:name)
+        assert_equal [Pathname("sig/a.rbs")], locs.map { _1.target_range.name }
       end
     end
 
@@ -962,7 +962,7 @@ RUBY
     b.assign!([:lib, Pathname("sig/b.rbs")], 0)
     Services::GotoService.new(type_check: type_check, assignment: b).tap do |service|
       service.definition(path: dir + "lib/customer.rb", line: 1, column: 10).tap do |locs|
-        assert_equal [Pathname("sig/b.rbs")], locs.map(&:name)
+        assert_equal [Pathname("sig/b.rbs")], locs.map { _1.target_range.name }
       end
     end
   end
@@ -999,19 +999,19 @@ RUBY
 
     service.type_definition(path: dir + "lib/test.rb", line: 1, column: 3).tap do |locs|
       assert_equal 2, locs.size
-      assert locs.find {|loc| loc.source == "TrueClass" }
-      assert locs.find {|loc| loc.source == "FalseClass" }
+      assert locs.find {|loc| loc.target_selection_range.source == "TrueClass" }
+      assert locs.find {|loc| loc.target_selection_range.source == "FalseClass" }
     end
 
     service.type_definition(path: dir + "lib/test.rb", line: 2, column: 3).tap do |locs|
       assert_equal 1, locs.size
-      assert locs.find {|loc| loc.source == "Integer" }
+      assert locs.find {|loc| loc.target_selection_range.source == "Integer" }
     end
 
     service.type_definition(path: dir + "lib/test.rb", line: 3, column: 3).tap do |locs|
       assert_equal 2, locs.size
-      assert locs.find {|loc| loc.source == "Integer" }
-      assert locs.find {|loc| loc.source == "Array" }
+      assert locs.find {|loc| loc.target_selection_range.source == "Integer" }
+      assert locs.find {|loc| loc.target_selection_range.source == "Array" }
     end
   end
 
@@ -1035,8 +1035,8 @@ x = nil #: MyString?
 
     service.type_definition(path: dir + "inline/test.rb", line: 3, column: 15).tap do |locs|
       assert_equal 2, locs.size
-      assert locs.find {|loc| loc.source == "MyString" }
-      assert locs.find {|loc| loc.source == "NilClass" }
+      assert locs.find {|loc| loc.target_selection_range.source == "MyString" }
+      assert locs.find {|loc| loc.target_selection_range.source == "NilClass" }
     end
   end
 
@@ -1096,11 +1096,23 @@ x = nil #: MyString?
 
     name = Services::GotoService.parse_name("Customer") or raise
     service.query_definition(name).tap do |locs|
-      refute_empty locs
+      assert_equal 2, locs.size
       # One location from the RBS file
-      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
+      assert_any!(locs) do |loc|
+        assert loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("sig/customer.rbs"), Pathname(loc.target_selection_range.buffer.name)
+        # Selection range is just the class name
+        assert_equal "Customer", loc.target_selection_range.source
+        # Target range covers the full class declaration (class...end)
+        assert_equal "class Customer\n  VERSION: String\nend", loc.target_range.source
+      end
       # One location from the Ruby file
-      assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+      assert_any!(locs) do |loc|
+        refute loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("lib/customer.rb"), Pathname(loc.target_selection_range.source_buffer.name)
+        assert_equal "Customer", loc.target_selection_range.source
+        assert_equal "class Customer\n  VERSION = \"0.1.0\"\nend", loc.target_range.source
+      end
     end
   end
 
@@ -1115,8 +1127,12 @@ x = nil #: MyString?
 
     name = Services::GotoService.parse_name("name_or_id") or raise
     service.query_definition(name).tap do |locs|
-      refute_empty locs
-      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("types.rbs") }
+      assert_any!(locs, size: 1) do |loc|
+        assert loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("sig/types.rbs"), Pathname(loc.target_selection_range.buffer.name)
+        assert_equal "name_or_id", loc.target_selection_range.source
+        assert_equal "type name_or_id = String | Integer", loc.target_range.source
+      end
     end
   end
 
@@ -1133,8 +1149,12 @@ x = nil #: MyString?
 
     name = Services::GotoService.parse_name("_MyInterface") or raise
     service.query_definition(name).tap do |locs|
-      refute_empty locs
-      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("interface.rbs") }
+      assert_any!(locs, size: 1) do |loc|
+        assert loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("sig/interface.rbs"), Pathname(loc.target_selection_range.buffer.name)
+        assert_equal "_MyInterface", loc.target_selection_range.source
+        assert_equal "interface _MyInterface\n  def foo: () -> void\nend", loc.target_range.source
+      end
     end
   end
 
@@ -1158,9 +1178,21 @@ x = nil #: MyString?
 
     name = Services::GotoService.parse_name("Customer#greet") or raise
     service.query_definition(name).tap do |locs|
-      refute_empty locs
-      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
-      assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+      assert_equal 2, locs.size
+      # RBS definition: `def greet: () -> String`
+      assert_any!(locs) do |loc|
+        assert loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("sig/customer.rbs"), Pathname(loc.target_selection_range.buffer.name)
+        assert_equal "greet", loc.target_selection_range.source
+        assert_equal "def greet: () -> String", loc.target_range.source
+      end
+      # Ruby definition: full `def greet ... end` block
+      assert_any!(locs) do |loc|
+        refute loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("lib/customer.rb"), Pathname(loc.target_selection_range.source_buffer.name)
+        assert_equal "greet", loc.target_selection_range.source
+        assert_equal "def greet\n    \"hi\"\n  end", loc.target_range.source
+      end
     end
   end
 
@@ -1182,9 +1214,19 @@ x = nil #: MyString?
 
     name = Services::GotoService.parse_name("Customer::VERSION") or raise
     service.query_definition(name).tap do |locs|
-      refute_empty locs
-      assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
-      assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+      assert_equal 2, locs.size
+      # RBS: `VERSION: String`
+      assert_any!(locs) do |loc|
+        assert loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("sig/customer.rbs"), Pathname(loc.target_selection_range.buffer.name)
+        assert_equal "VERSION: String", loc.target_range.source
+      end
+      # Ruby: whole `VERSION = "0.1.0"` assignment
+      assert_any!(locs) do |loc|
+        refute loc.target_range.is_a?(RBS::Location)
+        assert_equal Pathname("lib/customer.rb"), Pathname(loc.target_selection_range.source_buffer.name)
+        assert_equal "VERSION = \"0.1.0\"", loc.target_range.source
+      end
     end
   end
 end

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -982,7 +982,7 @@ RUBY
 
     service.type_definition(path: dir + "lib/test.rb", line: 1, column: 5).tap do |locs|
       assert_equal 1, locs.size
-      assert_equal "Foo", locs[0].source
+      assert_equal "Foo", locs[0].target_selection_range.source
     end
   end
 

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -894,14 +894,16 @@ RUBY
         }
       ).tap do |job|
         worker.goto(job).tap do |locations|
+          # Worker always emits `LocationLink`; the master downgrades to `Location` based on client capability.
           assert_any!(locations, size: 1) do |loc|
-            assert_equal "#{file_scheme}#{current_dir}/sig/customer.rbs", loc[:uri]
+            assert_equal "#{file_scheme}#{current_dir}/sig/customer.rbs", loc[:targetUri]
             assert_equal(
-              {
-                start: { line: 0, character: 6 },
-                end: { line: 0, character: 14 }
-              },
-              loc[:range]
+              { start: { line: 0, character: 0 }, end: { line: 2, character: 3 } },
+              loc[:targetRange]
+            )
+            assert_equal(
+              { start: { line: 0, character: 6 }, end: { line: 0, character: 14 } },
+              loc[:targetSelectionRange]
             )
           end
         end


### PR DESCRIPTION
The `$/steep/query/definition` custom method previously returned only
the identifier (name) range of a definition. Coding agents typically
want the full declaration range (e.g. `class Foo ... end`), so this is
unhelpful.

Unify the result shape with LSP's `LocationLink`, which carries both
ranges (`targetRange` for the full declaration, `targetSelectionRange`
for the name). `textDocument/definition`, `/implementation`, and
`/typeDefinition` now also emit `LocationLink[]` when the client
advertises `linkSupport`, and fall back to `Location[]` (with the name
range, for backwards compatibility) otherwise.

Internally, `GotoService` helpers now return `DefinitionLocation`
values that pair the two ranges, and the range filtering is factored
into `filter_assigned_locations`.