### PR TITLE
Fix `UnreachableBranch` on `==` against literal supertype (`Symbol` / `Integer` / `String`)

### DIFF
--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -564,9 +564,12 @@ module Steep
                   false_types << type
                 end
               else
-                # For === (for_receiver: false), non-literal types can match the literal in truthy branch
-                # For == (for_receiver: true), non-literal types only go to falsy branch
-                true_types << AST::Types::Literal.new(value: value_node.children[0]) unless for_receiver
+                # For `==`, narrow only when the literal can be a value of `type`.
+                # e.g. `Symbol == :fatal` can be true, but `SomeClass == :fatal` cannot.
+                literal_type = AST::Types::Literal.new(value: value_node.children[0])
+                if !for_receiver || subtyping?(sub_type: literal_type, super_type: type)
+                  true_types << literal_type
+                end
                 false_types << type
               end
             end

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -103,6 +103,11 @@ class TypeCheckTest < Minitest::Test
 
   def test_type_narrowing__union_send2: () -> untyped
 
+  # Regression test for `==` narrowing against a literal whose superclass is the
+  # receiver type. `Symbol`/`Integer`/`String` include the corresponding literal
+  # values, so the truthy branch is reachable.
+  def test_type_narrowing__literal_equality_with_supertype: () -> untyped
+
   def test_argument_error__unexpected_unexpected_positional_argument: () -> untyped
 
   def test_type_assertion__type_error: () -> untyped

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1566,6 +1566,56 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  # Regression test for `==` narrowing against a literal whose superclass is the
+  # receiver type. `Symbol`/`Integer`/`String` include the corresponding literal
+  # values, so the truthy branch is reachable.
+  def test_type_narrowing__literal_equality_with_supertype
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class A
+            def foo_symbol: (Symbol symbol) -> void
+            def foo_integer: (Integer integer) -> void
+            def foo_string: (String string) -> void
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class A
+            def foo_symbol(symbol)
+              if symbol == :qux
+                puts "qux"
+              else
+                puts "other"
+              end
+            end
+
+            def foo_integer(integer)
+              if integer == 1
+                puts "one"
+              else
+                puts "other"
+              end
+            end
+
+            def foo_string(string)
+              if string == "x"
+                puts "x"
+              else
+                puts "other"
+              end
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
 
   def test_argument_error__unexpected_unexpected_positional_argument
     run_type_check_test(


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #2101 (shipped in 2.0.0) where comparing a value of type `Symbol` (or `Integer` / `String`) against a literal symbol/integer/string with `==` is incorrectly reported as `Ruby::UnreachableBranch`.

Closes #2222

## Reproduction

`a.rb`:

```ruby
class A
  def foo(symbol)
    if symbol == :qux
      puts "qux"
    else
      puts "other"
    end
  end
end
```

`a.rbs`:

```rbs
class A
  def foo: (Symbol symbol) -> void
end
```

```console
$ bundle exec steep check --severity-level=hint
a.rb:3:4: [hint] The branch is unreachable
│ Diagnostic ID: Ruby::UnreachableBranch
│
└     if symbol == :qux
      ~~
```

The same warning was emitted for `Integer == 1`, `String == "x"`, and the postfix-`if` form.

## Cause

#2101 added `for_receiver: true` to `LogicTypeInterpreter#literal_var_type_case_select` so that `==` against a literal could narrow union members like `Result | :some_symbol` properly: `Result` cannot equal `:some_symbol`, so it should flow only into the falsy branch.

The implementation, however, applied that rule to *every* non-literal type. `Symbol`, `Integer`, and `String` are non-literal class types but they include the corresponding literal values, so dropping them from the truthy bucket made the `if` branch look unreachable.

## Fix

In `for_receiver: true` mode, narrow only when the literal type is a subtype of the receiver type:

```ruby
literal_type = AST::Types::Literal.new(value: value_node.children[0])
if !for_receiver || subtyping?(sub_type: literal_type, super_type: type)
  true_types << literal_type
end
false_types << type
```

Behavior matrix:

| Receiver type vs literal | Truthy | Falsy |
| --- | --- | --- |
| `Symbol == :qux` | `:qux` | `Symbol` |
| `Result == :some_symbol` (unrelated class) | (empty → unreachable) | `Result` |
| `(Result \| :some_symbol) == :some_symbol` | `:some_symbol` | `Result` |
| `:foo == :qux` (literal vs literal) | (empty → unreachable) | `:foo` |

The first row is the regression being fixed. The remaining rows match #2101's intent and continue to pass `smoke/narrowing-else`.