### PR TITLE
Run test subprocesses outside the parent Bundler env

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -518,15 +518,15 @@ module ShellHelper
   end
 
   def sh(*command, **opts)
-    Open3.capture2(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd, **opts)
+    Bundler.with_unbundled_env { Open3.capture2(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd, **opts) }
   end
 
   def sh3(*command)
-    Open3.capture3(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd)
+    Bundler.with_unbundled_env { Open3.capture3(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd) }
   end
 
   def sh2e(*command)
-    Open3.capture2e(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd)
+    Bundler.with_unbundled_env { Open3.capture2e(env_vars, *command, chdir: current_dir&.to_s || Dir.pwd) }
   end
 
   def sh!(*command, **opts)


### PR DESCRIPTION
Under Bundler 4, `require "bundler/setup"` exports `BUNDLE_LOCKFILE` into ENV (a new behaviour since 2/3 -- see `set_bundle_variables`), so `ShellHelper#sh!` leaks it into child processes. The binstub tests then run `bundle install` in a tmpdir whose Gemfile uses `gem "steep", path: ...`, and the inherited `BUNDLE_LOCKFILE` causes that install to rewrite this project's `Gemfile.lock` -- dropping the optional `development` group and breaking subsequent `bundle exec`s with `Could not find gem 'stackprof mri'`.

Wrap the `Open3` calls in `Bundler.with_unbundled_env` so each child starts with a clean Bundler env.