### PR TITLE
Include inline source files in --save-expectations

### DIFF
--- a/lib/steep/drivers/check.rb
+++ b/lib/steep/drivers/check.rb
@@ -395,6 +395,7 @@ module Steep
           loader = Services::FileLoader.new(base_dir: project.base_dir)
           all_files = project.targets.each.with_object(Set[]) do |target, set|
             set.merge(loader.load_changes(target.source_pattern, command_line_patterns, changes: {}).each_key)
+            set.merge(loader.load_changes(target.inline_source_pattern, command_line_patterns, changes: {}).each_key)
             set.merge(loader.load_changes(target.signature_pattern, changes: {}).each_key)
           end.to_a
 

--- a/sig/test/cli_test.rbs
+++ b/sig/test/cli_test.rbs
@@ -77,6 +77,8 @@ class CLITest < Minitest::Test
 
   def test_check_inline_with_command_line_pattern: () -> untyped
 
+  def test_check_inline_save_expectations: () -> untyped
+
   def test_check_expression_success: () -> untyped
 
   def test_check_expression_failure: () -> untyped

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -911,6 +911,31 @@ end
     end
   end
 
+  def test_check_inline_save_expectations
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "lib", inline: true
+end
+      EOF
+
+      (current_dir + "lib").mkdir
+      (current_dir + "lib/foo.rb").write(<<-EOF)
+1 + "2"
+      EOF
+
+      stdout, status = sh(*steep, "check", "--save-expectations")
+
+      assert_predicate status, :success?, stdout
+      assert_match(/Saved expectations in steep_expectations\.yml/, stdout)
+
+      expectations = YAML.load_file(current_dir + "steep_expectations.yml")
+      refute_empty expectations
+      assert_equal ["lib/foo.rb"], expectations.map {|entry| entry["file"] }
+      refute_empty expectations[0]["diagnostics"]
+    end
+  end
+
   def test_check_expression_success
     stdout, status = sh(*steep, "check", "-e", "1 + 2")
 


### PR DESCRIPTION
## Summary

When a target is configured with `inline: true`, `steep check --save-expectations` produced an empty YAML (`--- []`) even when diagnostics were reported, because the inline source files were not collected into `all_files`.

`print_typecheck_result` was iterating over `target.source_pattern` and `target.signature_pattern` only, missing `target.inline_source_pattern`. This change adds the missing iteration so inline source files participate in both the populate and prune logic of `save_expectations`.

## Repro

```ruby
# Steepfile
target :app do
  check "lib", inline: true
end
```

```ruby
# lib/foo.rb
1 + "2"
```

```
$ steep check --save-expectations
$ cat steep_expectations.yml
--- []
```

With this fix, `steep_expectations.yml` correctly contains the `lib/foo.rb` entry with its diagnostics.

## Test plan

- [x] `bundle exec ruby -Itest test/cli_test.rb -n test_check_inline_save_expectations`
- [x] Confirmed the new test fails on master and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)