### PR TITLE
feat: support the `it` block parameter

### DIFF
--- a/lib/steep/diagnostic/ruby.rb
+++ b/lib/steep/diagnostic/ruby.rb
@@ -112,7 +112,7 @@ module Steep
           send = case node.type
                  when :send, :csend
                    node
-                 when :block, :numblock
+                 when :block, :numblock, :itblock
                    node.children[0]
                  end
 
@@ -163,7 +163,7 @@ module Steep
           send = case node.type
                  when :send, :csend
                    node
-                 when :block, :numblock
+                 when :block, :numblock, :itblock
                    node.children[0]
                  end
 
@@ -245,7 +245,7 @@ module Steep
                   loc ||= node.loc.operator if node.loc.respond_to?(:operator) # steep:ignore NoMethod
                   loc ||= node.loc.selector if node.loc.respond_to?(:selector) # steep:ignore NoMethod
                   loc
-                when :block
+                when :block, :numblock, :itblock
                   node.children[0].loc.selector
                 end
           super(node: node, location: loc || node.loc.expression)
@@ -1061,7 +1061,7 @@ module Steep
         def header_line
           header =
             case node&.type
-            when :send, :csend, :block, :numblock
+            when :send, :csend, :block, :numblock, :itblock
               "The method is deprecated"
             when :const, :casgn
               "The constant is deprecated"

--- a/lib/steep/node_helper.rb
+++ b/lib/steep/node_helper.rb
@@ -220,7 +220,7 @@ module Steep
 
     def private_send?(node)
       case node.type
-      when :block, :numblock
+      when :block, :numblock, :itblock
         private_send?(node.children[0])
       when :send, :csend
         receiver, = deconstruct_send_node!(node)
@@ -243,7 +243,7 @@ module Steep
         when :send, :csend, :super
           if block_node
             case block_node.type
-            when :block, :numblock
+            when :block, :numblock, :itblock
               if send_node.equal?(block_node.children[0])
                 return [send_node, block_node]
               end

--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -422,7 +422,7 @@ module Steep
           when :send
             location = (_ = node.location) #: Parser::AST::_SelectorLocation
             if test_ast_location(location.selector, line: line, column: column)
-              if (parent = parents[0]) && parent.type == :block && parent.children[0] === node
+              if (parent = parents[0]) && (parent.type == :block || parent.type == :numblock || parent.type == :itblock) && parent.children[0] === node
                 node = parents[0]
               end
 

--- a/lib/steep/services/hover_provider/ruby.rb
+++ b/lib/steep/services/hover_provider/ruby.rb
@@ -103,7 +103,7 @@ module Steep
             when :send, :csend
               result_node =
                 case parents[0]&.type
-                when :block, :numblock
+                when :block, :numblock, :itblock
                   if node == parents.fetch(0).children[0]
                     parents.fetch(0)
                   else

--- a/lib/steep/services/signature_help_provider.rb
+++ b/lib/steep/services/signature_help_provider.rb
@@ -59,7 +59,7 @@ module Steep
               if begin_loc.end_pos <= pos && pos <= end_loc.begin_pos
                 # Given position is between open/close parens of args of send node
 
-                if parent && (parent.type == :block || parent.type == :numblock) && node.equal?(parent.children[0])
+                if parent && (parent.type == :block || parent.type == :numblock || parent.type == :itblock) && node.equal?(parent.children[0])
                   send_node = parent
                 else
                   send_node = node

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -31,7 +31,7 @@ module Steep
     end
 
     def self.new_parser
-      Prism::Translation::Parser33.new(Builder.new).tap do |parser|
+      Prism::Translation::Parser34.new(Builder.new).tap do |parser|
         parser.diagnostics.all_errors_are_fatal = true
         parser.diagnostics.ignore_warnings = true
       end
@@ -257,7 +257,7 @@ module Steep
         annot.line or next
 
         case node.type
-        when :def, :module, :class, :block, :numblock, :ensure, :defs, :resbody
+        when :def, :module, :class, :block, :numblock, :itblock, :ensure, :defs, :resbody
           location = node.loc
           location.line <= annot.line && annot.line < location.last_line
         else
@@ -565,13 +565,13 @@ module Steep
                   end
                 ]
               )
-            when :numblock
-              send, size, body = node.children
+            when :numblock, :itblock
+              send, arg, body = node.children
               node = node.updated(
                 nil,
                 [
                   map_child_node(send) {|child| insert_type_node(child, child_assertions) },
-                  size,
+                  arg,
                   insert_type_node(body, child_assertions)
                 ]
               )
@@ -648,7 +648,7 @@ module Steep
         case node.type
         when :send, :csend
           node
-        when :block, :numblock
+        when :block, :numblock, :itblock
           send = node.children[0]
           case send.type
           when :send, :csend

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -2696,7 +2696,7 @@ module Steep
             constr.add_typing(node, type: type)
           end
 
-        when :block, :numblock, :send, :csend
+        when :block, :numblock, :itblock, :send, :csend
           synthesize_sendish(node, hint: hint, tapp: nil)
 
         when :forwarded_args, :forward_arg
@@ -2770,6 +2770,20 @@ module Steep
             arg_nodes = max_num.times.map {|i| Parser::AST::Node.new(:arg, [:"_#{i+1}"]) }
           end
 
+          params = Parser::AST::Node.new(:args, arg_nodes)
+
+          if send_node.type == :lambda
+            # @type var node: Parser::AST::Node & Parser::AST::_BlockNode
+            type_lambda(node, params_node: params, body_node: body, type_hint: hint)
+          else
+            type_send(node, send_node: send_node, block_params: params, block_body: body, unwrap: send_node.type == :csend, tapp: tapp, hint: hint)
+          end
+        end
+      when :itblock
+        yield_self do
+          send_node, _name, body = node.children
+
+          arg_nodes = [Parser::AST::Node.new(:procarg0, [:it])]
           params = Parser::AST::Node.new(:args, arg_nodes)
 
           if send_node.type == :lambda
@@ -3346,7 +3360,7 @@ module Steep
             end
           end
 
-          if node.type == :csend || ((node.type == :block || node.type == :numblock) && node.children[0].type == :csend)
+          if node.type == :csend || ((node.type == :block || node.type == :numblock || node.type == :itblock) && node.children[0].type == :csend)
             optional_type = AST::Types::Union.build(types: [call.return_type, AST::Builtin.nil_type])
             call = call.with_return_type(optional_type)
           end
@@ -3509,7 +3523,7 @@ module Steep
 
         when AST::Types::Any
           case node.type
-          when :block, :numblock
+          when :block, :numblock, :itblock
             # @type var node: Parser::AST::Node & Parser::AST::_BlockNode
             block_annotations = source.annotations(block: node, factory: checker.factory, context: nesting)
             block_params or raise

--- a/lib/steep/typing.rb
+++ b/lib/steep/typing.rb
@@ -106,7 +106,7 @@ module Steep
             set(body_begin_pos..body_end_pos, context)
           end
 
-        when :block, :numblock
+        when :block, :numblock, :itblock
           range = block_range(node)
           set(range, context)
 
@@ -132,7 +132,7 @@ module Steep
                         node.loc.begin.end_pos # steep:ignore NoMethod
                       end
           end_pos = node.loc.end.begin_pos # steep:ignore NoMethod
-        when :numblock
+        when :numblock, :itblock
           send_node, _ = node.children
           begin_pos = node.loc.begin.end_pos # steep:ignore NoMethod
           end_pos = node.loc.end.begin_pos # steep:ignore NoMethod
@@ -245,7 +245,7 @@ module Steep
                       node.loc.begin.end_pos # steep:ignore NoMethod
                     end
         end_pos = node.loc.end.begin_pos # steep:ignore NoMethod
-      when :numblock
+      when :numblock, :itblock
         send_node, _ = node.children
         begin_pos = node.loc.begin.end_pos # steep:ignore NoMethod
         end_pos = node.loc.end.begin_pos # steep:ignore NoMethod

--- a/sig/shims/prism.rbs
+++ b/sig/shims/prism.rbs
@@ -14,5 +14,15 @@ module Prism
 
       attr_reader diagnostics: untyped
     end
+
+    class Parser34 < Parser
+      def initialize: (Parser::Builders::Default builder) -> void
+
+      def parse: (Parser::Source::Buffer) -> Parser::AST::Node
+
+      def parse_with_comments: (Parser::Source::Buffer) -> [Parser::AST::Node, Array[Parser::Source::Comment]]
+
+      attr_reader diagnostics: untyped
+    end
   end
 end

--- a/sig/steep/source.rbs
+++ b/sig/steep/source.rbs
@@ -29,7 +29,7 @@ module Steep
       def string_value: (untyped token) -> untyped
     end
 
-    def self.new_parser: () -> Prism::Translation::Parser33
+    def self.new_parser: () -> Prism::Translation::Parser34
 
     def self.parse: (String source_code, path: Pathname, factory: AST::Types::Factory) -> Source
 

--- a/sig/test/type_construction_test.rbs
+++ b/sig/test/type_construction_test.rbs
@@ -727,6 +727,10 @@ class TypeConstructionTest < Minitest::Test
 
   def test_ruby3_numbered_parameter4: () -> untyped
 
+  def test_ruby3_it_parameter1: () -> untyped
+
+  def test_ruby3_it_parameter2: () -> untyped
+
   def test_type_check_def_without_decl: () -> untyped
 
   def test_break_without_value_to_block: () -> untyped

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -8382,6 +8382,56 @@ RUBY
     end
   end
 
+  def test_ruby3_it_parameter1
+    with_checker do |checker|
+      source = parse_ruby(<<RUBY)
+[1].map { it.to_s }
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_equal parse_type("::Array[::String]"), type
+
+        assert_no_error typing
+      end
+    end
+  end
+
+  def test_ruby3_it_parameter2
+    with_checker(<<RBS) do |checker|
+module Ruby3
+  class Foo
+    def foo: (Integer) { (Integer) -> void } -> void
+
+    def bar: (foo: Integer) { (Integer) -> void } -> void
+  end
+end
+RBS
+
+      source = parse_ruby(<<RUBY)
+Ruby3::Foo.new().foo { it }
+Ruby3::Foo.new().bar { it }
+RUBY
+
+      with_standard_construction(checker, source) do |construction, typing|
+        type, _ = construction.synthesize(source.node)
+
+        assert_typing_error(typing, size: 2) do |errors|
+          assert_any!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::InsufficientPositionalArguments, error
+            assert_equal "foo", error.location.source
+          end
+
+          assert_any!(errors) do |error|
+            assert_instance_of Diagnostic::Ruby::InsufficientKeywordArguments, error
+            assert_equal "bar", error.location.source
+          end
+        end
+      end
+    end
+  end
+
   def test_type_check_def_without_decl
     with_checker(<<RBS) do |checker|
 RBS


### PR DESCRIPTION
Recognize Ruby 3.4's `it` (e.g. `[1].map { it + 1 }`) by handling the new :itblock node alongside :numblock across type checking, source mapping, diagnostics, hover, and signature help.

This requires bumping Prism::Translation::Parser33 to Parser34.

Closes #1450