### PR TITLE
Report type check progress to master even when a worker job fails

### DIFF
--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -237,55 +237,58 @@ module Steep
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateAppSignature for guid=#{job.guid}, path=#{job.path}" }
 
-            formatter = Diagnostic::LSPFormatter.new({}, **{})
+            reporting_typecheck_progress(job) do
+              formatter = Diagnostic::LSPFormatter.new({}, **{})
 
-            diagnostics = service.validate_signature(path: project.relative_path(job.path), target: job.target)
+              diagnostics = service.validate_signature(path: project.relative_path(job.path), target: job.target)
 
-            typecheck_progress(
-              path: job.path,
-              guid: job.guid,
-              target: job.target,
-              diagnostics: diagnostics.filter_map { formatter.format(_1) }
-            )
+              diagnostics.filter_map { formatter.format(_1) }
+            end
           end
 
         when ValidateLibrarySignatureJob
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing ValidateLibrarySignature for guid=#{job.guid}, path=#{job.path}" }
 
-            formatter = Diagnostic::LSPFormatter.new({}, **{})
-            diagnostics = service.validate_signature(path: job.path, target: job.target)
+            reporting_typecheck_progress(job) do
+              formatter = Diagnostic::LSPFormatter.new({}, **{})
+              diagnostics = service.validate_signature(path: job.path, target: job.target)
 
-            typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics.filter_map { formatter.format(_1) })
+              diagnostics.filter_map { formatter.format(_1) }
+            end
           end
 
         when TypeCheckCodeJob
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing TypeCheckCodeJob for guid=#{job.guid}, path=#{job.path}, target=#{job.target.name}" }
-            group_target = project.group_for_source_path(job.path) || job.target
-            formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
-            relative_path = project.relative_path(job.path)
-            diagnostics = service.typecheck_source(path: relative_path, target: job.target)
-            typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics&.filter_map { formatter.format(_1) })
+            reporting_typecheck_progress(job) do
+              group_target = project.group_for_source_path(job.path) || job.target
+              formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
+              relative_path = project.relative_path(job.path)
+              diagnostics = service.typecheck_source(path: relative_path, target: job.target)
+              diagnostics&.filter_map { formatter.format(_1) }
+            end
           end
 
         when TypeCheckInlineCodeJob
           if job.guid == current_type_check_guid
             Steep.logger.info { "Processing TypeCheckInlineCodeJob for guid=#{job.guid}, path=#{job.path}, target=#{job.target.name}" }
-            group_target = project.group_for_inline_source_path(job.path) || job.target
-            formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
-            relative_path = project.relative_path(job.path)
-            diagnostics = service.typecheck_source(path: relative_path, target: job.target) #: Array[Diagnostic::Ruby::Base | Diagnostic::Signature::Base] | nil
-            signature_diagnostics = service.validate_signature(path: relative_path, target: job.target)
-            if diagnostics
-              diagnostics.concat(signature_diagnostics)
-            else
-              unless signature_diagnostics.empty?
-                diagnostics = signature_diagnostics
+            reporting_typecheck_progress(job) do
+              group_target = project.group_for_inline_source_path(job.path) || job.target
+              formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
+              relative_path = project.relative_path(job.path)
+              diagnostics = service.typecheck_source(path: relative_path, target: job.target) #: Array[Diagnostic::Ruby::Base | Diagnostic::Signature::Base] | nil
+              signature_diagnostics = service.validate_signature(path: relative_path, target: job.target)
+              if diagnostics
+                diagnostics.concat(signature_diagnostics)
+              else
+                unless signature_diagnostics.empty?
+                  diagnostics = signature_diagnostics
+                end
               end
-            end
 
-            typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics&.filter_map { formatter.format(_1) })
+              diagnostics&.filter_map { formatter.format(_1) }
+            end
           end
 
         when WorkspaceSymbolJob
@@ -312,6 +315,20 @@ module Steep
 
       def typecheck_progress(guid:, path:, target:, diagnostics:)
         writer.write(CustomMethods::TypeCheck__Progress.notification({ guid: guid, path: path.to_s, target: target.name.to_s, diagnostics: diagnostics }))
+      end
+
+      # Reports the file to the master even when the given block raises an error
+      #
+      # The master waits for `$/steep/typeCheck/progress` of every file it assigned, and the type check session
+      # never finishes if a worker skips reporting a file, for example because building a definition
+      # from the RBS environment raised an error during type checking.
+      #
+      def reporting_typecheck_progress(job)
+        diagnostics = yield
+        typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics)
+      rescue StandardError
+        typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: nil)
+        raise
       end
 
       def workspace_symbol_result(query)

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -161,6 +161,14 @@ module Steep
 
       def typecheck_progress: (guid: String, path: Pathname, target: Project::Target, diagnostics: Array[LSPDiagnostic::json]?) -> void
 
+      # Reports the file to the master even when the given block raises an error
+      #
+      # The master waits for `$/steep/typeCheck/progress` of every file it assigned, and the type check session
+      # never finishes if a worker skips reporting a file, for example because building a definition
+      # from the RBS environment raised an error during type checking.
+      #
+      def reporting_typecheck_progress: (ValidateAppSignatureJob | ValidateLibrarySignatureJob | TypeCheckCodeJob | TypeCheckInlineCodeJob job) { () -> Array[LSPDiagnostic::json]? } -> void
+
       def workspace_symbol_result: (untyped query) -> untyped
 
       def stats_result: () -> Array[StatsCalculator::stats]

--- a/sig/test/type_check_worker_test.rbs
+++ b/sig/test/type_check_worker_test.rbs
@@ -50,6 +50,8 @@ class TypeCheckWorkerTest < Minitest::Test
 
   def test_handle_job_typecheck_code_diagnostics: () -> untyped
 
+  def test_handle_job_typecheck_code_error: () -> untyped
+
   def test_handle_job_typecheck_skip: () -> untyped
 
   def test_handle_job_typecheck_inline__no_error: () -> untyped

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -583,6 +583,62 @@ class TypeCheckWorkerTest < Minitest::Test
     end
   end
 
+  def test_handle_job_typecheck_code_error
+    in_tmpdir do
+      with_master_read_queue do |master_read_queue|
+        project = Project.new(steepfile_path: current_dir + "Steepfile")
+        Project::DSL.parse(project, <<~RUBY)
+          target :lib do
+            check "lib"
+            signature "sig"
+          end
+        RUBY
+
+        worker = Server::TypeCheckWorker.new(
+          project: project,
+          assignment: assignment,
+          commandline_args: [],
+          reader: worker_reader,
+          writer: worker_writer
+        )
+
+        worker.instance_variable_set(:@current_type_check_guid, "guid")
+
+        {}.tap do |changes|
+          changes[Pathname("lib/hello.rb")] = [Services::ContentChange.string(<<~RUBY)]
+            Hello.new.world()
+          RUBY
+          # `Module#ruby2_keywords` conflicts with the *private* method in core, and
+          # building a definition raises an error during type checking, not validation.
+          changes[Pathname("sig/hello.rbs")] = [Services::ContentChange.string(<<~RBS)]
+            class Hello
+              def world: () -> void
+            end
+
+            class Module
+              def ruby2_keywords: (*Symbol) -> void
+            end
+          RBS
+          worker.handle_job(TypeCheckWorker::StartTypeCheckJob.new(guid: "guid", changes: changes))
+        end
+
+        job = TypeCheckWorker::TypeCheckCodeJob.new(guid: "guid", path: current_dir + "lib/hello.rb", target: project.targets[0])
+        assert_raises(RBS::DuplicatedMethodDefinitionError) do
+          worker.handle_job(job)
+        end
+
+        # The file is reported to the master even when the type check fails, so that
+        # the master doesn't wait for the file forever
+        master_read_queue.pop.tap do |message|
+          assert_equal TypeCheck__Progress::METHOD, message[:method]
+          assert_equal "guid", message[:params][:guid]
+          assert_equal (current_dir + "lib/hello.rb").to_s, message[:params][:path]
+          assert_nil message[:params][:diagnostics]
+        end
+      end
+    end
+  end
+
   def test_handle_job_typecheck_skip
     in_tmpdir do
       with_master_read_queue do |master_read_queue|


### PR DESCRIPTION
## Problem

`steep check` hangs forever (all processes idle at 0% CPU) when type checking a file raises an error outside of the signature validation path.

The master waits for a `$/steep/typeCheck/progress` notification for every file it assigned to workers. When `Services::TypeCheckService#typecheck_source` (or `#validate_signature`) raises — for example when building a definition from the RBS environment fails with `RBS::DuplicatedMethodDefinitionError` — the error is rescued in `BaseWorker#run`, so the worker survives, but the progress notification for that file is never sent and the type check session never finishes.

This is easy to hit after upgrading to Steep 2.0 / RBS 4, whose core signatures added methods (like `private def ruby2_keywords` on `Module`) that conflict with method definitions in a project's own signatures with a different visibility. Minimal reproduction:

```rbs
# sig/foo.rbs
class Foo
  def bar: () -> Integer
end

class Module
  def ruby2_keywords: (*Symbol) -> void
end
```

```ruby
# lib/foo.rb
class Foo
  def bar
    1
  end
end
```

`steep check` on this project (with rbs 4.x) hangs forever. Type checking the RBS gem's own v3.10.4 source tree with Steep 2.0 hangs the same way, because its `sig/unit_test/spy.rbs` defines `Module#ruby2_keywords`.

## Fix

Wrap the four progress-reporting jobs in `TypeCheckWorker#handle_job` (`ValidateAppSignatureJob`, `ValidateLibrarySignatureJob`, `TypeCheckCodeJob`, `TypeCheckInlineCodeJob`) with `#reporting_typecheck_progress`, which reports the file to the master with `diagnostics: nil` and re-raises the error. The existing error logging and `window/showMessage` behavior in `BaseWorker` is unchanged, and the session now finishes: `steep check` prints `Unexpected error reported. 🚨` and exits with status 1 instead of hanging.

## Tests

* Added a regression test that asserts the `$/steep/typeCheck/progress` notification is sent even when `handle_job` raises `RBS::DuplicatedMethodDefinitionError`.
* `test/type_check_worker_test.rb` (19 runs) and `test/master_test.rb` (19 runs) pass.
* `steep check` on the reproduction projects above completes with exit status 1 instead of hanging; healthy projects report identical diagnostics as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019d8VZ7KWvCH1otxL7KEEf5

---
_Generated by [Claude Code](https://claude.ai/code/session_019d8VZ7KWvCH1otxL7KEEf5)_