### PR TITLE
Share method entries between shapes via RBS Method identity

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -54,7 +54,7 @@ module Steep
         end
       end
 
-      attr_reader :factory, :object_shape_cache, :union_shape_cache, :singleton_shape_cache, :ground_shape_cache, :implicitly_returns_nil
+      attr_reader :factory, :object_shape_cache, :union_shape_cache, :singleton_shape_cache, :ground_shape_cache, :method_entry_cache, :implicitly_returns_nil
 
       def initialize(factory, implicitly_returns_nil:)
         @factory = factory
@@ -62,6 +62,7 @@ module Steep
         @union_shape_cache = {}
         @singleton_shape_cache = {}
         @ground_shape_cache = {}
+        (@method_entry_cache = {}).compare_by_identity
         @implicitly_returns_nil = implicitly_returns_nil
       end
 
@@ -292,21 +293,46 @@ module Steep
 
           definition.methods.each do |name, method|
             Steep.logger.tagged(-> { "method = #{type_name}.#{name}" }) do
-              overloads = method.defs.map do |type_def|
-                method_name = method_name_for(type_def, name)
-                method_type = factory.method_type(type_def.type)
-                method_type = replace_primitive_method(method_name, type_def, method_type)
-                method_type = replace_kernel_class(method_name, type_def, method_type) { AST::Builtin::Class.instance_type }
-                method_type = add_implicitly_returns_nil(type_def.each_annotation, method_type)
-                Shape::MethodOverload.new(method_type, [type_def])
-              end
-
-              shape.methods[name] = Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
+              shape.methods[name] = method_entry(name, method, kernel_class_type: AST::Builtin::Class.instance_type)
             end
           end
 
           shape
         end
+      end
+
+      # Returns a `Shape::Entry` of the method, shared across the shapes of different types
+      #
+      # `RBS::DefinitionBuilder` returns the identical `RBS::Definition::Method` object for
+      # methods that are inherited without any change -- no overloading, no type application --,
+      # and the entries built from such methods are equal.
+      # Sharing the entries skips most of the shape construction work, because the vast
+      # majority of the methods of a type are the ones inherited from `Object`/`Kernel`.
+      #
+      # The `class` method is the exception that cannot be cached, because its return type is
+      # replaced with the type-specific singleton type. (See `#replace_kernel_class`.)
+      #
+      def method_entry(name, method, kernel_class_type:)
+        if kernel_class_type && name == :class
+          build_method_entry(name, method, kernel_class_type: kernel_class_type)
+        else
+          method_entry_cache[method] ||= build_method_entry(name, method, kernel_class_type: nil)
+        end
+      end
+
+      def build_method_entry(name, method, kernel_class_type:)
+        overloads = method.defs.map do |type_def|
+          method_name = method_name_for(type_def, name)
+          method_type = factory.method_type(type_def.type)
+          method_type = replace_primitive_method(method_name, type_def, method_type)
+          if kernel_class_type
+            method_type = replace_kernel_class(method_name, type_def, method_type) { kernel_class_type }
+          end
+          method_type = add_implicitly_returns_nil(type_def.each_annotation, method_type)
+          Shape::MethodOverload.new(method_type, [type_def])
+        end
+
+        Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
       end
 
       def object_shape(type_name)
@@ -324,18 +350,12 @@ module Steep
 
           definition.methods.each do |name, method|
             Steep.logger.tagged(-> { "method = #{type_name}##{name}" }) do
-              overloads = method.defs.map do |type_def|
-                method_name = method_name_for(type_def, name)
-                method_type = factory.method_type(type_def.type)
-                method_type = replace_primitive_method(method_name, type_def, method_type)
+              kernel_class_type =
                 if type_name.class?
-                  method_type = replace_kernel_class(method_name, type_def, method_type) { AST::Types::Name::Singleton.intern(name: type_name) }
+                  AST::Types::Name::Singleton.intern(name: type_name)
                 end
-                method_type = add_implicitly_returns_nil(type_def.each_annotation, method_type)
-                Shape::MethodOverload.new(method_type, [type_def])
-              end
 
-              shape.methods[name] = Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
+              shape.methods[name] = method_entry(name, method, kernel_class_type: kernel_class_type)
             end
           end
 

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -54,6 +54,9 @@ module Steep
       # Cache of shapes for types without free variables, keyed by the type
       attr_reader ground_shape_cache: Hash[AST::Types::t, Shape?]
 
+      # Cache of method entries, keyed by the identity of `RBS::Definition::Method` objects
+      attr_reader method_entry_cache: Hash[RBS::Definition::Method, Shape::Entry]
+
       attr_reader implicitly_returns_nil: bool
 
       def initialize: (AST::Types::Factory, implicitly_returns_nil: bool) -> void
@@ -93,6 +96,14 @@ module Steep
       # The `self` types included in the shape is the `self` types in the definition.
       #
       def singleton_shape: (RBS::TypeName) -> Shape
+
+      # Returns a `Shape::Entry` of the method, shared across the shapes of different types
+      #
+      # See the implementation for the details of the sharing.
+      #
+      def method_entry: (Symbol name, RBS::Definition::Method method, kernel_class_type: AST::Types::t?) -> Shape::Entry
+
+      def build_method_entry: (Symbol name, RBS::Definition::Method method, kernel_class_type: AST::Types::t?) -> Shape::Entry
 
       def union_shape: (AST::Types::t, Array[Shape]) -> Shape?
 


### PR DESCRIPTION
Stacked on #2247. (Retarget to `master` after #2247 merges.)

## Problem

`RBS::DefinitionBuilder` returns the *identical* `Definition::Method` object for methods inherited without any change (no overriding, no type application) — `Object#tap` in `build_instance(::String)` is the same object as in `build_instance(::Object)`. Steep, however, rebuilt `Shape::Entry`/`MethodOverload` wrappers for every method of every type.

Measured on Steep's own environment (765 classes): the definitions contain **118,475 (type, method) entries, of which only 21,399 (18%) are distinct `Method` objects** — 82% of shape construction work was duplicated, mostly for methods inherited from `Object`/`Kernel`/`Enumerable`.

## Change

`Interface::Builder#method_entry` caches entries in an identity-keyed Hash (`compare_by_identity`), so an entry is built once and shared by the shapes of every type that inherits the same `Method` object.

The only type-dependent entry is the `class` method (defined in `Kernel`), whose return type is replaced with the singleton type of the owner (`replace_kernel_class`), so it bypasses the cache. The other rewrites (`method_name_for`, `replace_primitive_method`, `add_implicitly_returns_nil`) depend only on the type definition itself and are safe to share.

## Results

Checking Steep's app target (single process, interleaved A/B on the same machine):

| | before | after |
|---|---|---|
| wall | 32.9s | **30.1s (−8.5%)** |
| GC time | 6.9s | **5.6s (−19%)** |
| allocated objects | 30.4M | **27.0M (−11%)** |
| peak RSS | 408MB | **348MB (−15%)** |

Eagerly building the shapes of all 1,646 classes in the environment retains **161MB instead of 283MB (−43%)**, which also helps a future warmup-then-fork worker design.

## Verification

- `test/type_check_test.rb` (133 runs), `test/subtyping_test.rb` (50 runs), `test/interface_test.rb` all pass
- `steep check` self-type-check reports the same 23 problems as the base branch (unchanged)
- `test/interface_builder_test.rb` has 1 pre-existing failure on the base branch as well (rbs master changed `Hash#[]` to take `_Key`), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WWMEZWwe2481yi4BZNKLo

---
_Generated by [Claude Code](https://claude.ai/code/session_011WWMEZWwe2481yi4BZNKLo)_