### PR TITLE
Fix self-type substitution for reopened generic modules

### DIFF
--- a/lib/steep/signature/validator.rb
+++ b/lib/steep/signature/validator.rb
@@ -214,7 +214,17 @@ module Steep
           ancestor_ancestors.self_types or raise
           ancestor_ancestors.params or raise
           self_constraints = ancestor_ancestors.self_types.map do |self_ancestor|
-            s = Interface::Substitution.build(ancestor_ancestors.params, args)
+            params = ancestor_ancestors.params
+
+            if source = self_ancestor.source
+              if entry = env.class_decls[ancestor.name]
+                if decl = entry.each_decl.find { _1.is_a?(RBS::AST::Declarations::Module) && _1.self_types.include?(source) }
+                  params = decl.type_params.map(&:name)
+                end
+              end
+            end
+
+            s = Interface::Substitution.build(params, args)
             ancestor_to_type(self_ancestor).subst(s)
           end
 

--- a/sig/test/validation_test.rbs
+++ b/sig/test/validation_test.rbs
@@ -41,6 +41,8 @@ class ValidationTest < Minitest::Test
 
   def test_validate_mixin_class: () -> untyped
 
+  def test_validate_mixin_with_renamed_type_params: () -> untyped
+
   def test_validate_mixin_module: () -> untyped
 
   def test_validate_instance_variables: () -> untyped

--- a/test/validation_test.rb
+++ b/test/validation_test.rb
@@ -485,6 +485,33 @@ end
     end
   end
 
+  def test_validate_mixin_with_renamed_type_params
+    with_checker <<~RBS do |checker|
+      interface _Each[A]
+        def each: () { (A) -> void } -> void
+      end
+
+      module Enum[E] : _Each[E]
+      end
+
+      module Enum[Elem] : _Each[Elem]
+      end
+
+      class Collection
+        include Enum[String]
+
+        def each: () { (String) -> void } -> void
+      end
+    RBS
+
+      Validator.new(checker: checker).tap do |validator|
+        validator.validate_one_class(RBS::TypeName.parse("::Collection"))
+
+        assert_predicate validator, :no_error?
+      end
+    end
+  end
+
   def test_validate_mixin_module
     with_checker <<-EOF do |checker|
 interface _FooEach[A]


### PR DESCRIPTION
This pull request fixes module self-type validation when a generic module is reopened with different type parameter names.

RBS treats the type parameters of reopened declarations positionally, so declarations using `E` and `Elem` are equivalent. 

Steep previously substituted every self type using the parameter names from the module's primary declaration. A self type originating from another declaration could therefore retain an unresolved type variable and incorrectly produce `RBS::ModuleSelfTypeError`.

The signature validator now finds the declaration that introduced each self type and uses that declaration's parameter names for substitution. A regression test covers equivalent module reopenings with differently named parameters:

```rbs
module Enum[E] : _Each[E]
end

module Enum[Elem] : _Each[Elem]
end

class Collection
  include Enum[String]

  def each: () { (String) -> void } -> void
end
```

This also allows the RBS 4.1.2 core and shim declarations for `Enumerable` to be validated together.

Resolves #2254
