### PR TITLE
Version 2.1.0.dev.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    steep (2.1.0.dev)
+    steep (2.1.0.dev.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -102,4 +102,4 @@ DEPENDENCIES
   vernier (~> 1.5)
 
 BUNDLED WITH
-  4.0.5
+  4.0.9

--- a/lib/steep/version.rb
+++ b/lib/steep/version.rb
@@ -1,3 +1,3 @@
 module Steep
-  VERSION = "2.1.0.dev"
+  VERSION = "2.1.0.dev.1"
 end


### PR DESCRIPTION
Sets `Steep::VERSION` to `2.1.0.dev.1` to cut a dev release from `master`, exercising the release workflow from #2257 end to end. A `.dev.N` release is a gem and a tag and nothing else, so there is no CHANGELOG.md section to add.

Once this is merged, dispatch the `Release gem` workflow with the merge commit's full SHA and `2.1.0.dev.1` — see [doc/release.md](https://github.com/soutaro/steep/blob/master/doc/release.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm8vCN39XbRnUumtJKaXfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm8vCN39XbRnUumtJKaXfR)_