### PR TITLE
Accept a type alias as the type of a lambda's block parameter

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -3164,11 +3164,14 @@ module Steep
       block =
         if block_param = params.block_param
           if block_param_type = block_param.type
-            case block_param_type
+            # Expanding aliases because the cases below test the structure of the type
+            expanded_type = deep_expand_alias(block_param_type) || block_param_type
+
+            case expanded_type
             when AST::Types::Proc
-              Interface::Block.new(type: block_param_type.type, optional: false, self_type: block_param_type.self_type)
+              Interface::Block.new(type: expanded_type.type, optional: false, self_type: expanded_type.self_type)
             else
-              if proc_type = optional_proc?(block_param_type)
+              if proc_type = optional_proc?(expanded_type)
                 Interface::Block.new(type: proc_type.type, optional: true, self_type: proc_type.self_type)
               else
                 block_constr.typing.add_error(

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -299,4 +299,8 @@ class TypeCheckTest < Minitest::Test
   def test_block_pass_optional_block: () -> untyped
 
   def test_block_pass_optional_block_mismatch: () -> untyped
+
+  def test_lambda_block_param_type_alias: () -> untyped
+
+  def test_lambda_block_param_type_alias_not_proc: () -> untyped
 end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -4659,4 +4659,77 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_lambda_block_param_type_alias
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          type callback = ^(Integer) -> void
+
+          type optional_callback = ^(Integer) -> void | nil
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          required = -> (&blk) {
+            # @type var blk: callback
+            blk.call(1)
+          }
+
+          optional = -> (&blk) {
+            # @type var blk: callback?
+            blk&.call(1)
+          }
+
+          expanded = -> (&blk) {
+            # @type var blk: optional_callback
+            blk&.call(1)
+          }
+
+          inline = -> (&blk) {
+            # @type var blk: ^(Integer) -> void
+            blk.call(1)
+          }
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_lambda_block_param_type_alias_not_proc
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          type not_proc = Integer
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          lambda = -> (&blk) {
+            # @type var blk: not_proc
+            blk
+          }
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 13
+              end:
+                line: 1
+                character: 17
+            severity: ERROR
+            message: Proc type is expected but `::not_proc` is specified
+            code: Ruby::ProcTypeExpected
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
Fixes #2262.

Annotating a lambda's block parameter with a proc type alias reports `Ruby::ProcTypeExpected`, while the same proc type written inline is accepted:

```
test.rb:1:8: [error] Proc type is expected but `::callback` is specified
│ Diagnostic ID: Ruby::ProcTypeExpected
│
└ f = -> (&blk) {
          ~~~~
```

`type_lambda` tests the structure of the annotated type — `AST::Types::Proc` for a required block, `optional_proc?` (a two-clause union of `Proc` and `Nil`) for an optional one. A `Name::Alias` misses both, whether it stands alone (`callback`) or appears inside the union (`callback?`).

Fixed by expanding aliases before the tests. The diagnostic still reports the type as written, so a non-proc alias says `::not_proc` rather than its expansion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nx2PCA7ngK5EZkgNtHM5b6)_