### PR TITLE
Type check Data.define and Struct.new block bodies as class definitions

### DIFF
--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -469,6 +469,10 @@ module Steep
       send_node, _ = deconstruct_sendish_and_block_nodes(node)
       return false unless send_node
 
+      data_struct_definition_send?(send_node)
+    end
+
+    def self.data_struct_definition_send?(send_node)
       if send_node.type == :send
         receiver, method, args = deconstruct_send_node!(send_node)
 

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -278,7 +278,9 @@ module Steep
                          method_name: InstanceMethodName.new(type_name: module_context.class_name, method_name: method_name)
                        )
                      else
-                       raise "Unexpected self_type: #{self_type}"
+                       # The type of `self` cannot be resolved to a concrete class/module,
+                       # for example a `def` inside a block whose self type is unsolved or `untyped`
+                       TypeInference::MethodCall::UnknownContext.new()
                      end
 
       self.class.new(
@@ -575,6 +577,21 @@ module Steep
       constr.checker.push_variable_bounds(constr.variable_context.upper_bounds) do
         yield constr
       end
+    end
+
+    def synthesize_data_struct_class_body(block_node, constant_name, constant_type)
+      send_node, _, body_node = block_node.children
+
+      type, constr = synthesize(send_node, hint: constant_type)
+
+      constr.with_class_constr(block_node, constant_name, nil) do |constructor|
+        constructor.typing.cursor_context.set_node_context(block_node, constructor.context)
+        constructor.typing.cursor_context.set_body_context(block_node, constructor.context)
+
+        constructor.synthesize(body_node) if body_node
+      end
+
+      constr.add_typing(block_node, type: type)
     end
 
     def with_sclass_constr(node, type)
@@ -1664,7 +1681,17 @@ module Steep
               constr.check_deprecation_constant(constant_name, node, location.name)
             end
 
-            value_type, constr = constr.synthesize(node.children.last, hint: constant_type)
+            value_node = node.children.last #: Parser::AST::Node
+
+            if constant_name && value_node.type == :block &&
+                value_node.children[1].children.empty? &&
+                Source.data_struct_definition_send?(value_node.children[0])
+              # Class definition using `C = Data.define(...) do ... end` or `C = Struct.new(...) do ... end`
+              # The block body is type checked as a class definition body of `C`.
+              value_type, constr = constr.synthesize_data_struct_class_body(value_node, constant_name, constant_type)
+            else
+              value_type, constr = constr.synthesize(value_node, hint: constant_type)
+            end
 
             result = check_relation(sub_type: value_type, super_type: constant_type)
             if result.failure?

--- a/sig/steep/source.rbs
+++ b/sig/steep/source.rbs
@@ -107,6 +107,10 @@ module Steep
     #
     def self.skip_arg_assertions: (Parser::AST::Node) -> bool
 
+    # Returns `true` if the node is a `Data.define` or `Struct.new` call
+    #
+    def self.data_struct_definition_send?: (Parser::AST::Node) -> bool
+
     def self.adjust_location: (Parser::AST::Node) -> Parser::AST::Node
 
     # Returns an `:assertion` node with `TypeAssertion`

--- a/sig/steep/type_construction.rbs
+++ b/sig/steep/type_construction.rbs
@@ -100,6 +100,10 @@ module Steep
 
     def with_class_constr: [T] (Parser::AST::Node node, untyped new_class_name, untyped super_class_name) { (TypeConstruction) -> T } -> T
 
+    # Type checks `C = Data.define(...) do ... end` and `C = Struct.new(...) do ... end`,
+    # where the block body is type checked as a class definition body of `C`
+    def synthesize_data_struct_class_body: (Parser::AST::Node block_node, RBS::TypeName constant_name, AST::Types::t constant_type) -> Pair
+
     def with_sclass_constr: [A] (Parser::AST::Node node, AST::Types::t `type`) { (TypeConstruction?) -> A } -> A
 
     # Returns one-level _meta_ type from given type

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -160,6 +160,32 @@ class TypeCheckTest < Minitest::Test
 
   def test_data_struct_annotation: () -> untyped
 
+  def test_data_define_block: () -> untyped
+
+  def test_data_define_block__body_type_mismatch: () -> untyped
+
+  def test_data_define_block__undeclared_method: () -> untyped
+
+  def test_data_define_block__singleton_method: () -> untyped
+
+  def test_data_define_block__cbase: () -> untyped
+
+  def test_data_define_block__empty_body: () -> untyped
+
+  def test_data_define_block__super_reader: () -> untyped
+
+  def test_data_define_block__implements_annotation: () -> untyped
+
+  def test_data_define_block__nonclass_constant: () -> untyped
+
+  def test_data_define_block__initialize_super: () -> untyped
+
+  def test_data_define_block__unassigned: () -> untyped
+
+  def test_data_define_block__undeclared_constant: () -> untyped
+
+  def test_struct_new_block: () -> untyped
+
   def test_any_upperbound: () -> untyped
 
   def test_generics_upperbound_default: () -> untyped

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -2390,6 +2390,459 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  def test_data_define_block
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+            attr_reader unit(): String
+
+            def self.new: (Integer amount, String unit) -> instance
+                        | (amount: Integer, unit: String) -> instance
+
+            def to_s: () -> String
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount, :unit) do
+            def to_s
+              "\#{amount} \#{unit}"
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_data_define_block__body_type_mismatch
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+
+            def to_s: () -> String
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount) do
+            def to_s
+              amount
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 2
+                character: 6
+              end:
+                line: 2
+                character: 10
+            severity: ERROR
+            message: |-
+              Cannot allow method body have type `::Integer` because declared as type `::String`
+                ::Integer <: ::String
+                  ::Numeric <: ::String
+                    ::Object <: ::String
+                      ::BasicObject <: ::String
+            code: Ruby::MethodBodyTypeMismatch
+      YAML
+    )
+  end
+
+  def test_data_define_block__undeclared_method
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount) do
+            def foo
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 2
+                character: 6
+              end:
+                line: 2
+                character: 9
+            severity: ERROR
+            message: Method `::Measure#foo` is not declared in RBS
+            code: Ruby::UndeclaredMethodDefinition
+      YAML
+    )
+  end
+
+  def test_data_define_block__singleton_method
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+
+            def self.new: (amount: Integer) -> instance
+            def self.parse: (String) -> Measure
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount) do
+            def self.parse(string)
+              new(amount: Integer(string))
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_data_define_block__cbase
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+
+            def to_s: () -> String
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = ::Data.define(:amount) do
+            def to_s
+              amount.to_s
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_data_define_block__empty_body
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount) do
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_data_define_block__super_reader
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount) do
+            def amount = super
+          end
+        RUBY
+      },
+      # `Data.define` defines the readers on the returned class itself, so a reader override in
+      # the block replaces them and `super` raises NoMethodError at runtime. The diagnostic
+      # matches the runtime behavior. (The inheritance form `class Measure < Data.define(...)`
+      # keeps the readers on the anonymous superclass, so `super` works there.)
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 2
+                character: 15
+              end:
+                line: 2
+                character: 20
+            severity: ERROR
+            message: No superclass method `amount` defined
+            code: Ruby::UnexpectedSuper
+      YAML
+    )
+  end
+
+  def test_data_define_block__implements_annotation
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Measure < Data
+            attr_reader amount(): Integer
+          end
+
+          class Other
+            def foo: () -> Integer
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Measure = Data.define(:amount) do
+            # @implements Other
+
+            def foo
+              1
+            end
+          end
+        RUBY
+      },
+      # An explicit `@implements` annotation takes precedence over the assigned constant
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
+  def test_data_define_block__nonclass_constant
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          Frame: Integer
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Frame = Data.define(:a) do
+            def b = 1
+          end
+        RUBY
+      },
+      # The constant is declared but is not a class
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 2
+                character: 6
+              end:
+                line: 2
+                character: 7
+            severity: ERROR
+            message: Method `b` is defined in undeclared module
+            code: Ruby::MethodDefinitionInUndeclaredModule
+      YAML
+    )
+  end
+
+  def test_data_define_block__initialize_super
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class Frame < Data
+            attr_reader name(): String
+            attr_reader elems(): Array[String]
+
+            def self.new: (name: String, ?elems: Array[String]) -> instance
+
+            def initialize: (name: String, ?elems: Array[String]) -> void
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Frame = Data.define(:name, :elems) do
+            def initialize(name:, elems: [])
+              super(name: name, elems: elems)
+            end
+          end
+        RUBY
+      },
+      # The `UnexpectedKeywordArgument` diagnostics are a pre-existing limitation, not specific to
+      # the block form: RBS core doesn't declare `Data#initialize`, so `super` resolves to
+      # `Object#initialize`. `class Frame < Data.define(:name, :elems)` reports exactly the same.
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 3
+                character: 10
+              end:
+                line: 3
+                character: 14
+            severity: ERROR
+            message: Unexpected keyword argument
+            code: Ruby::UnexpectedKeywordArgument
+          - range:
+              start:
+                line: 3
+                character: 22
+              end:
+                line: 3
+                character: 27
+            severity: ERROR
+            message: Unexpected keyword argument
+            code: Ruby::UnexpectedKeywordArgument
+      YAML
+    )
+  end
+
+  def test_data_define_block__unassigned
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          ::Data.define(:foo) do
+            def self.bar
+            end
+          end
+        RUBY
+      },
+      # No `Ruby::UnexpectedError` -- the `def self.bar` used to crash with
+      # `Unexpected self_type: untyped` because the type of `self` in the block cannot be solved
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 2
+                character: 11
+              end:
+                line: 2
+                character: 14
+            severity: ERROR
+            message: Method `bar` is defined in undeclared module
+            code: Ruby::MethodDefinitionInUndeclaredModule
+      YAML
+    )
+  end
+
+  def test_data_define_block__undeclared_constant
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          Frame = Data.define(:a) do
+            def self.b
+            end
+          end
+        RUBY
+      },
+      # No `Ruby::UnexpectedError` even when the constant is not declared in RBS
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 1
+                character: 0
+              end:
+                line: 1
+                character: 5
+            severity: ERROR
+            message: 'Cannot find the declaration of constant: `Frame`'
+            code: Ruby::UnknownConstant
+          - range:
+              start:
+                line: 2
+                character: 11
+              end:
+                line: 2
+                character: 12
+            severity: ERROR
+            message: Method `b` is defined in undeclared module
+            code: Ruby::MethodDefinitionInUndeclaredModule
+      YAML
+    )
+  end
+
+  def test_struct_new_block
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class World < Struct[untyped]
+            attr_accessor size(): Integer
+
+            def double_size: () -> Integer
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          World = Struct.new(:size) do
+            def double_size
+              size * 2
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics: []
+      YAML
+    )
+  end
+
   def test_any_upperbound
     run_type_check_test(
       signatures: {


### PR DESCRIPTION
Fixes #963
Fixes #1180

Hi! Thank you for Steep, it type checks several of my gems every day.

RuboCop's `Style/DataInheritance` cop autocorrects the inheritance form into a constant assignment:

```ruby
# before
class Measure < Data.define(:amount, :unit)
  def to_s
    "#{amount} #{unit}"
  end
end

# after
Measure = Data.define(:amount, :unit) do
  def to_s
    "#{amount} #{unit}"
  end
end
```

Steep attributes `to_s` in the block to the enclosing module, so the autocorrected code stops type checking:

```
a.rb:3:7: [error] Type `::Object` does not have method `amount`
│ Diagnostic ID: Ruby::NoMethod
│
└     "#{amount} #{unit}"
         ~~~~~~
```

A singleton method in an unassigned block also breaks the type checking of the file (#1180):

```
sample.rb:2:2: [error] UnexpectedError: Unexpected self_type: untyped(RuntimeError)
```

## What this PR does

- The `:casgn` branch detects `C = Data.define(...) do ... end` and `C = Struct.new(...) do ... end`, and type checks the block body as a class definition body of `C`. The result matches the `class C < Data.define(...)` form: same module context, same diagnostics.
- `@implements` annotations inside the block keep precedence, so the existing `Request = _ = Struct.new(...) do # @implements Request ... end` pattern (`smoke/implements`) works unchanged.
- `validate_method_definitions` is skipped for the block form, because `Data` and `Struct` generate the attribute readers and `new` at runtime.
- `for_new_method` falls back to `UnknownContext` when the type of `self` is an unsolved type variable or `untyped`, instead of raising. `::Data.define(:foo) do def self.bar; end end` now reports `Ruby::MethodDefinitionInUndeclaredModule` instead of `Ruby::UnexpectedError`.

A nice side effect: `def amount = super` in the block form now reports `Ruby::UnexpectedSuper`, and that matches the runtime. `Data.define` defines the readers on the returned class itself, so a reader override in the block replaces them and `super` raises `NoMethodError`. The inheritance form keeps the readers on the anonymous superclass, so `super` works there. The `test_data_define_block__super_reader` test pins this down.

## Notes

- The class body context nests as `[outer, C]`, the same approximation the inheritance form uses today. A Ruby block does not push a cref, so constant lookup inside the block is slightly wider than at runtime.
- The cast form from the #963 report, `Frame = _ = Data.define(...) do ... end`, keeps today's behavior: the cast bypasses the constant declaration, so there is no class to attach the block to. Dropping the `_ =` is the supported spelling.
- Blocks with parameters, `_1` and `it` blocks keep today's behavior.
