### PR TITLE
Fix Ruby warnings printed while running tests

### DIFF
--- a/lib/steep/ast/types/helper.rb
+++ b/lib/steep/ast/types/helper.rb
@@ -4,7 +4,6 @@ module Steep
       module Helper
         module ChildrenLevel
           def level_of_children(children)
-            levels = children.map(&:level)
             children.map(&:level).sort {|a, b| (b.size <=> a.size) || 0 }.inject() do |a, b|
               a.zip(b).map do |x, y|
                 if x && y

--- a/lib/steep/ast/types/name.rb
+++ b/lib/steep/ast/types/name.rb
@@ -88,7 +88,7 @@ module Steep
           def map_type(&block)
             args = self.args.map(&block)
 
-            _ = self.class.new(name: self.name, args: self.args)
+            _ = self.class.new(name: self.name, args: args)
           end
         end
 

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -1,7 +1,7 @@
 module Steep
   module Server
     class TypeCheckWorker < BaseWorker
-      attr_reader :project, :assignment, :service
+      attr_reader :project, :assignment
       attr_reader :commandline_args
       attr_reader :current_type_check_guid
 

--- a/lib/steep/services/hover_provider/content.rb
+++ b/lib/steep/services/hover_provider/content.rb
@@ -56,7 +56,7 @@ module Steep
 
           def class_or_module?
             (class_decl || class_alias) ?  true : false
-        end
+          end
       end
 
       TypeAliasContent = _ = Struct.new(:location, :decl, keyword_init: true)

--- a/lib/steep/source.rb
+++ b/lib/steep/source.rb
@@ -231,7 +231,7 @@ module Steep
         end
 
       when :rescue
-        body, resbodies, else_node, loc = deconstruct_rescue_node!(node)
+        body, _, else_node, loc = deconstruct_rescue_node!(node)
 
         if else_node
           loc.else or raise
@@ -356,7 +356,6 @@ module Steep
 
     def find_heredoc_nodes(line, column, position)
       each_heredoc_node() do |nodes, location|
-        node = nodes[0]
         loc = location.heredoc_body #: Parser::Source::Range
 
         if range = loc.to_range
@@ -470,7 +469,7 @@ module Steep
       return false unless send_node
 
       if send_node.type == :send
-        receiver, method, args = deconstruct_send_node!(send_node)
+        receiver, method, _ = deconstruct_send_node!(send_node)
 
         return false unless receiver
 
@@ -657,7 +656,7 @@ module Steep
         end
 
       if send_node
-        receiver_node, name, _, location = deconstruct_send_node!(send_node)
+        receiver_node, _, _, location = deconstruct_send_node!(send_node)
 
         if receiver_node
           if location.dot && location.selector

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -653,7 +653,6 @@ module Steep
         instance_definition: instance_definition
       )
 
-      singleton_definition = checker.factory.definition_builder.build_singleton(module_context.class_name)
       type_env =
         TypeInference::TypeEnvBuilder.new(
           TypeInference::TypeEnvBuilder::Command::ImportGlobalDeclarations.new(checker.factory),
@@ -781,7 +780,7 @@ module Steep
               end
 
               if rhs
-                rhs_type, rhs_constr, rhs_context = synthesize(rhs, hint: hint).to_ary
+                rhs_type, rhs_constr, _ = synthesize(rhs, hint: hint).to_ary
 
                 constr = rhs_constr.update_type_env do |type_env|
                   var_type = rhs_type
@@ -1913,7 +1912,7 @@ module Steep
           yield_self do
             cond, true_clause, false_clause = node.children
 
-            cond_type, constr = synthesize(cond, condition: true).to_ary
+            _, constr = synthesize(cond, condition: true).to_ary
             interpreter = TypeInference::LogicTypeInterpreter.new(subtyping: checker, typing: constr.typing, config: builder_config)
             truthy, falsy = interpreter.eval(env: constr.context.type_env, node: cond)
 
@@ -2045,7 +2044,7 @@ module Steep
                 branch_reachable = false
 
                 tests.each do |test|
-                  test_type, condition_constr = condition_constr.synthesize(test, condition: true)
+                  _, condition_constr = condition_constr.synthesize(test, condition: true)
                   truthy, falsy = interpreter.eval(env: condition_constr.context.type_env, node: test)
                   truthy_env = truthy.env
                   falsy_env = falsy.env
@@ -2295,7 +2294,7 @@ module Steep
         when :while, :until
           yield_self do
             cond, body = node.children
-            cond_type, constr = synthesize(cond, condition: true).to_ary
+            _, constr = synthesize(cond, condition: true).to_ary
 
             interpreter = TypeInference::LogicTypeInterpreter.new(subtyping: checker, typing: typing, config: builder_config)
             truthy, falsy = interpreter.eval(env: constr.context.type_env, node: cond)
@@ -2347,7 +2346,7 @@ module Steep
                   .for_branch(body, break_context: TypeInference::Context::BreakContext.new(break_type: hint || AST::Builtin.nil_type, next_type: nil))
 
               typing.cursor_context.set_node_context(body, for_loop.context)
-              _, body_constr, body_context = for_loop.synthesize(body)
+              _, _, body_context = for_loop.synthesize(body)
 
               constr = cond_constr.update_type_env {|env| env.join(env, body_context.type_env) }
 
@@ -2886,10 +2885,8 @@ module Steep
           if node.type == :splat
             asgn_node = node.children[0]
             next unless asgn_node
-            var_type = asgn_node.type
           else
             asgn_node = node
-            var_type = type
           end
 
           case asgn_node.type

--- a/lib/steep/type_inference/case_when.rb
+++ b/lib/steep/type_inference/case_when.rb
@@ -20,14 +20,14 @@ module Steep
 
           latest_constr, unreachable_pattern = latest_result
 
-          type, constr = yield(test_node, latest_constr, unreachable_pattern)
+          yield(test_node, latest_constr, unreachable_pattern)
           truthy_result, falsy_result = logic.eval(env: latest_constr.context.type_env, node: test_node)
 
           pattern_results << [pat, truthy_result, falsy_result]
         end
 
         def latest_result
-          if (_, truthy, falsy = pattern_results.last)
+          if (_, _, falsy = pattern_results.last)
             [
               initial_constr.update_type_env { falsy.env },
               falsy.unreachable

--- a/test/args_test.rb
+++ b/test/args_test.rb
@@ -696,7 +696,7 @@ class ArgsTest < Minitest::Test
       SendArgs.new(node: node, arguments: args, type: parse_method_type("(a: String, ?b: Symbol, **bool) -> void")).tap do |args|
         pairs = {}
 
-        errors = args.each() do |value|
+        args.each() do |value|
           case value
           when SendArgs::KeywordArgs::ArgTypePairs
             value.pairs.each do |node, type|

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -163,7 +163,7 @@ end
 1 + "2"
       EOF
 
-      stdout, status = sh(*steep, "check", "--group=app")
+      stdout, _ = sh(*steep, "check", "--group=app")
 
       assert_match(/^foo.rb:1:0/, stdout)
       refute_match(/^test.rb/, stdout)
@@ -710,7 +710,7 @@ end
 1 + 2
       EOF
 
-      stdout, stderr, status = sh3(*steep, "stats", "--format=table")
+      stdout, _, status = sh3(*steep, "stats", "--format=table")
 
       assert_predicate status, :success?, stdout
       assert_equal <<CSV, stdout

--- a/test/daemon_test.rb
+++ b/test/daemon_test.rb
@@ -127,7 +127,7 @@ target :app do
 end
       EOF
 
-      output, status = sh(*steep, "server", "stop", err: [:child, :out])
+      output, _ = sh(*steep, "server", "stop", err: [:child, :out])
       assert_match(/not running|cleaned up stale files/, output)
     end
   end
@@ -224,7 +224,7 @@ x = "string"
 
       sleep 0.5
 
-      stdout2, status2 = sh(*steep, "check")
+      stdout2, _ = sh(*steep, "check")
       assert_match(/server mode/, stdout2)
 
       sh!(*steep, "server", "stop", err: [:child, :out])

--- a/test/logic_type_interpreter_test.rb
+++ b/test/logic_type_interpreter_test.rb
@@ -125,22 +125,6 @@ end
 
       node = source.node.children[1]
 
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :is_a?,
-        receiver_type: parse_type("::String?"),
-        actual_method_type: parse_method_type("(::Class) -> void").yield_self do |method_type|
-          method_type.with(
-            type: method_type.type.with(
-              return_type: AST::Types::Logic::ReceiverIsArg.new()
-            )
-          )
-        end,
-        method_decls: [],
-        return_type: AST::Types::Logic::ReceiverIsArg.new()
-      )
-
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Logic::ReceiverIsArg.new(), nil)
       typing.add_typing(dig(node, 0), parse_type("::String?"), nil)
@@ -166,22 +150,6 @@ end
 
       node = source.node.children[1]
 
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :is_a?,
-        receiver_type: parse_type("::String?"),
-        actual_method_type: parse_method_type("() -> bool").yield_self do |method_type|
-          method_type.with(
-            type: method_type.type.with(
-              return_type: AST::Types::Logic::ReceiverIsNil.new()
-            )
-          )
-        end,
-        method_decls: [],
-        return_type: AST::Types::Logic::ReceiverIsNil.new()
-      )
-
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Logic::ReceiverIsNil.new(), nil)
       typing.add_typing(dig(node, 0), parse_type("::String?"), nil)
@@ -205,22 +173,6 @@ end
       source = parse_ruby("email = foo; String === email")
 
       node = source.node.children[1]
-
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :is_a?,
-        receiver_type: parse_type("singleton(::String)"),
-        actual_method_type: parse_method_type("(untyped) -> bool").yield_self do |method_type|
-          method_type.with(
-            type: method_type.type.with(
-              return_type: AST::Types::Logic::ArgIsReceiver.new()
-            )
-          )
-        end,
-        method_decls: [],
-        return_type: AST::Types::Logic::ArgIsReceiver.new()
-      )
 
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Logic::ArgIsReceiver.new(), nil)
@@ -247,22 +199,6 @@ end
 
       node = source.node.children[1]
 
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :is_a?,
-        receiver_type: parse_type("::String"),
-        actual_method_type: parse_method_type("(untyped) -> bool").yield_self do |method_type|
-          method_type.with(
-            type: method_type.type.with(
-              return_type: AST::Types::Logic::ArgEqualsReceiver.new()
-            )
-          )
-        end,
-        method_decls: [],
-        return_type: AST::Types::Logic::ArgEqualsReceiver.new()
-      )
-
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Logic::ArgEqualsReceiver.new(), nil)
       typing.add_typing(dig(node, 0), parse_type("::String"), nil)
@@ -286,22 +222,6 @@ end
       source = parse_ruby("klass = Foo; klass < String")
 
       node = source.node.children[1]
-
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :<,
-        receiver_type: parse_type("singleton(::Object)"),
-        actual_method_type: parse_method_type("(::Module) -> bool?").yield_self do |method_type|
-          method_type.with(
-            type: method_type.type.with(
-              return_type: AST::Types::Logic::ArgIsAncestor.new()
-            )
-          )
-        end,
-        method_decls: [],
-        return_type: AST::Types::Logic::ArgIsAncestor.new()
-      )
 
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Logic::ArgIsAncestor.new(), nil)
@@ -328,22 +248,6 @@ end
       source = parse_ruby("email = foo; !email")
 
       node = source.node.children[1]
-
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :is_a?,
-        receiver_type: parse_type("::String?"),
-        actual_method_type: parse_method_type("() -> bool").yield_self do |method_type|
-          method_type.with(
-            type: method_type.type.with(
-              return_type: AST::Types::Logic::Not.new()
-            )
-          )
-        end,
-        method_decls: [],
-        return_type: AST::Types::Logic::Not.new()
-      )
 
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Logic::Not.new(), nil)
@@ -383,16 +287,6 @@ end
       source = parse_ruby("email = foo; email.void!")
 
       node = source.node.children[1]
-
-      call = TypeInference::MethodCall::Typed.new(
-        node: node,
-        context: TypeInference::MethodCall::TopLevelContext.new,
-        method_name: :void!,
-        receiver_type: parse_type("::String"),
-        actual_method_type: parse_method_type("() -> void"),
-        method_decls: [],
-        return_type: AST::Types::Void.new()
-      )
 
       typing = Typing.new(source: source, root_context: nil, cursor: nil)
       typing.add_typing(dig(node), AST::Types::Void.new(), nil)

--- a/test/multiple_assignment_test.rb
+++ b/test/multiple_assignment_test.rb
@@ -26,7 +26,7 @@ class MultipleAssignmentTest < Minitest::Test
   def test_tuple_assignment
     with_checker do
       source = parse_ruby("a, *b, c = _")
-      mlhs, rhs = source.node.children
+      mlhs, _ = source.node.children
 
       masgn = MultipleAssignment.new()
       asgns = masgn.expand(mlhs, parse_type("[::Integer, ::String, ::Symbol]"), false)
@@ -47,7 +47,7 @@ class MultipleAssignmentTest < Minitest::Test
   def test_tuple_assignment_optional
     with_checker do
       source = parse_ruby("a, *b, c = _")
-      mlhs, rhs = source.node.children
+      mlhs, _ = source.node.children
 
       masgn = MultipleAssignment.new()
       asgns = masgn.expand(mlhs, parse_type("[::Integer, ::String, ::Symbol]"), true)
@@ -68,7 +68,7 @@ class MultipleAssignmentTest < Minitest::Test
   def test_array_assignment
     with_checker do
       source = parse_ruby("a, *b, c = _")
-      mlhs, rhs = source.node.children
+      mlhs, _ = source.node.children
 
       masgn = MultipleAssignment.new()
       asgns = masgn.expand(mlhs, parse_type("::Array[::Integer]"), false)
@@ -89,7 +89,7 @@ class MultipleAssignmentTest < Minitest::Test
   def test_array_assignment_optional
     with_checker do
       source = parse_ruby("a, *b, c = _")
-      mlhs, rhs = source.node.children
+      mlhs, _ = source.node.children
 
       masgn = MultipleAssignment.new()
       asgns = masgn.expand(mlhs, parse_type("::Array[::Integer]"), true)
@@ -109,8 +109,6 @@ class MultipleAssignmentTest < Minitest::Test
 
   def test_hint_for_mlhs
     with_checker do
-      env =
-
       masgn = MultipleAssignment.new()
 
       masgn.hint_for_mlhs(

--- a/test/signature_help_provider_test.rb
+++ b/test/signature_help_provider_test.rb
@@ -68,31 +68,31 @@ class SignatureHelpProviderTest < Minitest::Test
       RUBY
 
       SignatureHelpProvider.new(source: source, subtyping: checker).tap do |provider|
-        items, index = provider.run(line: 1, column: 14)
+        items, _ = provider.run(line: 1, column: 14)
         assert_equal 0, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 18)
+        items, _ = provider.run(line: 1, column: 18)
         assert_equal 1, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 23)
+        items, _ = provider.run(line: 1, column: 23)
         assert_equal 2, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 27)
+        items, _ = provider.run(line: 1, column: 27)
         assert_equal 2, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 31)
+        items, _ = provider.run(line: 1, column: 31)
         assert_equal 3, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 40)
+        items, _ = provider.run(line: 1, column: 40)
         assert_equal 4, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 50)
+        items, _ = provider.run(line: 1, column: 50)
         assert_equal 5, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 59)
+        items, _ = provider.run(line: 1, column: 59)
         assert_equal 5, items.first.active_parameter
 
-        items, index = provider.run(line: 1, column: 68)
+        items, _ = provider.run(line: 1, column: 68)
         assert_equal 5, items.first.active_parameter
       end
     end
@@ -119,34 +119,34 @@ class SignatureHelpProviderTest < Minitest::Test
       RUBY
 
       SignatureHelpProvider.new(source: source, subtyping: checker).tap do |provider|
-        items, index = provider.run(line: 1, column: 14)
+        items, _ = provider.run(line: 1, column: 14)
         assert_equal 0, items.first.active_parameter
 
-        items, index = provider.run(line: 2, column: 17)
+        items, _ = provider.run(line: 2, column: 17)
         assert_equal 1, items.first.active_parameter
 
-        items, index = provider.run(line: 3, column: 21)
+        items, _ = provider.run(line: 3, column: 21)
         assert_equal 2, items.first.active_parameter
 
-        items, index = provider.run(line: 4, column: 25)
+        items, _ = provider.run(line: 4, column: 25)
         assert_equal 2, items.first.active_parameter
 
-        items, index = provider.run(line: 5, column: 29)
+        items, _ = provider.run(line: 5, column: 29)
         assert_equal 2, items.first.active_parameter
 
-        items, index = provider.run(line: 6, column: 36)
+        items, _ = provider.run(line: 6, column: 36)
         assert_equal 3, items.first.active_parameter
 
-        items, index = provider.run(line: 7, column: 47)
+        items, _ = provider.run(line: 7, column: 47)
         assert_equal 4, items.first.active_parameter
 
-        items, index = provider.run(line: 8, column: 47)
+        items, _ = provider.run(line: 8, column: 47)
         assert_equal 5, items.first.active_parameter
 
-        items, index = provider.run(line: 9, column: 47)
+        items, _ = provider.run(line: 9, column: 47)
         assert_equal 5, items.first.active_parameter
 
-        items, index = provider.run(line: 10, column: 57)
+        items, _ = provider.run(line: 10, column: 57)
         assert_equal 5, items.first.active_parameter
       end
     end

--- a/test/source/ignore_ranges_test.rb
+++ b/test/source/ignore_ranges_test.rb
@@ -53,7 +53,7 @@ class SourceIgnoreRangesTest < Minitest::Test
   end
 
   def test_ignore?
-    ranges, buf = parse(<<~RUBY)
+    ranges, _ = parse(<<~RUBY)
       # steep:ignore:start
 
 

--- a/test/source_test.rb
+++ b/test/source_test.rb
@@ -355,7 +355,7 @@ end
 
   def test_empty_clauses
     with_factory do |factory|
-      source = Steep::Source.parse(<<-EOF, path: Pathname("foo.rb"), factory: factory)
+      Steep::Source.parse(<<-EOF, path: Pathname("foo.rb"), factory: factory)
 case
 when bar
 else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -681,7 +681,6 @@ module TypeConstructionHelper
       instance_type = AST::Builtin::Object.instance_type
     end
 
-    rbs_env = checker.factory.env
     type_env = Steep::TypeInference::TypeEnvBuilder.new(
       Steep::TypeInference::TypeEnvBuilder::Command::ImportGlobalDeclarations.new(checker.factory),
       Steep::TypeInference::TypeEnvBuilder::Command::ImportInstanceVariableAnnotations.new(annotations),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,14 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 # @rbs use Steep::*
 
-Encoding.default_external = Encoding::UTF_8
+# Setting Encoding.default_external prints a warning under `ruby -w`. Silence it because
+# the setting is intentional here.
+begin
+  verbose, $VERBOSE = $VERBOSE, nil
+  Encoding.default_external = Encoding::UTF_8
+ensure
+  $VERBOSE = verbose
+end
 
 require "bundler/setup"
 require 'steep'

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -462,6 +462,7 @@ class TypeCheckWorkerTest < Minitest::Test
           guid: "guid",
           path: RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs"
         )
+        worker.handle_job(job)
 
         # handle_job doesn't write anything because the #current_type_check_guid is different.
         worker.writer.write({ method: "sentinel"})
@@ -617,6 +618,7 @@ class TypeCheckWorkerTest < Minitest::Test
         end
 
         job = TypeCheckWorker::TypeCheckCodeJob.new(guid: "guid", path: current_dir + "lib/hello.rb")
+        worker.handle_job(job)
 
         # handle_job doesn't write anything because the #current_type_check_guid is different.
         worker.writer.write({ method: "sentinel"})

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -676,7 +676,7 @@ class TypeCheckWorkerTest < Minitest::Test
     end
   end
 
-    def test_handle_job_typecheck_inline__implementation_error
+  def test_handle_job_typecheck_inline__implementation_error
     in_tmpdir do
       with_master_read_queue do |master_read_queue|
         project = Project.new(steepfile_path: current_dir + "Steepfile")

--- a/test/type_construction_test.rb
+++ b/test/type_construction_test.rb
@@ -114,7 +114,7 @@ z = x
       EOF
 
       with_standard_construction(checker, source, cursor: [1, 0]) do |construction, typing|
-        pair = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal parse_type("::Integer"), typing.type_of(node: source.node)
 
@@ -1760,7 +1760,7 @@ a, @b = _ = nil
       EOF
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, constr, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_all!(typing.errors) do |error|
           assert_instance_of Diagnostic::Ruby::UnknownInstanceVariable, error
@@ -2049,7 +2049,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -2065,7 +2065,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal 1, typing.errors.size
 
@@ -2359,7 +2359,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_all!(typing.errors) do |error|
           assert_instance_of Diagnostic::Ruby::UndeclaredMethodDefinition, error
@@ -3211,7 +3211,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        pair = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -4304,7 +4304,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -5470,7 +5470,7 @@ q
 EOF
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -5508,7 +5508,7 @@ x = A::B::C
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -6808,7 +6808,7 @@ y = test.bar("foo")      # With a constraint: String <: A
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, constr = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal 2, typing.errors.size
 
@@ -6856,7 +6856,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, constr = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error typing, size: 3 do |errors|
           assert_any!(errors) do |error|
@@ -6893,7 +6893,7 @@ test.foo(&->(x) { "" })
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, constr = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal 1, typing.errors.size
 
@@ -6928,7 +6928,7 @@ test.foo(&p)
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, constr = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal 1, typing.errors.size
 
@@ -7249,7 +7249,7 @@ x = "foo"
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -7267,7 +7267,7 @@ x = "foo"
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -7301,7 +7301,7 @@ x = { }
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -7391,7 +7391,7 @@ x = 30.is_a?(String) || false
 EOF
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -7439,7 +7439,7 @@ x.is_a?(String) && y && x + y
 EOF
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -7461,7 +7461,7 @@ x.is_a?(Float) || y || (z = x; z = y)
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -7771,7 +7771,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error typing, size: 2 do |errors|
           assert_all!(errors) do |error|
@@ -7807,7 +7807,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error typing
       end
     end
@@ -7832,7 +7832,7 @@ a = case x
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error typing
       end
     end
@@ -7859,7 +7859,7 @@ a = case x
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error typing
       end
     end
@@ -7878,7 +7878,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error typing
       end
     end
@@ -8018,7 +8018,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8042,7 +8042,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do | error|
@@ -8078,7 +8078,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8116,7 +8116,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8137,7 +8137,7 @@ TestNilBlock.new.bar(&nil)
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error typing, size: 1 do |errors|
           assert_any!(errors) do |error|
@@ -8173,7 +8173,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -8207,7 +8207,7 @@ Issue328::Foo.new.to_h { [1, ""] }
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8225,7 +8225,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8252,7 +8252,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8277,7 +8277,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8317,7 +8317,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8341,7 +8341,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -8365,7 +8365,7 @@ Ruby3::Foo.new().bar { _1 }
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 2) do |errors|
           assert_any!(errors) do |error|
@@ -8415,7 +8415,7 @@ Ruby3::Foo.new().bar { it }
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 2) do |errors|
           assert_any!(errors) do |error|
@@ -8449,7 +8449,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_typing_error(typing, size: 1) do |errors|
           assert_all!(errors) do |error|
             assert_instance_of Diagnostic::Ruby::UndeclaredMethodDefinition, error
@@ -8550,7 +8550,7 @@ MissingArgs::Foo.new&.csendkw
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 2) do |errors|
           assert_any!(errors) do |error|
@@ -8580,7 +8580,7 @@ EachNoParam.new.each(*a)
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -8603,7 +8603,7 @@ ints = ["1", ["2", nil]]
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do
           assert_any!(typing.errors) do |error|
@@ -8730,7 +8730,7 @@ cdr = A.new.cdr(a)
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_no_error(typing)
 
@@ -8757,7 +8757,7 @@ end
       RUBY
 
       with_standard_construction(checker, source, cursor: [4, 5]) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal parse_type("[X, untyped]", variables: [:X]), typing.cursor_context.context.type_env[:z]
       end
@@ -8784,7 +8784,7 @@ end
       RUBY
 
       with_standard_construction(checker, source, cursor: [7, 5]) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal parse_type("[X, untyped]", variables: [:X]), typing.cursor_context.context.type_env[:z]
       end
@@ -8808,7 +8808,7 @@ end
       RUBY
 
       with_standard_construction(checker, source, cursor: [4, 5]) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_equal parse_type("[X, untyped]", variables: [:X]), typing.cursor_context.context.type_env[:z]
       end
@@ -8979,7 +8979,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9006,7 +9006,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9032,7 +9032,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9050,7 +9050,7 @@ foo = -> (&block) { block[80]; 123 }
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9069,7 +9069,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 2) do |errors|
           assert_any!(errors) do |error|
@@ -9198,7 +9198,7 @@ result = b.compact
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9228,7 +9228,7 @@ result = b.compact
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9302,7 +9302,7 @@ c = _ = nil
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        _, constr = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9461,7 +9461,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           errors[0].tap do |error|
@@ -9487,7 +9487,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error(typing)
       end
@@ -9508,7 +9508,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 2) do |errors|
           assert_any!(errors) do |error|
@@ -9544,7 +9544,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error(typing)
       end
@@ -9578,7 +9578,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9600,7 +9600,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error(typing)
       end
@@ -9623,7 +9623,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           errors[0].tap do |error|
@@ -9650,7 +9650,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9672,7 +9672,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9695,7 +9695,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9718,7 +9718,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9740,7 +9740,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9759,7 +9759,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9778,7 +9778,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9801,7 +9801,7 @@ ref.value + ""
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9825,7 +9825,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9844,7 +9844,7 @@ reader.read("123", -> () { 123 })
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error typing
         assert_equal parse_type("::Integer | ::String"), type
@@ -9867,7 +9867,7 @@ ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_equal parse_type("::Integer"), context.type_env[:ok]
         assert_equal parse_type("::Integer"), context.type_env[:ng]
@@ -9888,7 +9888,7 @@ ng = Issue610::Foo.new.ng(123) do -> (x) { x + 1 } end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_no_error typing
 
@@ -9920,7 +9920,7 @@ end
 -> (_) { 123 }
 RUBY
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -9943,7 +9943,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error typing
 
@@ -9964,7 +9964,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error typing
 
@@ -9986,7 +9986,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error typing
 
@@ -10053,7 +10053,7 @@ x = x.itself
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error typing
       end
     end
@@ -10074,7 +10074,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_typing_error(typing, size: 1) do |errors|
           errors[0].tap do |error|
             assert_instance_of Diagnostic::Ruby::InsufficientPositionalArguments, error
@@ -10225,7 +10225,7 @@ end
 RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _ = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10253,7 +10253,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -10276,7 +10276,7 @@ end
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_no_error typing
         assert_equal parse_type("::Integer | nil"), context.type_env[:bar]
@@ -10294,7 +10294,7 @@ hash = array #: Hash[Symbol, String]
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10319,7 +10319,7 @@ name = 3 #: String?
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10348,7 +10348,7 @@ z = [1].map { _1.to_s } #$ Object
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_no_error typing
 
@@ -10374,7 +10374,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 3) do |errors|
           assert_any!(errors) do |error|
@@ -10429,7 +10429,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_any!(typing.errors) do |error|
           assert_instance_of Diagnostic::Ruby::UnknownConstant, error
@@ -10481,7 +10481,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10516,7 +10516,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10550,7 +10550,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error(typing)
       end
@@ -10574,7 +10574,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error(typing)
       end
@@ -10592,7 +10592,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error(typing)
       end
@@ -10608,7 +10608,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error(typing)
         assert_equal parse_type("::String"), type
@@ -10626,7 +10626,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error(typing)
         assert_equal parse_type("::String"), type
@@ -10644,7 +10644,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_all!(typing.errors) do |error|
           assert_operator error, :is_a?, Diagnostic::Ruby::NoMethod
@@ -10669,7 +10669,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error(typing)
       end
     end
@@ -10686,7 +10686,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
         assert_no_error(typing)
         assert_equal parse_type("::Integer"), context.type_env[:a]
         assert_equal parse_type("::String"), context.type_env[:b]
@@ -10703,7 +10703,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
         assert_no_error(typing)
         assert_equal parse_type("::Integer"), context.type_env[:a]
         assert_equal parse_type("nil"), context.type_env[:b]
@@ -10722,7 +10722,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        _, _, context = construction.synthesize(source.node)
         assert_no_error(typing)
         assert_equal parse_type("::Integer?"), context.type_env[:a]
         assert_equal parse_type("::Integer?"), context.type_env[:b]
@@ -10749,7 +10749,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error(typing)
       end
     end
@@ -10773,7 +10773,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10805,7 +10805,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        type, _, _ = construction.synthesize(source.node)
 
         assert_no_error typing
 
@@ -10829,7 +10829,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -10847,7 +10847,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -10869,7 +10869,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_no_error typing
       end
@@ -10891,7 +10891,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10916,7 +10916,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10938,7 +10938,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10961,7 +10961,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
 
         assert_typing_error(typing, size: 1) do |errors|
           assert_any!(errors) do |error|
@@ -10984,7 +10984,7 @@ z = AppTest.new.foo(1, 2) #$ Integer, Integer, String
       RUBY
 
       with_standard_construction(checker, source) do |construction, typing|
-        type, _, context = construction.synthesize(source.node)
+        construction.synthesize(source.node)
         assert_no_error typing
       end
     end

--- a/test/type_factory_test.rb
+++ b/test/type_factory_test.rb
@@ -256,8 +256,6 @@ class TypeFactoryTest < Minitest::Test
 
   def test_method_type
     with_factory() do |factory|
-      self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
-
       factory.method_type(parse_method_type("[A] (A) { (A, B) -> nil } -> void")).yield_self do |type|
         assert_equal "[A] (A) { (A, B) -> nil } -> void", type.to_s
       end
@@ -281,8 +279,6 @@ class TypeFactoryTest < Minitest::Test
 
   def test_bounded_method_type
     with_factory() do |factory|
-      self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
-
       factory.method_type(parse_method_type("[A < Integer] (A) -> void")).yield_self do |type|
         assert_equal "[A < Integer] (A) -> void", type.to_s
       end
@@ -305,8 +301,6 @@ class TypeFactoryTest < Minitest::Test
 
   def test_method_type_1
     with_factory() do |factory|
-      self_type = factory.type(parse_type("::Array[X]", variables: [:X]))
-
       parse_method_type("[A] (A) { (A, B) -> nil } -> void").tap do |original|
         type = factory.method_type_1(factory.method_type(original))
         assert_equal original, type


### PR DESCRIPTION
`rake test` runs the test suite with `ruby -w`, which printed about 190 warnings. This PR fixes all of them, one commit per change:

* Fix `Applying#map_type` to use the mapped type arguments (a real bug found via an unused variable warning)
* Call `handle_job` in two tests that verify jobs are skipped -- they constructed the job but never handled it
* Fix `assigned but unused variable` warnings by renaming unused assignment targets to `_` and dropping side-effect-free dead assignments
* Fix `mismatched indentations` warnings by aligning `end` with its `def`
* Fix `method redefined` warning by dropping `attr_reader :service`, which `TypeCheckWorker#service` overrode
* Silence the intentional `setting Encoding.default_external` warning in `test_helper.rb`
