### PR TITLE
Update RBS to 4.2.0.pre.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,4 @@ group :development, optional: true do
 end
 
 # gem "rbs", path: "../rbs"
-# gem "rbs", git: "https://github.com/ruby/rbs.git", branch: "master"
+gem "rbs", "4.2.0.pre.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (4.0.3)
+    rbs (4.2.0.pre.1)
       logger
       prism (>= 1.6.0)
       tsort
@@ -97,6 +97,7 @@ DEPENDENCIES
   minitest-hooks
   minitest-slow_test
   rake
+  rbs (= 4.2.0.pre.1)
   stackprof
   steep!
   vernier (~> 1.5)

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -592,11 +592,31 @@ module Steep
           )
         end
 
+        to_ary_entry = Shape::Entry.new(
+          method_name: :to_ary,
+          private_method: false,
+          overloads: [
+            Shape::MethodOverload.new(
+              MethodType.new(
+                type_params: [],
+                type: Function.new(
+                  params: Function::Params.empty,
+                  return_type: tuple,
+                  location: nil
+                ),
+                block: nil
+              ),
+              []
+            )
+          ]
+        )
+
         shape.methods[:[]] = aref_entry
         shape.methods[:[]=] = aref_update_entry
         shape.methods[:fetch] = fetch_entry
         shape.methods[:first] = first_entry
         shape.methods[:last] = last_entry
+        shape.methods[:to_ary] = to_ary_entry
 
         shape
       end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -1760,6 +1760,11 @@ module Steep
             else
               if hint
                 tuples = select_flatten_types(hint) {|type| type.is_a?(AST::Types::Tuple) } #: Array[AST::Types::Tuple]
+                if tuples.empty?
+                  if converted = try_convert(hint, :to_ary)
+                    tuples = select_flatten_types(converted) {|type| type.is_a?(AST::Types::Tuple) } #: Array[AST::Types::Tuple]
+                  end
+                end
                 unless tuples.empty?
                   fallback_pair = nil #: Pair?
                   tuples.each do |tuple|

--- a/smoke/array/test_expectations.yml
+++ b/smoke/array/test_expectations.yml
@@ -13,12 +13,10 @@
       Cannot find compatible overloading of method `[]=` of type `::Array[::Integer]`
       Method types:
         def []=: (::int, ::Integer) -> ::Integer
+               | [T < ::_ToAry[E]] (::range[(::int | nil)], T) -> T
+               | (::range[(::int | nil)], ::Integer) -> ::Integer
+               | [T < ::_ToAry[E]] (::int, ::int, T) -> T
                | (::int, ::int, ::Integer) -> ::Integer
-               | (::int, ::int, ::Array[::Integer]) -> ::Array[::Integer]
-               | (::int, ::int, nil) -> nil
-               | (::Range[(::Integer | nil)], ::Integer) -> ::Integer
-               | (::Range[(::Integer | nil)], ::Array[::Integer]) -> ::Array[::Integer]
-               | (::Range[(::Integer | nil)], nil) -> nil
     code: Ruby::UnresolvedOverloading
   - range:
       start:

--- a/smoke/block/test_expectations.yml
+++ b/smoke/block/test_expectations.yml
@@ -104,8 +104,8 @@
         character: 28
     severity: ERROR
     message: |-
-      Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(::Integer) -> U(3)`
-        ::Proc <: ^(::Integer) -> U(3)
+      Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(::Integer) -> T(3)`
+        ::Proc <: ^(::Integer) -> T(3)
     code: Ruby::BlockTypeMismatch
   - range:
       start:
@@ -116,8 +116,8 @@
         character: 20
     severity: ERROR
     message: |-
-      Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(::Integer) -> U(4)`
-        ::Proc <: ^(::Integer) -> U(4)
+      Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(::Integer) -> T(4)`
+        ::Proc <: ^(::Integer) -> T(4)
     code: Ruby::BlockTypeMismatch
 - file: e.rb
   diagnostics:

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -299,6 +299,7 @@ end
 
         assert_equal([parse_method_type("() -> ::Integer")], shape.methods[:first].method_types)
         assert_equal([parse_method_type("() -> top")], shape.methods[:last].method_types)
+        assert_equal([parse_method_type("() -> [::Integer, top]")], shape.methods[:to_ary].method_types)
       end
 
       builder.shape(parse_type("[::Integer, self]"), config).tap do |shape|
@@ -319,6 +320,7 @@ end
 
         assert_equal([parse_method_type("() -> ::Integer")], shape.methods[:first].method_types)
         assert_equal([parse_method_type("() -> self")], shape.methods[:last].method_types)
+        assert_equal([parse_method_type("() -> [::Integer, self]")], shape.methods[:to_ary].method_types)
       end
     end
   end

--- a/test/interface_builder_test.rb
+++ b/test/interface_builder_test.rb
@@ -341,7 +341,7 @@ end
 
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:id) -> ::Integer"))
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name) -> ::String"))
-        assert_includes(shape.methods[:[]].method_types, parse_method_type("(::Symbol) -> (::String | ::Integer | nil)"))
+        assert_includes(shape.methods[:[]].method_types, parse_method_type("(::Hash::_Key) -> (::String | ::Integer | nil)"))
 
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:id, ::Integer) -> ::Integer"))
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:name, ::String) -> ::String"))
@@ -359,7 +359,7 @@ end
 
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:id) -> ::Integer"))
         assert_includes(shape.methods[:[]].method_types, parse_method_type("(:name) -> self"))
-        assert_includes(shape.methods[:[]].method_types, parse_method_type("(::Symbol) -> (self | ::Integer | nil)"))
+        assert_includes(shape.methods[:[]].method_types, parse_method_type("(::Hash::_Key) -> (self | ::Integer | nil)"))
 
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:id, ::Integer) -> ::Integer"))
         assert_includes(shape.methods[:[]=].method_types, parse_method_type("(:name, self) -> self"))


### PR DESCRIPTION
Update RBS to 4.2.0.pre.1 and adjust the affected standard library expectations.

RBS 4.2 models pair-like values structurally through `Hash::_Pair`, whose `to_ary` method returns a tuple. Steep now exposes `to_ary` on tuple shapes and follows that conversion when an array literal is checked against a pair-like hint, preserving precise element types for code such as `array.to_h { |item| [item.key, item.value] }`.