### PR TITLE
Point the Steepfile template, README and CLAUDE.md at rbs collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ bundle exec rake build
 **Steepfile**: Defines type checking targets
 - `check`: Directories to type check
 - `signature`: RBS signature directories
-- `library`: Standard library dependencies
-- `collection_config`: External RBS definitions
+- `library`: RBSs that rbs collection doesn't manage
+- `collection_config`: Path to `rbs_collection.yaml` (the project root one is read by default)
 - Multiple targets supported (app, test, bin)
 
 **RBS Collection**: Manages external type definitions via `rbs_collection.steep.yaml`

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Edit the `Steepfile`:
 target :app do
   check "lib"
   signature "sig"
-
-  library "pathname"
 end
 ```
+
+RBSs for the gems in `Gemfile.lock` are loaded via [rbs collection](https://github.com/ruby/rbs/blob/master/docs/collection.md), which you set up with `rbs collection init` and `rbs collection install`. Add a `library` call only for an RBS that rbs collection doesn't manage.
 
 ### 1. Declare Types
 

--- a/lib/steep/drivers/init.rb
+++ b/lib/steep/drivers/init.rb
@@ -19,8 +19,9 @@ module Steep
       #   check "app/models/**/*.rb"        # Glob
       #   # ignore "lib/templates/*.rb"
       #
-      #   # library "pathname"              # Standard libraries
-      #   # library "strong_json"           # Gems
+      #   # RBSs for the gems in Gemfile.lock are loaded via rbs collection automatically.
+      #   # Set it up with `rbs collection init` and `rbs collection install`.
+      #   # library "monitor"               # Load an RBS that rbs collection doesn't manage
       #
       #   # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
       #   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
@@ -38,7 +39,7 @@ module Steep
       #
       #   configure_code_diagnostics(D::Ruby.lenient)      # Weak type checking for test code
       #
-      #   # library "pathname"              # Standard libraries
+      #   # library "monitor"               # Load an RBS that rbs collection doesn't manage
       # end
       EOF
 

--- a/sig/test/init_command_test.rbs
+++ b/sig/test/init_command_test.rbs
@@ -13,6 +13,8 @@ class InitCommandTest < Minitest::Test
 
   def test_init: () -> untyped
 
+  def test_init_mentions_rbs_collection: () -> untyped
+
   def test_init_with_option: () -> untyped
 
   def test_existing_file: () -> untyped

--- a/test/init_command_test.rb
+++ b/test/init_command_test.rb
@@ -27,6 +27,18 @@ class InitCommandTest < Minitest::Test
     end
   end
 
+  def test_init_mentions_rbs_collection
+    in_tmpdir do
+      Dir.chdir current_dir.to_s do
+        assert_equal 0, Steep::Drivers::Init.new(stdout: stdout, stderr: stderr).run
+      end
+
+      content = (current_dir + "Steepfile").read
+      assert_match(/rbs collection init/, content)
+      assert_match(/rbs collection install/, content)
+    end
+  end
+
   def test_init_with_option
     in_tmpdir do
       Dir.chdir current_dir.to_s do


### PR DESCRIPTION

Ask a coding agent to set up RBS and Steep in a project and it usually writes a Steepfile that lists every dependency with `library`, one gem per line. `rbs collection` exists so that nobody has to maintain that list, and Steep already reads `rbs_collection.yaml` from the project root without being told to (`Project::DSL::LibraryOptions#to_library_options`), so gems in `Gemfile.lock` need no `library` call at all. The motivation, and the matching change on the RBS side, is https://github.com/ruby/rbs/issues/3093.

The places someone reads before writing a Steepfile point the other way:

* The `steep init` template explained dependencies with `library "pathname"  # Standard libraries` and `library "strong_json"  # Gems`, and never mentioned rbs collection, so hand-written `library` calls read as *the* way to load RBSs.
* `README.md` showed a Steepfile with `library "pathname"` right after `steep init`. It is read far more than the generated template.
* `CLAUDE.md` described `library` as "Standard library dependencies" -- the description this change is correcting -- in the file coding agents read before working in this repository.

The template now points at `rbs collection init` / `rbs collection install` and describes `library` as loading an RBS that rbs collection doesn't manage:

```rb
#   # RBSs for the gems in Gemfile.lock are loaded via rbs collection automatically.
#   # Set it up with `rbs collection init` and `rbs collection install`.
#   # library "monitor"               # Load an RBS that rbs collection doesn't manage
```

Not "an RBS without rbs collection": `guides/src/gem-rbs-collection/gem-rbs-collection.md` tells people to keep `library` calls for implicitly installed gems that are not in the Gemfile even when they do use rbs collection, and that wording would exclude them.

The example is `monitor` rather than `pathname` because ruby/rbs 8066053b moved `Pathname` to `core/pathname.rbs`, leaving two methods in `stdlib/pathname/0` -- `library "pathname"` demonstrates nothing. `monitor` is a non-gem standard library that rbs collection installs only when it is listed in `rbs_collection.yaml`, which is what the comment above the line claims.

A non-gem standard library can be loaded either way -- with `library` here, or listed under `gems:` in `rbs_collection.yaml` (the RBS-side change uses `socket` for that example) -- so the two templates show different options rather than contradicting each other.
