### PR TITLE
Fix `bin/steep-check.rb` for the current API

### DIFF
--- a/bin/steep-check.rb
+++ b/bin/steep-check.rb
@@ -67,7 +67,7 @@ class Command
     target.options.load_collection_lock
 
     signature_service = Steep::Project::Target.construct_env_loader(options: target.options, project: project).yield_self do |loader|
-      Steep::Services::SignatureService.load_from(loader)
+      Steep::Services::SignatureService.load_from(loader, implicitly_returns_nil: target.implicitly_returns_nil)
     end
 
     env = signature_service.latest_env
@@ -76,8 +76,8 @@ class Command
 
     signature_files.each do |path, content|
       buffer = RBS::Buffer.new(name: path.to_s, content: content)
-      buffer, dirs, decls = RBS::Parser.parse_signature(buffer)
-      env.add_signature(buffer: buffer, directives: dirs, decls: decls)
+      _, dirs, decls = RBS::Parser.parse_signature(buffer)
+      env.add_source(RBS::Source::RBS.new(buffer, dirs, decls))
       new_decls.merge(decls)
     end
 
@@ -94,7 +94,7 @@ class Command
 
     definition_builder = RBS::DefinitionBuilder.new(env: env)
     factory = AST::Types::Factory.new(builder: definition_builder)
-    builder = Interface::Builder.new(factory)
+    builder = Interface::Builder.new(factory, implicitly_returns_nil: target.implicitly_returns_nil)
     subtyping = Subtyping::Check.new(builder: builder)
 
     typings = {}


### PR DESCRIPTION
The profiling driver has not been run since `SignatureService.load_from` and
`Interface::Builder.new` gained the `implicitly_returns_nil:` keyword, and since
RBS replaced `Environment#add_signature` with `#add_source`. It raised while
loading signatures, so none of the profiling modes worked.
