### PR TITLE
Build expensive log tags only when something is logged

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -65,7 +65,7 @@ module Steep
       end
 
       def shape(type, config)
-        Steep.logger.tagged "shape(#{type})" do
+        Steep.logger.tagged(-> { "shape(#{type})" }) do
           if shape = raw_shape(type, config)
             # Optimization that skips unnecessary substitution
             if type.free_variables.include?(AST::Types::Self.instance)
@@ -277,7 +277,7 @@ module Steep
           definition = factory.definition_builder.build_singleton(type_name)
 
           definition.methods.each do |name, method|
-            Steep.logger.tagged "method = #{type_name}.#{name}" do
+            Steep.logger.tagged(-> { "method = #{type_name}.#{name}" }) do
               overloads = method.defs.map do |type_def|
                 method_name = method_name_for(type_def, name)
                 method_type = factory.method_type(type_def.type)
@@ -309,7 +309,7 @@ module Steep
           definition or raise
 
           definition.methods.each do |name, method|
-            Steep.logger.tagged "method = #{type_name}##{name}" do
+            Steep.logger.tagged(-> { "method = #{type_name}##{name}" }) do
               overloads = method.defs.map do |type_def|
                 method_name = method_name_for(type_def, name)
                 method_type = factory.method_type(type_def.type)

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -189,7 +189,7 @@ module Steep
 
         relation.type!
 
-        Steep.logger.tagged "#{relation.sub_type} <: #{relation.super_type}" do
+        Steep.logger.tagged(-> { "#{relation.sub_type} <: #{relation.super_type}" }) do
           bounds = cache_bounds(relation)
           fvs = relation.sub_type.free_variables + relation.super_type.free_variables
           cached = cache[relation, @self_type, @instance_type, @class_type, bounds]
@@ -201,7 +201,7 @@ module Steep
             else
               push_assumption(relation) do
                 check_type0(relation).tap do |result|
-                  Steep.logger.debug "result=#{result.class}"
+                  Steep.logger.debug { "result=#{result.class}" }
                   cache[relation, @self_type, @instance_type, @class_type, bounds] = result
                 end
               end
@@ -854,7 +854,7 @@ module Steep
       end
 
       def check_method_type(name, relation)
-        Steep.logger.tagged "#{name} : #{relation.sub_type} <: #{relation.super_type}" do
+        Steep.logger.tagged(-> { "#{name} : #{relation.sub_type} <: #{relation.super_type}" }) do
           relation.method!
 
           sub_type, super_type = relation

--- a/lib/steep/tagged_logging.rb
+++ b/lib/steep/tagged_logging.rb
@@ -33,7 +33,10 @@ module Steep
     end
 
     def formatted_tags
-      current_tags.map { |tag| "[#{tag}]" }.join(" ")
+      current_tags.map do |tag|
+        tag = tag.call if tag.is_a?(Proc)
+        "[#{tag}]"
+      end.join(" ")
     end
   end
 end

--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -729,7 +729,7 @@ module Steep
     end
 
     def synthesize(node, hint: nil, condition: false)
-      Steep.logger.tagged "synthesize:(#{node.location&.yield_self {|loc| loc.expression.to_s.split(/:/, 2).last } || "-"})" do
+      Steep.logger.tagged(-> { "synthesize:(#{node.location&.yield_self {|loc| loc.expression.to_s.split(/:/, 2).last } || "-"})" }) do
         Steep.logger.debug node.type
         case node.type
         when :begin, :kwbegin

--- a/sig/steep/tagged_logging.rbs
+++ b/sig/steep/tagged_logging.rbs
@@ -1,12 +1,19 @@
 module Steep
   class TaggedLogging < ::Logger
+    type tag = String | ^() -> String
+
     @thread_key: String
 
-    def tagged: [T] (String tag) { () -> T } -> T
+    # Pushes `tag` while the block runs.
+    #
+    # A tag that is expensive to render can be given as a proc, which is called only if a message
+    # is actually written while it is on the stack.
+    #
+    def tagged: [T] (tag) { () -> T } -> T
 
-    def current_tags: () -> Array[String]
+    def current_tags: () -> Array[tag]
 
-    def push_tags: (*String tags) -> Array[String]
+    def push_tags: (*tag tags) -> Array[tag]
 
     def formatted_tags: () -> String
   end


### PR DESCRIPTION
`Steep.logger.tagged` takes the tag as a string, so the hottest paths of the type
checker rendered a tag on every call and threw it away: `check_type` stringified
both sides of every relation, `Builder#shape` stringified the type of every shape,
and `synthesize` formatted a source range for every node. The default log level is
ERROR, so almost none of it was ever written.

`tagged` now also accepts a proc, and those call sites pass one. `formatted_tags`
calls it while writing a message instead of at push time; none of the call sites
reassign what the proc closes over, so the rendered tag is unchanged.

Checking `lib` single-threaded with `bin/steep-check.rb --target=app` goes from
68.5s to 61.9s, and from 92.3M to 86.4M allocated objects.
