### PR TITLE
Serve steep query/check through the language server's UNIX socket

### DIFF
--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -133,6 +133,7 @@ require "steep/server/target_group_files"
 require "steep/server/type_check_controller"
 require "steep/server/inline_source_change_detector"
 require "steep/server/master"
+require "steep/server/command_socket"
 require "steep/daemon"
 
 require "steep/project"

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -355,6 +355,9 @@ Options:
 BANNER
           handle_steepfile_option(opts, command)
           opts.on("--refork") { command.refork = true }
+          opts.on("--[no-]command-socket", "Accept `steep query`/`steep check` connections on a UNIX socket (default: true)") do |v|
+            command.command_socket = v ? true : false
+          end
           handle_jobs_option command.jobs_option, opts
           handle_logging_options opts
         end.parse!(argv)

--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -726,8 +726,9 @@ Usage: steep query diagnostics [options] [FILE ...]
 
 Description:
     Get the type check diagnostics the server has computed.
-    Connects to the running Steep server, waits for the type checking to finish, and
-    prints the diagnostics as JSONL (one JSON object per line for each file).
+    Connects to the running Steep server, reloads files changed on disk, waits for the
+    type checking to finish, and prints the diagnostics as JSONL (one JSON object per
+    line for each file).
 
     When FILEs are given, only the diagnostics of those files are printed.
     `"diagnostics": null` means the server has not type checked the file yet.

--- a/lib/steep/daemon.rb
+++ b/lib/steep/daemon.rb
@@ -43,17 +43,21 @@ module Steep
         false
       end
 
+      # Returns true when something is serving the socket, whether it is a daemon or a language server
+      #
+      # The socket is the only reliable signal: a language server records its pid elsewhere, so
+      # requiring `pid_path` here would hide it from `steep check` and `steep query`.
+      #
       def running?
-        return false unless File.exist?(pid_path) && File.exist?(socket_path)
+        return false unless File.exist?(socket_path)
 
-        pid = File.read(pid_path).to_i
-        Process.kill(0, pid)
         socket = UNIXSocket.new(socket_path)
         socket.close
         true
-      rescue Errno::ESRCH, Errno::ENOENT, Errno::ECONNREFUSED, Errno::ENOTSOCK
+      rescue Errno::ENOENT, Errno::ECONNREFUSED, Errno::ENOTSOCK
         false
       end
+
 
       def cleanup
         [socket_path, pid_path].each do |path|
@@ -64,8 +68,13 @@ module Steep
       end
 
       def start(stderr:)
+        if pid = live_pid(pid_path)
+          stderr.puts "Steep server already running (PID: #{pid})"
+          return true
+        end
+
         if running?
-          stderr.puts "Steep server already running (PID: #{File.read(pid_path).strip})"
+          stderr.puts "Another process is already serving this project (e.g. `steep langserver`)"
           return true
         end
 
@@ -106,7 +115,12 @@ module Steep
 
       def stop(stderr:)
         unless File.exist?(pid_path)
-          stderr.puts "Steep server is not running"
+          if running?
+            stderr.puts "Steep server is not running. This project is served by another process"
+            stderr.puts "(e.g. `steep langserver`), which this command does not stop."
+          else
+            stderr.puts "Steep server is not running"
+          end
           return
         end
 
@@ -129,13 +143,29 @@ module Steep
         end
         cleanup
       rescue Errno::ESRCH
-        cleanup
-        stderr.puts "Steep server was not running (cleaned up stale files)"
+        # The pid file was stale. The socket may still belong to another live server,
+        # which `cleanup` would break by deleting it.
+        if running?
+          begin
+            File.delete(pid_path)
+          rescue Errno::ENOENT
+            # Already deleted
+          end
+          stderr.puts "Removed a stale pid file. This project is served by another process."
+        else
+          cleanup
+          stderr.puts "Steep server was not running (cleaned up stale files)"
+        end
       end
 
       def status(stderr:)
         if running?
-          pid = File.read(pid_path).to_i
+          unless pid = live_pid(pid_path)
+            stderr.puts "This project is served by another process (e.g. `steep langserver`)"
+            stderr.puts "  Socket: #{socket_path}"
+            return
+          end
+
           stderr.puts "Steep server running (PID: #{pid})"
           stderr.puts "  Socket: #{socket_path}"
           stderr.puts "  Log:    #{log_path}"
@@ -166,6 +196,16 @@ module Steep
       end
 
       private
+
+      # The pid recorded in `path`, when the file exists and that process is alive
+      def live_pid(path)
+        pid = File.read(path).to_i
+        return nil unless pid > 0
+        Process.kill(0, pid)
+        pid
+      rescue Errno::ESRCH, Errno::ENOENT
+        nil
+      end
 
       def run_server(stderr:)
         project = load_project

--- a/lib/steep/drivers/langserver.rb
+++ b/lib/steep/drivers/langserver.rb
@@ -9,6 +9,7 @@ module Steep
       attr_reader :type_check_thread
       attr_reader :jobs_option
       attr_accessor :refork
+      attr_accessor :command_socket
 
       include Utils::DriverHelper
 
@@ -20,6 +21,7 @@ module Steep
         @type_check_queue = Queue.new
         @jobs_option = Utils::JobsOption.new(jobs_count_modifier: -1)
         @refork = false
+        @command_socket = true
       end
 
       def writer
@@ -50,9 +52,39 @@ module Steep
         )
         master.typecheck_automatically = true
 
-        master.start()
+        socket = start_command_socket(master)
+
+        begin
+          master.start()
+        ensure
+          socket&.stop
+        end
 
         0
+      end
+
+      # Starts accepting `steep query`/`steep check` connections on the UNIX socket
+      #
+      # Returns `nil` when the command socket is disabled, is not supported on the platform,
+      # or is already served by another process.
+      #
+      def start_command_socket(master)
+        return nil unless command_socket
+
+        configuration = Daemon::Configuration.new(base_dir: project.base_dir.to_s)
+        socket = Server::CommandSocket.new(master: master, configuration: configuration)
+
+        if socket.start
+          stderr.puts "Steep command socket is ready: #{configuration.socket_path}"
+          socket
+        else
+          stderr.puts "Steep command socket is not available: #{configuration.socket_path}"
+          nil
+        end
+      rescue NotImplementedError, StandardError => error
+        Steep.logger.error { "Failed to start command socket: #{error.inspect}" }
+        stderr.puts "Failed to start Steep command socket: #{error.message}"
+        nil
       end
     end
   end

--- a/lib/steep/drivers/query.rb
+++ b/lib/steep/drivers/query.rb
@@ -15,7 +15,7 @@ module Steep
       # @rbs return: Integer
       def run_hover(locations:)
         unless Daemon.running?
-          stderr.puts "Error: Steep daemon is not running. Start it with `steep server start`."
+          stderr.puts "Error: Steep server is not running. Start it with `steep server start` or `steep langserver`."
           return 1
         end
 
@@ -51,7 +51,7 @@ module Steep
       # @rbs return: Integer
       def run_definition(names:)
         unless Daemon.running?
-          stderr.puts "Error: Steep daemon is not running. Start it with `steep server start`."
+          stderr.puts "Error: Steep server is not running. Start it with `steep server start` or `steep langserver`."
           return 1
         end
 
@@ -74,7 +74,7 @@ module Steep
 
       def run_diagnostics(paths:)
         unless Daemon.running?
-          stderr.puts "Error: Steep daemon is not running. Start it with `steep server start`."
+          stderr.puts "Error: Steep server is not running. Start it with `steep server start` or `steep langserver`."
           return 1
         end
 

--- a/lib/steep/server/command_socket.rb
+++ b/lib/steep/server/command_socket.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+module Steep
+  module Server
+    # Accepts connections on a UNIX socket and forwards the received requests to the master
+    #
+    # Started by `steep langserver` so that CLI commands like `steep query` and `steep check` can
+    # talk to the language server the IDE is running, instead of a standalone daemon process.
+    #
+    class CommandSocket
+      LSP = LanguageServer::Protocol
+
+      # A connection from a CLI client
+      #
+      # `#write` never raises even if the client is disconnected, because it may be called from
+      # the master's write thread, which should keep running for other clients.
+      #
+      class Session
+        attr_reader :socket
+
+        def initialize(socket)
+          @socket = socket
+          @writer = LSP::Transport::Io::Writer.new(socket)
+          @mutex = Mutex.new
+          @closed = false
+        end
+
+        def write(message)
+          @mutex.synchronize do
+            return if @closed
+            @writer.write(message)
+          end
+        rescue SystemCallError, IOError
+          close()
+        end
+
+        def close
+          @mutex.synchronize do
+            @closed = true
+          end
+          begin
+            @socket.close
+          rescue IOError
+            # Already closed
+          end
+        end
+      end
+
+      attr_reader :master, :configuration
+
+      def initialize(master:, configuration:)
+        @master = master
+        @configuration = configuration
+        @server = nil
+        @accept_thread = nil
+      end
+
+      def socket_path
+        configuration.socket_path
+      end
+
+      # Binds the UNIX socket and starts accepting connections in a background thread
+      #
+      # Returns `false` without binding when another process (a standalone `steep server` daemon or
+      # another language server) is already serving on the socket.
+      #
+      def start
+        if File.exist?(socket_path)
+          if socket_alive?
+            Steep.logger.warn { "Command socket is already served by another process: #{socket_path}" }
+            return false
+          end
+
+          unless File.socket?(socket_path)
+            Steep.logger.error { "#{socket_path} exists but is not a socket, skipping command socket setup" }
+            return false
+          end
+
+          File.delete(socket_path)
+        end
+
+        @server = UNIXServer.new(socket_path)
+        File.chmod(0o600, socket_path)
+
+        @accept_thread = Thread.new do
+          Thread.current.abort_on_exception = false
+          accept_loop()
+        end
+
+        Steep.logger.info { "Command socket is ready: #{socket_path}" }
+
+        true
+      rescue Errno::EADDRINUSE
+        Steep.logger.warn { "Command socket is already served by another process: #{socket_path}" }
+        false
+      end
+
+      def stop
+        server = @server
+        @server = nil
+
+        if server
+          begin
+            server.close
+          rescue IOError
+            # Already closed
+          end
+
+          @accept_thread&.join(1)
+
+          begin
+            File.delete(socket_path)
+          rescue Errno::ENOENT
+            # Already deleted
+          end
+        end
+      end
+
+      private
+
+      def socket_alive?
+        socket = UNIXSocket.new(socket_path)
+        socket.close
+        true
+      rescue SystemCallError
+        false
+      end
+
+      def accept_loop
+        while server = @server
+          socket =
+            begin
+              server.accept
+            rescue IOError, SystemCallError => error
+              Steep.logger.info { "Command socket accept loop stopping: #{error.inspect}" }
+              break
+            end
+
+          # The loop must survive anything but the accept errors above: it runs with
+          # `abort_on_exception` disabled, so an uncaught error would kill the thread
+          # silently and every connection after it would sit in the backlog forever.
+          begin
+            Steep.logger.info { "Command socket accepted a connection" }
+
+            # `session` is passed as a thread argument: `while` shares its locals across
+            # iterations, so a block reading `session` directly would serve the session of a
+            # later iteration when the accept loop wins the race against the thread's start,
+            # leaving the accepted connection unread.
+            Thread.new(Session.new(socket)) do |session|
+              Thread.current.abort_on_exception = false
+              serve(session)
+            end
+          rescue StandardError => error
+            Steep.logger.error { "Command socket could not serve an accepted connection: #{error.inspect}" }
+            begin
+              socket.close
+            rescue IOError
+              # Already closed
+            end
+          end
+        end
+      ensure
+        Steep.logger.info { "Command socket accept loop finished" }
+      end
+
+      def serve(session)
+        reader = LSP::Transport::Io::Reader.new(session.socket)
+        reader.read do |message|
+          Steep.logger.info { "Command socket received message: method=#{message[:method] || "-"}, id=#{message[:id] || "-"}" }
+          master.process_command_socket_message(message, session)
+        end
+      rescue IOError, SystemCallError => error
+        Steep.logger.warn { "Command socket client error: #{error.inspect}" }
+      ensure
+        Steep.logger.info { "Command socket connection closed" }
+        master.finish_command_socket_session(session)
+        session.close
+      end
+    end
+  end
+end

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -203,6 +203,7 @@ module Steep
         @refork_mutex = Mutex.new
         @need_to_refork = refork
         @typecheck_quiescent_callbacks = []
+        @project_file_mtimes = nil
         @command_socket_requests = {}
         @command_socket_mutex = Mutex.new
 
@@ -426,6 +427,8 @@ module Steep
                 progress.end()
               end
 
+              reset_project_file_mtimes()
+
               if file_system_watcher_supported?
                 setup_file_system_watcher()
               end
@@ -451,6 +454,7 @@ module Steep
 
             unless controller.open_paths.include?(path)
               updated_watched_files << path
+              record_project_file_mtime(path)
 
               case type
               when LSP::Constant::FileChangeType::CREATED, LSP::Constant::FileChangeType::CHANGED
@@ -1197,7 +1201,12 @@ module Steep
           return
         end
 
-        job_queue << ReceiveMessageJob.new(source: :client, message: message)
+        # Reload files changed on disk before processing, because command socket clients
+        # modify files without sending `didChange` notifications
+        job_queue << -> do
+          sync_project_files_from_disk()
+          process_message_from_client(message)
+        end
       rescue ClosedQueueError
         Steep.logger.warn { "Command socket: server is shutting down" }
       end
@@ -1238,6 +1247,116 @@ module Steep
 
         sessions.uniq!
         sessions.each {|session| session.write(message) }
+      end
+
+      # Records the mtimes of all project files, as the baseline of `#sync_project_files_from_disk`
+      def reset_project_file_mtimes
+        mtimes = {} #: Hash[Pathname, Time?]
+        each_project_file_path do |path|
+          mtimes[path] = file_mtime(path)
+        end
+        @project_file_mtimes = mtimes
+      end
+
+      def record_project_file_mtime(path)
+        if mtimes = @project_file_mtimes
+          mtimes[path] = file_mtime(path)
+        end
+      end
+
+      def file_mtime(path)
+        File.mtime(path)
+      rescue SystemCallError
+        nil
+      end
+
+      def each_project_file_path(&block)
+        loader = Services::FileLoader.new(base_dir: project.base_dir)
+        project.targets.each do |target|
+          loader.each_path_in_target(target) do |relative_path|
+            yield project.absolute_path(relative_path)
+          end
+        end
+      end
+
+      # Detects files changed on disk since the last load/sync, and reloads them
+      #
+      # Skips files open in the editor because the client owns their contents.
+      # Does nothing until the initial project load finishes.
+      #
+      def sync_project_files_from_disk
+        mtimes = @project_file_mtimes or return
+
+        changes = {} #: Hash[Pathname, Symbol]
+        seen = Set[] #: Set[Pathname]
+
+        each_project_file_path do |path|
+          next if seen.include?(path)
+          seen << path
+
+          mtime = file_mtime(path)
+          recorded = mtimes[path]
+
+          case
+          when recorded.nil? && mtime
+            changes[path] = mtimes.key?(path) ? :changed : :created
+          when recorded && mtime.nil?
+            changes[path] = :deleted
+          when recorded != mtime
+            changes[path] = :changed
+          end
+
+          mtimes[path] = mtime
+        end
+
+        deleted_paths = mtimes.keys.select {|path| !seen.include?(path) && mtimes[path] && file_mtime(path).nil? }
+        deleted_paths.each do |path|
+          changes[path] = :deleted
+          mtimes[path] = nil
+        end
+
+        changes.delete_if {|path, _| controller.open_paths.include?(path) }
+        return if changes.empty?
+
+        Steep.logger.info { "Command socket: reloading #{changes.size} file(s) changed on disk" }
+
+        changes.each do |path, type|
+          content =
+            if type == :deleted
+              ""
+            else
+              begin
+                path.read
+              rescue SystemCallError
+                next
+              end
+            end
+
+          case
+          when controller.code_path?(path)
+            controller.add_dirty_code_path(path)
+          when controller.signature_path?(path)
+            controller.add_dirty_signature_path(path)
+          when controller.inline_path?(path)
+            controller.add_dirty_inline_path(path, content)
+          end
+
+          broadcast_notification(CustomMethods::FileReset.notification({ uri: PathHelper.to_uri(path).to_s, content: content }))
+        end
+
+        if typecheck_automatically
+          start_type_checking_queue.execute do
+            job_queue.push(
+              -> do
+                start_type_check(
+                  last_request: current_type_check_request,
+                  progress: work_done_progress(SecureRandom.uuid),
+                  needs_response: false
+                )
+              end
+            )
+          end
+        end
       end
 
       def work_done_progress(guid)

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -186,6 +186,9 @@ module Steep
       attr_accessor :typecheck_automatically
       attr_reader :start_type_checking_queue
 
+      # Type check requests waiting for the current type check to finish
+      attr_reader :pending_typecheck_requests
+
       # Callbacks to be called when no type check is running anymore
       attr_reader :typecheck_quiescent_callbacks
 
@@ -203,6 +206,7 @@ module Steep
         @refork_mutex = Mutex.new
         @need_to_refork = refork
         @typecheck_quiescent_callbacks = []
+        @pending_typecheck_requests = []
         @project_file_mtimes = nil
         @command_socket_requests = {}
         @command_socket_mutex = Mutex.new
@@ -694,7 +698,7 @@ module Steep
             request.inline_paths << [target_name.to_sym, Pathname(path)]
           end
 
-          start_type_check(request: request, last_request: nil)
+          start_type_check(request: request, last_request: current_type_check_request)
 
         when CustomMethods::TypeCheckGroups::METHOD
           params = message[:params] #: CustomMethods::TypeCheckGroups::params
@@ -824,6 +828,17 @@ module Steep
 
       def start_type_check(request: nil, last_request:, progress: nil, include_unchanged: false, report_progress_threshold: 10, needs_response: nil)
         Steep.logger.tagged "#start_type_check(#{progress&.guid || request&.guid}, #{last_request&.guid}" do
+          if (current = current_type_check_request) && typecheck_request_from_command_socket?(current)
+            # Never supersede a type check that a command socket client is waiting for
+            if request
+              Steep.logger.info { "Queueing type check request #{request.guid} until the command socket request finishes" }
+              pending_typecheck_requests << request
+            else
+              Steep.logger.info { "Deferring automatic type checking until the command socket request finishes" }
+            end
+            return
+          end
+
           if last_request
             finish_type_check(last_request)
           end
@@ -903,7 +918,7 @@ module Steep
               finish_type_check(current)
               @current_type_check_request = nil
               refork_workers
-              flush_typecheck_quiescent_callbacks()
+              start_pending_typecheck()
             end
           end
         end
@@ -1065,11 +1080,33 @@ module Steep
           end
         end
 
-        if current_type_check_request
+        if current_type_check_request || !pending_typecheck_requests.empty?
           typecheck_quiescent_callbacks << block
         else
           yield
         end
+      end
+
+      # Starts the next queued type check request if any, or the automatic type check for dirty paths
+      #
+      # Calls the quiescent callbacks when nothing is left to type check.
+      #
+      def start_pending_typecheck
+        while request = pending_typecheck_requests.shift
+          start_type_check(request: request, last_request: nil)
+          return if current_type_check_request
+        end
+
+        if typecheck_automatically && initialize_params
+          guid = SecureRandom.uuid
+          if request = controller.make_request(guid: guid, progress: work_done_progress(guid))
+            request.needs_response = false
+            start_type_check(request: request, last_request: nil)
+            return if current_type_check_request
+          end
+        end
+
+        flush_typecheck_quiescent_callbacks()
       end
 
       # Calls the waiting quiescent callbacks, once a type check for the paths that went dirty
@@ -1247,6 +1284,12 @@ module Steep
 
         sessions.uniq!
         sessions.each {|session| session.write(message) }
+      end
+
+      def typecheck_request_from_command_socket?(request)
+        @command_socket_mutex.synchronize do
+          @command_socket_requests.key?(request.guid)
+        end
       end
 
       # Records the mtimes of all project files, as the baseline of `#sync_project_files_from_disk`

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -203,6 +203,8 @@ module Steep
         @refork_mutex = Mutex.new
         @need_to_refork = refork
         @typecheck_quiescent_callbacks = []
+        @command_socket_requests = {}
+        @command_socket_mutex = Mutex.new
 
         @controller = TypeCheckController.new(project: project)
         @result_controller = ResultController.new()
@@ -249,7 +251,7 @@ module Steep
                 case job.dest
                 when :client
                   Steep.logger.info { "Processing SendMessageJob: dest=client, method=#{job.message[:method] || "-"}, id=#{job.message[:id] || "-"}" }
-                  writer.write job.message
+                  write_message_to_client(job.message)
                 when WorkerProcess
                   refork_mutex.synchronize do
                     Steep.logger.info { "Processing SendMessageJob: dest=#{job.dest.name}, method=#{job.message[:method] || "-"}, id=#{job.message[:id] || "-"}" }
@@ -1127,6 +1129,115 @@ module Steep
             )
           end
         end
+      end
+
+      # Methods that command socket clients cannot send because they control the server lifecycle
+      # The only methods a command socket client may send: what `steep check` and
+      # `steep query` use. Everything else is rejected -- lifecycle methods because the
+      # server belongs to whoever started it, and document synchronization because the
+      # LSP client owns the content of the files it opens.
+      COMMAND_SOCKET_ALLOWED_METHODS = [
+        CustomMethods::TypeCheck::METHOD,
+        CustomMethods::Query__Diagnostics::METHOD,
+        CustomMethods::Query__Definition::METHOD,
+        "textDocument/hover",
+        "$/ping"
+      ].freeze
+
+      # Notifications that are copied to command socket sessions with a pending `$/steep/typecheck` request
+      COMMAND_SOCKET_FORWARDED_NOTIFICATIONS = ["textDocument/publishDiagnostics", "window/showMessage"].freeze
+
+      # Processes a message received from a command socket client
+      #
+      # Requests are assigned a fresh id and enqueued as if they came from the LSP client,
+      # and the responses are routed back to the session through `#write_message_to_client`.
+      #
+      # May be called from any thread.
+      #
+      def process_command_socket_message(message, session)
+        method = message[:method]
+        id = message[:id]
+
+        if method && !COMMAND_SOCKET_ALLOWED_METHODS.include?(method.to_s)
+          Steep.logger.warn { "Command socket: rejected `#{method}`" }
+          if id
+            session.write({
+              id: id,
+              error: {
+                code: LSP::Constant::ErrorCodes::INVALID_REQUEST,
+                message: "`#{method}` is not allowed through the command socket"
+              }
+            })
+          end
+          return
+        end
+
+        unless initialize_params
+          if id
+            session.write({
+              id: id,
+              error: {
+                code: LSP::Constant::ErrorCodes::SERVER_NOT_INITIALIZED,
+                message: "The language server is not initialized yet"
+              }
+            })
+          end
+          return
+        end
+
+        case
+        when method && id
+          guid = SecureRandom.uuid
+          @command_socket_mutex.synchronize do
+            @command_socket_requests[guid] = [session, id, method.to_s == CustomMethods::TypeCheck::METHOD]
+          end
+          message = message.merge({ id: guid })
+        when id
+          # A response from the client, but nothing is waiting for it
+          return
+        end
+
+        job_queue << ReceiveMessageJob.new(source: :client, message: message)
+      rescue ClosedQueueError
+        Steep.logger.warn { "Command socket: server is shutting down" }
+      end
+
+      # Deregisters the pending requests of a disconnected command socket session
+      def finish_command_socket_session(session)
+        @command_socket_mutex.synchronize do
+          @command_socket_requests.delete_if {|_, entry| entry[0] == session }
+        end
+      end
+
+      def write_message_to_client(message)
+        unless message.key?(:method)
+          entry = @command_socket_mutex.synchronize { @command_socket_requests.delete(message[:id]) }
+          if entry
+            session, original_id, _ = entry
+            session.write(message.merge({ id: original_id }))
+            return
+          end
+        end
+
+        writer.write(message)
+
+        if message.key?(:method) && !message.key?(:id)
+          forward_notification_to_command_sessions(message)
+        end
+      end
+
+      def forward_notification_to_command_sessions(message)
+        return unless COMMAND_SOCKET_FORWARDED_NOTIFICATIONS.include?(message[:method].to_s)
+
+        sessions = @command_socket_mutex.synchronize do
+          @command_socket_requests.each_value.with_object([]) do |entry, array|
+            session, _, typecheck = entry
+            array << session if typecheck
+          end
+        end
+
+        sessions.uniq!
+        sessions.each {|session| session.write(message) }
       end
 
       def work_done_progress(guid)

--- a/sig/shims/language-server_protocol.rbs
+++ b/sig/shims/language-server_protocol.rbs
@@ -158,6 +158,13 @@ module LanguageServer
 
         type t = 1 | 2 | 3
       end
+
+      module ErrorCodes
+        INVALID_REQUEST: -32600
+        SERVER_NOT_INITIALIZED: -32002
+
+        type t = Integer
+      end
     end
 
     module Interface

--- a/sig/steep/daemon.rbs
+++ b/sig/steep/daemon.rbs
@@ -17,7 +17,9 @@ module Steep
 
     def self.log_path: () -> String
 
+    # Returns true when something is serving the socket, whether it is a daemon or a language server
     def self.running?: () -> bool
+
 
     def self.starting?: () -> bool
 
@@ -30,6 +32,9 @@ module Steep
     def self.status: (stderr: IO) -> void
 
     private
+
+    # The pid recorded in `path`, when the file exists and that process is alive
+    def self.live_pid: (String path) -> Integer?
 
     def self.run_server: (stderr: IO) -> void
 

--- a/sig/steep/drivers/langserver.rbs
+++ b/sig/steep/drivers/langserver.rbs
@@ -17,6 +17,8 @@ module Steep
 
       attr_accessor refork: bool
 
+      attr_accessor command_socket: bool
+
       include Utils::DriverHelper
 
       def initialize: (stdout: untyped, stderr: untyped, stdin: untyped) -> void
@@ -33,6 +35,13 @@ module Steep
       def project: () -> Project
 
       def run: () -> Integer
+
+      # Starts accepting `steep query`/`steep check` connections on the UNIX socket
+      #
+      # Returns `nil` when the command socket is disabled, is not supported on the platform,
+      # or is already served by another process.
+      #
+      def start_command_socket: (Server::Master master) -> Server::CommandSocket?
     end
   end
 end

--- a/sig/steep/server/command_socket.rbs
+++ b/sig/steep/server/command_socket.rbs
@@ -1,0 +1,58 @@
+module Steep
+  module Server
+    # Accepts connections on a UNIX socket and forwards the received requests to the master
+    #
+    # Started by `steep langserver` so that CLI commands like `steep query` and `steep check` can
+    # talk to the language server the IDE is running, instead of a standalone daemon process.
+    #
+    class CommandSocket
+      module LSP = LanguageServer::Protocol
+
+      # A connection from a CLI client
+      class Session
+        attr_reader socket: UNIXSocket
+
+        @writer: LanguageServer::Protocol::Transport::Io::Writer
+
+        @mutex: Thread::Mutex
+
+        @closed: bool
+
+        def initialize: (UNIXSocket socket) -> void
+
+        # Writes a message to the client, never raises even if the client is disconnected
+        def write: (untyped message) -> void
+
+        def close: () -> void
+      end
+
+      attr_reader master: Master
+
+      attr_reader configuration: Daemon::Configuration
+
+      @server: UNIXServer?
+
+      @accept_thread: Thread?
+
+      def initialize: (master: Master, configuration: Daemon::Configuration) -> void
+
+      def socket_path: () -> String
+
+      # Binds the UNIX socket and starts accepting connections in a background thread
+      #
+      # Returns `false` without binding when another process is already serving on the socket.
+      #
+      def start: () -> bool
+
+      def stop: () -> void
+
+      private
+
+      def socket_alive?: () -> bool
+
+      def accept_loop: () -> void
+
+      def serve: (Session session) -> void
+    end
+  end
+end

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -162,6 +162,14 @@ module Steep
 
       # Callbacks to be called when no type check is running anymore
       attr_reader typecheck_quiescent_callbacks: Array[^() -> void]
+      # Pending requests received through the command socket
+      #
+      # A map from the id assigned by the master to the session, the original request id, and
+      # whether the request is a `$/steep/typecheck` request.
+      #
+      @command_socket_requests: Hash[String, [CommandSocket::Session, String | Integer, bool]]
+
+      @command_socket_mutex: Thread::Mutex
 
       def initialize: (project: Project, reader: untyped, writer: untyped, interaction_worker: WorkerProcess?, typecheck_workers: Array[WorkerProcess], ?queue: Thread::Queue, ?refork: boolish) -> void
 
@@ -244,6 +252,28 @@ module Steep
       # `paths` is an array of absolute path strings to filter the result, or `nil` to return everything.
       #
       def collect_query_diagnostics: (String id, Array[String]? paths) -> void
+      # The only methods a command socket client may send: what `steep check` and `steep query` use
+      COMMAND_SOCKET_ALLOWED_METHODS: Array[String]
+
+      # Notifications that are copied to command socket sessions with a pending `$/steep/typecheck` request
+      COMMAND_SOCKET_FORWARDED_NOTIFICATIONS: Array[String]
+
+      # Processes a message received from a command socket client
+      #
+      # Requests are assigned a fresh id and enqueued as if they came from the LSP client,
+      # and the responses are routed back to the session through `#write_message_to_client`.
+      #
+      # May be called from any thread.
+      #
+      def process_command_socket_message: (untyped message, CommandSocket::Session session) -> void
+
+      # Deregisters the pending requests of a disconnected command socket session
+      def finish_command_socket_session: (CommandSocket::Session session) -> void
+
+      # Writes a message to the LSP client, or to the command socket session waiting for the response
+      def write_message_to_client: (untyped message) -> void
+
+      def forward_notification_to_command_sessions: (untyped message) -> void
 
       def work_done_progress: (String) -> WorkDoneProgress
 

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -162,6 +162,13 @@ module Steep
 
       # Callbacks to be called when no type check is running anymore
       attr_reader typecheck_quiescent_callbacks: Array[^() -> void]
+
+      # The mtimes of the project files when they were loaded or reloaded
+      #
+      # `nil` until the initial project load finishes.
+      # Touched only from the main loop thread.
+      #
+      @project_file_mtimes: Hash[Pathname, Time?]?
       # Pending requests received through the command socket
       #
       # A map from the id assigned by the master to the session, the original request id, and
@@ -252,6 +259,22 @@ module Steep
       # `paths` is an array of absolute path strings to filter the result, or `nil` to return everything.
       #
       def collect_query_diagnostics: (String id, Array[String]? paths) -> void
+
+      # Records the mtimes of all project files, as the baseline of `#sync_project_files_from_disk`
+      def reset_project_file_mtimes: () -> void
+
+      def record_project_file_mtime: (Pathname path) -> void
+
+      def file_mtime: (Pathname path) -> Time?
+
+      def each_project_file_path: () { (Pathname) -> void } -> void
+
+      # Detects files changed on disk since the last load/sync, and reloads them
+      #
+      # Skips files open in the editor because the client owns their contents.
+      # Does nothing until the initial project load finishes.
+      #
+      def sync_project_files_from_disk: () -> void
       # The only methods a command socket client may send: what `steep check` and `steep query` use
       COMMAND_SOCKET_ALLOWED_METHODS: Array[String]
 

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -160,6 +160,9 @@ module Steep
 
       @need_to_refork: boolish
 
+      # Type check requests waiting for the current type check to finish
+      attr_reader pending_typecheck_requests: Array[TypeCheckController::Request]
+
       # Callbacks to be called when no type check is running anymore
       attr_reader typecheck_quiescent_callbacks: Array[^() -> void]
 
@@ -259,6 +262,14 @@ module Steep
       # `paths` is an array of absolute path strings to filter the result, or `nil` to return everything.
       #
       def collect_query_diagnostics: (String id, Array[String]? paths) -> void
+
+      def typecheck_request_from_command_socket?: (TypeCheckController::Request request) -> bool
+
+      # Starts the next queued type check request if any, or the automatic type check for dirty paths
+      #
+      # Calls the quiescent callbacks when nothing is left to type check.
+      #
+      def start_pending_typecheck: () -> void
 
       # Records the mtimes of all project files, as the baseline of `#sync_project_files_from_disk`
       def reset_project_file_mtimes: () -> void

--- a/sig/test/command_socket_test.rbs
+++ b/sig/test/command_socket_test.rbs
@@ -36,6 +36,8 @@ class CommandSocketTest < Minitest::Test
   # file forever.
   def test_command_socket_ignores_document_synchronization: () -> untyped
 
+  def test_typecheck_requests_are_serialized: () -> untyped
+
   # `steep server stop` signals the pid recorded in the daemon's pid file, so a language server
   # serving the same socket must not write one.
   def test_langserver_writes_no_pid_file: () -> untyped

--- a/sig/test/command_socket_test.rbs
+++ b/sig/test/command_socket_test.rbs
@@ -9,6 +9,16 @@ class CommandSocketTest < Minitest::Test
 
   def langserver_command: (untyped steepfile) -> untyped
 
+  # Where the language server's stderr goes, to be dumped when something goes wrong
+  def langserver_log: () -> untyped
+
+  # Prints the language server log once, so that a failure of the subprocess is diagnosable
+  # from the test output
+  #
+  # `force:` prints it again -- the teardown uses it to show the lines the server wrote
+  # after the first dump, like the shutdown handshake or a kill.
+  def dump_langserver_log: (?force: untyped) -> untyped
+
   def socket_path: () -> untyped
 
   def prepare_project: () -> untyped

--- a/sig/test/command_socket_test.rbs
+++ b/sig/test/command_socket_test.rbs
@@ -17,6 +17,9 @@ class CommandSocketTest < Minitest::Test
 
   def request_via_socket: (untyped message) -> untyped
 
+  # Writes the file and bumps its mtime so that the server detects the change reliably
+  def write_file: (untyped path, untyped content) -> untyped
+
   def wait_for_socket: () -> untyped
 
   def daemon_pid_path: () -> untyped
@@ -25,6 +28,13 @@ class CommandSocketTest < Minitest::Test
   def with_daemon_config: (untyped base_dir) -> untyped
 
   def test_langserver_serves_requests_through_command_socket: () -> untyped
+
+  def test_query_diagnostics_syncs_files_changed_on_disk: () -> untyped
+
+  # Document synchronization belongs to the LSP client. A `didOpen` through the socket
+  # must not make the server treat the file as open, or the disk syncing would skip the
+  # file forever.
+  def test_command_socket_ignores_document_synchronization: () -> untyped
 
   # `steep server stop` signals the pid recorded in the daemon's pid file, so a language server
   # serving the same socket must not write one.

--- a/sig/test/command_socket_test.rbs
+++ b/sig/test/command_socket_test.rbs
@@ -17,7 +17,18 @@ class CommandSocketTest < Minitest::Test
 
   def request_via_socket: (untyped message) -> untyped
 
+  def wait_for_socket: () -> untyped
+
+  def daemon_pid_path: () -> untyped
+
+  # `Steep::Daemon` memoizes its configuration from `Dir.pwd`, which the tests do not change
+  def with_daemon_config: (untyped base_dir) -> untyped
+
   def test_langserver_serves_requests_through_command_socket: () -> untyped
+
+  # `steep server stop` signals the pid recorded in the daemon's pid file, so a language server
+  # serving the same socket must not write one.
+  def test_langserver_writes_no_pid_file: () -> untyped
 
   def test_langserver_with_no_command_socket_option: () -> untyped
 end

--- a/sig/test/command_socket_test.rbs
+++ b/sig/test/command_socket_test.rbs
@@ -1,0 +1,23 @@
+# Generated from test/command_socket_test.rb with RBS::Inline
+
+class CommandSocketTest < Minitest::Test
+  include TestHelper
+
+  include ShellHelper
+
+  def dirs: () -> untyped
+
+  def langserver_command: (untyped steepfile) -> untyped
+
+  def socket_path: () -> untyped
+
+  def prepare_project: () -> untyped
+
+  def start_langserver: (untyped command) -> untyped
+
+  def request_via_socket: (untyped message) -> untyped
+
+  def test_langserver_serves_requests_through_command_socket: () -> untyped
+
+  def test_langserver_with_no_command_socket_option: () -> untyped
+end

--- a/test/command_socket_test.rb
+++ b/test/command_socket_test.rb
@@ -1,0 +1,155 @@
+require_relative "test_helper"
+
+class CommandSocketTest < Minitest::Test
+  include TestHelper
+  include ShellHelper
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def langserver_command(steepfile)
+    "#{RUBY_PATH} #{__dir__}/../exe/steep langserver --log-level=error --steepfile=#{steepfile}"
+  end
+
+  def socket_path
+    project_id = Digest::MD5.hexdigest(current_dir.to_s)[0, 8]
+    File.join(Dir.tmpdir, "steep-server", "steep-#{project_id}.sock")
+  end
+
+  def prepare_project
+    (current_dir + "lib").mkdir
+    (current_dir + "sig").mkdir
+    (current_dir + "Steepfile").write(<<~RUBY)
+      target :app do
+        check "lib"
+        signature "sig"
+      end
+    RUBY
+    (current_dir + "lib/hello.rb").write(<<~RUBY)
+      class Hello
+        # @dynamic name
+        attr_reader :name
+      end
+    RUBY
+    (current_dir + "sig/hello.rbs").write(<<~RBS)
+      class Hello
+        attr_reader name: String
+      end
+    RBS
+  end
+
+  def start_langserver(command)
+    Open3.popen2(command) do |stdin, stdout|
+      reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdout)
+      writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdin)
+
+      responses = Thread::Queue.new
+      reader_thread = Thread.new do
+        begin
+          reader.read do |message|
+            if message[:id] && !message[:method]
+              responses << message
+            end
+          end
+        rescue IOError
+          # Server exited
+        end
+      end
+
+      writer.write(id: 1, method: "initialize", params: { capabilities: {} })
+      Timeout.timeout(TestHelper.timeout) do
+        response = responses.pop
+        assert_equal 1, response[:id]
+      end
+
+      writer.write(method: "initialized", params: {})
+
+      begin
+        yield writer, responses
+      ensure
+        writer.write(id: 999, method: "shutdown", params: nil)
+        Timeout.timeout(TestHelper.timeout) do
+          loop do
+            break if responses.pop[:id] == 999
+          end
+        end
+        writer.write(method: "exit")
+        reader_thread.join
+      end
+    end
+  end
+
+  def request_via_socket(message)
+    UNIXSocket.open(socket_path) do |socket|
+      socket_reader = LanguageServer::Protocol::Transport::Io::Reader.new(socket)
+      socket_writer = LanguageServer::Protocol::Transport::Io::Writer.new(socket)
+
+      socket_writer.write(message)
+
+      Timeout.timeout(TestHelper.timeout) do
+        socket_reader.read do |response|
+          return response
+        end
+      end
+    end
+  end
+
+  def test_langserver_serves_requests_through_command_socket
+    skip "UNIX socket is not supported on this platform" if Gem.win_platform?
+
+    in_tmpdir do
+      prepare_project
+
+      start_langserver(langserver_command(current_dir + "Steepfile")) do |writer, responses|
+        Timeout.timeout(TestHelper.timeout) do
+          sleep 0.1 until File.socket?(socket_path)
+        end
+
+        # A request is routed to the master and the response comes back with the original id
+        response = request_via_socket(id: "ping-1", method: "$/ping", params: { message: "hello" })
+        assert_equal "ping-1", response[:id]
+        assert_equal({ message: "hello" }, response[:result])
+
+        # LSP requests work through the socket
+        response = request_via_socket(
+          id: 55,
+          method: "textDocument/hover",
+          params: {
+            textDocument: { uri: "file://#{current_dir}/lib/hello.rb" },
+            position: { line: 2, character: 15 }
+          }
+        )
+        assert_equal 55, response[:id]
+
+        # Methods outside the allowlist are rejected
+        response = request_via_socket(id: "bad-1", method: "shutdown", params: nil)
+        assert_equal "bad-1", response[:id]
+        refute_nil response[:error]
+
+        response = request_via_socket(id: "bad-2", method: "textDocument/didChange", params: nil)
+        assert_equal "bad-2", response[:id]
+        refute_nil response[:error]
+      end
+
+      refute File.exist?(socket_path), "The socket file should be cleaned up on exit"
+    end
+  end
+
+  def test_langserver_with_no_command_socket_option
+    skip "UNIX socket is not supported on this platform" if Gem.win_platform?
+
+    in_tmpdir do
+      prepare_project
+
+      start_langserver("#{langserver_command(current_dir + "Steepfile")} --no-command-socket") do |writer, responses|
+        response = nil
+        assert_raises(Timeout::Error) do
+          Timeout.timeout(3) do
+            sleep 0.1 until File.socket?(socket_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/command_socket_test.rb
+++ b/test/command_socket_test.rb
@@ -292,6 +292,53 @@ class CommandSocketTest < Minitest::Test
     end
   end
 
+  def test_typecheck_requests_are_serialized
+    skip "UNIX socket is not supported on this platform" if Gem.win_platform?
+
+    in_tmpdir do
+      prepare_project
+
+      start_langserver(langserver_command(current_dir + "Steepfile")) do |writer, responses|
+        wait_for_socket
+
+        params = {
+          library_paths: [],
+          signature_paths: [["app", (current_dir + "sig/hello.rbs").to_s]],
+          code_paths: [["app", (current_dir + "lib/hello.rb").to_s]],
+          inline_paths: []
+        }
+
+        # Both concurrent typecheck requests must be responded, one after another
+        sockets = ["tc-1", "tc-2"].map do |id|
+          socket = UNIXSocket.new(socket_path)
+          connected_at = Time.now
+          LanguageServer::Protocol::Transport::Io::Writer.new(socket).write(
+            id: id, method: "$/steep/typecheck", params: params
+          )
+          # Timestamps to correlate with the server log when a request goes missing
+          STDERR.puts "#{id}: connected at #{connected_at.strftime("%H:%M:%S.%L")}, request written at #{Time.now.strftime("%H:%M:%S.%L")}"
+          [id, socket]
+        end
+
+        sockets.each do |id, socket|
+          reader = LanguageServer::Protocol::Transport::Io::Reader.new(socket)
+          response = nil
+          Timeout.timeout(TestHelper.timeout) do
+            reader.read do |message|
+              if message[:id] == id
+                response = message
+                break
+              end
+            end
+          end
+          assert_equal true, response.dig(:result, :completed), "request #{id} should complete: #{response.inspect}"
+        ensure
+          socket.close
+        end
+      end
+    end
+  end
+
   # `steep server stop` signals the pid recorded in the daemon's pid file, so a language server
   # serving the same socket must not write one.
   def test_langserver_writes_no_pid_file

--- a/test/command_socket_test.rb
+++ b/test/command_socket_test.rb
@@ -96,6 +96,16 @@ class CommandSocketTest < Minitest::Test
   end
 
 
+  # Writes the file and bumps its mtime so that the server detects the change reliably
+  def write_file(path, content)
+    file = current_dir + path
+    file.write(content)
+
+    @mtime_bump = (@mtime_bump || 0) + 10
+    time = Time.now + @mtime_bump
+    File.utime(time, time, file.to_s)
+  end
+
   def wait_for_socket
     Timeout.timeout(TestHelper.timeout) do
       sleep 0.1 until File.socket?(socket_path)
@@ -153,6 +163,132 @@ class CommandSocketTest < Minitest::Test
       end
 
       refute File.exist?(socket_path), "The socket file should be cleaned up on exit"
+    end
+  end
+
+  def test_query_diagnostics_syncs_files_changed_on_disk
+    skip "UNIX socket is not supported on this platform" if Gem.win_platform?
+
+    in_tmpdir do
+      prepare_project
+
+      start_langserver(langserver_command(current_dir + "Steepfile")) do |writer, responses|
+        wait_for_socket
+
+        hello_rb = (current_dir + "lib/hello.rb").to_s
+
+        # The server has not type checked anything yet
+        response = request_via_socket(
+          id: "d1",
+          method: "$/steep/query/diagnostics",
+          params: { paths: [hello_rb] }
+        )
+        assert_equal 1, response[:result].size
+        assert_nil response[:result][0][:diagnostics]
+
+        # Edit the file on disk, without any notification, like a coding agent does
+        write_file("lib/hello.rb", <<~RUBY)
+          class Hello
+            def name
+              42
+            end
+          end
+        RUBY
+
+        response = request_via_socket(
+          id: "d2",
+          method: "$/steep/query/diagnostics",
+          params: { paths: [hello_rb] }
+        )
+        diagnostics = response[:result][0][:diagnostics]
+        refute_nil diagnostics
+        assert diagnostics.any? {|d| d[:code] == "Ruby::MethodBodyTypeMismatch" }, diagnostics.inspect
+
+        # Edit the RBS file — the diagnostics of the dependent Ruby file must be updated
+        write_file("sig/hello.rbs", <<~RBS)
+          class Hello
+            def name: () -> Integer
+          end
+        RBS
+
+        response = request_via_socket(
+          id: "d3",
+          method: "$/steep/query/diagnostics",
+          params: { paths: [hello_rb] }
+        )
+        assert_equal [], response[:result][0][:diagnostics]
+      end
+    end
+  end
+
+
+  # Document synchronization belongs to the LSP client. A `didOpen` through the socket
+  # must not make the server treat the file as open, or the disk syncing would skip the
+  # file forever.
+  def test_command_socket_ignores_document_synchronization
+    skip "UNIX socket is not supported on this platform" if Gem.win_platform?
+
+    in_tmpdir do
+      prepare_project
+
+      start_langserver(langserver_command(current_dir + "Steepfile")) do |writer, responses|
+        wait_for_socket
+
+        hello_rb = (current_dir + "lib/hello.rb").to_s
+        content_with_error = <<~RUBY
+          class Hello
+            def name
+              42
+            end
+          end
+        RUBY
+
+        UNIXSocket.open(socket_path) do |socket|
+          socket_writer = LanguageServer::Protocol::Transport::Io::Writer.new(socket)
+          socket_reader = LanguageServer::Protocol::Transport::Io::Reader.new(socket)
+
+          socket_writer.write(
+            method: "textDocument/didOpen",
+            params: {
+              textDocument: {
+                uri: "file://#{hello_rb}",
+                languageId: "ruby",
+                version: 1,
+                text: content_with_error
+              }
+            }
+          )
+
+          # The same connection serves its messages in order, so the query observes
+          # whatever the `didOpen` above did
+          socket_writer.write(id: "d1", method: "$/steep/query/diagnostics", params: { paths: [hello_rb] })
+
+          response = nil #: untyped
+          Timeout.timeout(TestHelper.timeout) do
+            socket_reader.read do |message|
+              if message[:id] == "d1"
+                response = message
+                break
+              end
+            end
+          end
+
+          diagnostics = response[:result][0][:diagnostics]
+          assert_empty (diagnostics || []), "the content of the ignored `didOpen` must not be type checked: #{diagnostics.inspect}"
+        end
+
+        # The file is not marked as open either: an edit on disk is still picked up
+        write_file("lib/hello.rb", content_with_error)
+
+        response = request_via_socket(
+          id: "d2",
+          method: "$/steep/query/diagnostics",
+          params: { paths: [hello_rb] }
+        )
+        diagnostics = response[:result][0][:diagnostics]
+        refute_nil diagnostics
+        assert diagnostics.any? {|d| d[:code] == "Ruby::MethodBodyTypeMismatch" }, diagnostics.inspect
+      end
     end
   end
 

--- a/test/command_socket_test.rb
+++ b/test/command_socket_test.rb
@@ -95,6 +95,26 @@ class CommandSocketTest < Minitest::Test
     end
   end
 
+
+  def wait_for_socket
+    Timeout.timeout(TestHelper.timeout) do
+      sleep 0.1 until File.socket?(socket_path)
+    end
+  end
+
+  def daemon_pid_path
+    socket_path.sub(".sock", ".pid")
+  end
+
+  # `Steep::Daemon` memoizes its configuration from `Dir.pwd`, which the tests do not change
+  def with_daemon_config(base_dir)
+    saved = Steep::Daemon.instance_variable_get(:@config)
+    Steep::Daemon.instance_variable_set(:@config, Steep::Daemon::Configuration.new(base_dir: base_dir.to_s))
+    yield
+  ensure
+    Steep::Daemon.instance_variable_set(:@config, saved)
+  end
+
   def test_langserver_serves_requests_through_command_socket
     skip "UNIX socket is not supported on this platform" if Gem.win_platform?
 
@@ -133,6 +153,28 @@ class CommandSocketTest < Minitest::Test
       end
 
       refute File.exist?(socket_path), "The socket file should be cleaned up on exit"
+    end
+  end
+
+  # `steep server stop` signals the pid recorded in the daemon's pid file, so a language server
+  # serving the same socket must not write one.
+  def test_langserver_writes_no_pid_file
+    skip "UNIX socket is not supported on this platform" if Gem.win_platform?
+
+    in_tmpdir do
+      prepare_project
+
+      start_langserver(langserver_command(current_dir + "Steepfile")) do |_writer, _responses|
+        wait_for_socket
+
+        refute File.exist?(daemon_pid_path), "`steep server stop` would signal the language server"
+
+        # `ShellHelper#chdir` does not change the working directory, so point the memoized
+        # configuration at the project of this test.
+        with_daemon_config(current_dir) do
+          assert Steep::Daemon.running?, "`steep check` and `steep query` must find the language server"
+        end
+      end
     end
   end
 

--- a/test/command_socket_test.rb
+++ b/test/command_socket_test.rb
@@ -9,7 +9,29 @@ class CommandSocketTest < Minitest::Test
   end
 
   def langserver_command(steepfile)
-    "#{RUBY_PATH} #{__dir__}/../exe/steep langserver --log-level=error --steepfile=#{steepfile}"
+    "#{RUBY_PATH} #{__dir__}/../exe/steep langserver --log-level=info --steepfile=#{steepfile}"
+  end
+
+  # Where the language server's stderr goes, to be dumped when something goes wrong
+  def langserver_log
+    current_dir + "langserver.log"
+  end
+
+  # Prints the language server log once, so that a failure of the subprocess is diagnosable
+  # from the test output
+  #
+  # `force:` prints it again -- the teardown uses it to show the lines the server wrote
+  # after the first dump, like the shutdown handshake or a kill.
+  #
+  def dump_langserver_log(force: false)
+    return if @langserver_log_dumped && !force
+    @langserver_log_dumped = true
+
+    return unless langserver_log.file?
+
+    STDERR.puts "==== language server log: #{langserver_log} ===="
+    STDERR.puts langserver_log.read
+    STDERR.puts "==== end of language server log ===="
   end
 
   def socket_path
@@ -40,7 +62,7 @@ class CommandSocketTest < Minitest::Test
   end
 
   def start_langserver(command)
-    Open3.popen2(command) do |stdin, stdout|
+    Open3.popen2(command, pgroup: true, err: [langserver_log.to_s, "w"]) do |stdin, stdout, wait_thr|
       reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdout)
       writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdin)
 
@@ -67,15 +89,43 @@ class CommandSocketTest < Minitest::Test
 
       begin
         yield writer, responses
+      rescue Exception
+        dump_langserver_log
+        raise
       ensure
-        writer.write(id: 999, method: "shutdown", params: nil)
-        Timeout.timeout(TestHelper.timeout) do
-          loop do
-            break if responses.pop[:id] == 999
+        # Shut the server down gracefully, but never wait for it without a bound: a wedged
+        # server would otherwise hang the whole test suite on `Process.wait`
+        begin
+          writer.write(id: 999, method: "shutdown", params: nil)
+          Timeout.timeout(TestHelper.timeout) do
+            loop do
+              break if responses.pop[:id] == 999
+            end
+          end
+          writer.write(method: "exit")
+        rescue Timeout::Error, Errno::EPIPE, IOError
+          dump_langserver_log
+        end
+
+        unless wait_thr.join(TestHelper.timeout)
+          dump_langserver_log
+          begin
+            Process.kill(:TERM, -wait_thr.pid)
+            unless wait_thr.join(5)
+              Process.kill(:KILL, -wait_thr.pid)
+            end
+          rescue Errno::ESRCH, Errno::EPERM
+            # Already gone
           end
         end
-        writer.write(method: "exit")
-        reader_thread.join
+
+        reader_thread.join(TestHelper.timeout)
+
+        # A dump before this point misses what the server wrote afterwards -- dump the
+        # complete log once the server is down
+        if @langserver_log_dumped
+          dump_langserver_log(force: true)
+        end
       end
     end
   end
@@ -89,12 +139,11 @@ class CommandSocketTest < Minitest::Test
 
       Timeout.timeout(TestHelper.timeout) do
         socket_reader.read do |response|
-          return response
+          return response if response[:id] == message[:id]
         end
       end
     end
   end
-
 
   # Writes the file and bumps its mtime so that the server detects the change reliably
   def write_file(path, content)
@@ -220,7 +269,6 @@ class CommandSocketTest < Minitest::Test
       end
     end
   end
-
 
   # Document synchronization belongs to the LSP client. A `didOpen` through the socket
   # must not make the server treat the file as open, or the disk syncing would skip the


### PR DESCRIPTION
`steep langserver` now binds the per-project UNIX socket that `steep server` serves, so
`steep check` and `steep query` connect to the language server the editor is already
running instead of requiring a separate daemon process. The daemon remains the entry
point for editor-less environments — CI, or coding agents working headless — and
whichever server binds the socket first serves it; the other side skips it.

Builds on `steep query diagnostics` (#2274), and serves it through the command socket
too.

## Command socket

`Server::CommandSocket` accepts connections and forwards the received LSP messages to
the master. Each request gets a fresh id and is processed as if it came from the IDE,
with the response routed back to the originating session. `textDocument/publishDiagnostics`
and `window/showMessage` are copied to sessions waiting on a `$/steep/typecheck` request,
which is what makes `steep check` work in server mode. `--[no-]command-socket` disables
the socket.

Only the methods `steep check` and `steep query` use are accepted; everything else is
rejected — lifecycle methods because the server belongs to whoever started it, and
document synchronization because the LSP client owns the contents of the files it opens:
a `didOpen` through the socket would mark the file as client-owned, and nothing would
ever unmark it.

## Files changed on disk

Command socket clients edit files without sending `didChange`, so the master records
project file mtimes and sweeps them before serving a request, reloading what changed.
Files open in the editor are skipped — the client owns their contents.

The sweep does not replace the file watcher, it is the synchronous half of it: a
watcher notification is asynchronous and only sent by clients that ask for one, so a
client that edits a file and queries the result immediately cannot rely on it.
`Daemon::Server` runs the same kind of sweep before it forwards a request to its
master; that copy, and the mtime tracking beside it, go away with the supervisor
process once `steep server` runs in the foreground.

A type check requested through the socket is also never superseded: concurrent requests
queue instead of truncating the in-flight check, which previously could report partial
results.

## Pid file

The language server records no pid: nothing may signal it, so the pid file keeps its
one meaning — the daemon `steep server stop` may signal. `Daemon.running?` asks the
socket instead of requiring the pid file, or `steep check`/`steep query` would not
find a language server; the `steep server` commands report a served socket without a
live pid file as belonging to another process. Two side effects fall out: `steep
server stop` with a stale pid file no longer deletes a socket another process is
serving, and `steep server start` during the daemon's own startup window no longer
wipes its pid file and forks a second daemon.