### PR TITLE
Add `steep query diagnostics`

### DIFF
--- a/lib/steep/cli.rb
+++ b/lib/steep/cli.rb
@@ -618,8 +618,9 @@ BANNER
               The user interface and output format may change without deprecation.
 
           Available subcommands:
-              hover      Get hover information (type, documentation) for a position
-              definition Get the definition(s) of a class, type alias, constant, or method name
+              hover       Get hover information (type, documentation) for a position
+              definition  Get the definition(s) of a class, type alias, constant, or method name
+              diagnostics Get the type check diagnostics the server has computed
 
           Options:
               --help    Show this help message
@@ -628,6 +629,7 @@ BANNER
               steep query hover lib/foo.rb:10:5
               steep query definition RBS::Location
               steep query definition RBS::Parser.parse_signature
+              steep query diagnostics lib/foo.rb sig/foo.rbs
         HELP
         return 0
       end
@@ -714,9 +716,32 @@ BANNER
         end
 
         Drivers::Query.new(stdout: stdout, stderr: stderr).run_definition(names: argv.dup)
+      when "diagnostics"
+        OptionParser.new do |opts|
+          opts.banner = <<BANNER
+Usage: steep query diagnostics [options] [FILE ...]
+
+Description:
+    Get the type check diagnostics the server has computed.
+    Connects to the running Steep server, waits for the type checking to finish, and
+    prints the diagnostics as JSONL (one JSON object per line for each file).
+
+    When FILEs are given, only the diagnostics of those files are printed.
+    `"diagnostics": null` means the server has not type checked the file yet.
+
+Note:
+    This is an experimental command.
+    The user interface and output format may change without deprecation.
+
+Options:
+BANNER
+          handle_logging_options opts
+        end.parse!(argv)
+
+        Drivers::Query.new(stdout: stdout, stderr: stderr).run_diagnostics(paths: argv.dup)
       else
         stderr.puts "Unknown query subcommand: #{subcommand}"
-        stderr.puts "  available subcommands: hover, definition"
+        stderr.puts "  available subcommands: hover, definition, diagnostics"
         1
       end
     end

--- a/lib/steep/drivers/query.rb
+++ b/lib/steep/drivers/query.rb
@@ -72,6 +72,44 @@ module Steep
         1
       end
 
+      def run_diagnostics(paths:)
+        unless Daemon.running?
+          stderr.puts "Error: Steep daemon is not running. Start it with `steep server start`."
+          return 1
+        end
+
+        absolute_paths = [] #: Array[Pathname]
+        paths.each do |path|
+          pathname = Pathname(path)
+          pathname = Pathname.pwd + pathname unless pathname.absolute?
+          absolute_paths << pathname
+        end
+
+        request = {
+          id: SecureRandom.uuid,
+          method: Server::CustomMethods::Query__Diagnostics::METHOD,
+          params: { paths: absolute_paths.empty? ? nil : absolute_paths.map(&:to_s) }
+        }
+
+        result = send_request(request) #: Array[{ uri: String, diagnostics: Array[untyped]? }]?
+
+        (result || []).each do |entry|
+          path = PathHelper.to_pathname(entry[:uri]) || Pathname(entry[:uri])
+          begin
+            path = path.relative_path_from(Pathname.pwd)
+          rescue ArgumentError
+            # Keep the absolute path of files outside of the current directory
+          end
+
+          stdout.puts JSON.generate({ path: path.to_s, diagnostics: entry[:diagnostics] })
+        end
+
+        0
+      rescue Errno::ECONNREFUSED, Errno::ENOENT => e
+        stderr.puts "Error: Failed to connect to Steep server: #{e.message}"
+        1
+      end
+
       private
 
       def to_absolute_path(path)

--- a/lib/steep/server/custom_methods.rb
+++ b/lib/steep/server/custom_methods.rb
@@ -96,6 +96,18 @@ module Steep
           { id: id, result: result }
         end
       end
+
+      module Query__Diagnostics
+        METHOD = "$/steep/query/diagnostics"
+
+        def self.request(id, params)
+          { method: METHOD, id: id, params: params }
+        end
+
+        def self.response(id, result)
+          { id: id, result: result }
+        end
+      end
     end
   end
 end

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -955,6 +955,17 @@ module Steep
               refork_finished.pop
             end
           end
+
+          # The reforked workers started from a copy of the primary's state, which has the
+          # results of the primary's assigned paths only, and the results the replaced workers
+          # had computed are gone with them. Type check everything again so that queries
+          # reading the stored results, like `$/steep/query/diagnostics`, see all files.
+          job_queue << -> do
+            guid = SecureRandom.uuid
+            request = controller.make_all_request(guid: guid, progress: work_done_progress(guid))
+            request.needs_response = false
+            start_type_check(request: request, last_request: current_type_check_request, report_progress_threshold: 0)
+          end
         end
       end
 

--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -186,6 +186,9 @@ module Steep
       attr_accessor :typecheck_automatically
       attr_reader :start_type_checking_queue
 
+      # Callbacks to be called when no type check is running anymore
+      attr_reader :typecheck_quiescent_callbacks
+
       def initialize(project:, reader:, writer:, interaction_worker:, typecheck_workers:, queue: Queue.new, refork: false)
         @project = project
         @reader = reader
@@ -199,6 +202,7 @@ module Steep
         @write_queue = SizedQueue.new(100)
         @refork_mutex = Mutex.new
         @need_to_refork = refork
+        @typecheck_quiescent_callbacks = []
 
         @controller = TypeCheckController.new(project: project)
         @result_controller = ResultController.new()
@@ -703,6 +707,15 @@ module Steep
           request.needs_response = false
           start_type_check(request: request, last_request: current_type_check_request, report_progress_threshold: 0)
 
+        when CustomMethods::Query__Diagnostics::METHOD
+          id = message[:id]
+          params = message[:params] #: CustomMethods::Query__Diagnostics::params
+          paths = params[:paths]
+
+          run_when_typecheck_quiescent do
+            collect_query_diagnostics(id, paths)
+          end
+
         when "$/ping"
           enqueue_write_job SendMessageJob.to_client(
             message: {
@@ -884,6 +897,7 @@ module Steep
               finish_type_check(current)
               @current_type_check_request = nil
               refork_workers
+              flush_typecheck_quiescent_callbacks()
             end
           end
         end
@@ -1030,6 +1044,89 @@ module Steep
       def enqueue_write_job(job)
         Steep.logger.info { "Write_queue has #{write_queue.size} items"}
         write_queue.push(job)
+      end
+
+      # Calls the block once no type check is running
+      #
+      # Starts a type check for dirty paths first, so that the block observes up-to-date results.
+      #
+      def run_when_typecheck_quiescent(&block)
+        unless current_type_check_request
+          guid = SecureRandom.uuid
+          if request = controller.make_request(guid: guid, progress: work_done_progress(guid))
+            request.needs_response = false
+            start_type_check(request: request, last_request: nil)
+          end
+        end
+
+        if current_type_check_request
+          typecheck_quiescent_callbacks << block
+        else
+          yield
+        end
+      end
+
+      # Calls the waiting quiescent callbacks, once a type check for the paths that went dirty
+      # in the meantime finishes
+      #
+      def flush_typecheck_quiescent_callbacks
+        return if typecheck_quiescent_callbacks.empty?
+        return if current_type_check_request
+
+        guid = SecureRandom.uuid
+        if request = controller.make_request(guid: guid, progress: work_done_progress(guid))
+          request.needs_response = false
+          start_type_check(request: request, last_request: nil)
+          return if current_type_check_request
+        end
+
+        callbacks = typecheck_quiescent_callbacks.dup
+        typecheck_quiescent_callbacks.clear
+        callbacks.each(&:call)
+      end
+
+      # Collects the stored diagnostics from all typecheck workers and sends the response
+      #
+      # `paths` is an array of absolute path strings to filter the result, or `nil` to return everything.
+      #
+      def collect_query_diagnostics(id, paths)
+        uris = paths&.map {|path| PathHelper.to_uri(Pathname(path)).to_s }
+
+        result_controller << group_request do |group|
+          typecheck_workers.each do |worker|
+            group << send_request(method: CustomMethods::Query__Diagnostics::METHOD, params: nil, worker: worker)
+          end
+
+          group.on_completion do |handlers|
+            diagnostics = {} #: Hash[String, Array[untyped]]
+
+            handlers.each do |handler|
+              result = handler.result or next
+              result.each do |entry|
+                array = diagnostics[entry[:uri]] ||= []
+                array.concat(entry[:diagnostics] || [])
+                array.uniq!
+              end
+            end
+
+            # @type var result: CustomMethods::Query__Diagnostics::result
+            result =
+              if uris
+                # Files the server has not type checked yet are reported with `diagnostics: nil`
+                uris.sort.map do |uri|
+                  { uri: uri, diagnostics: diagnostics[uri] }
+                end
+              else
+                diagnostics.keys.sort.map do |uri|
+                  { uri: uri, diagnostics: diagnostics.fetch(uri) }
+                end
+              end
+
+            enqueue_write_job SendMessageJob.to_client(
+              message: CustomMethods::Query__Diagnostics.response(id, result)
+            )
+          end
+        end
       end
 
       def work_done_progress(guid)

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -8,6 +8,7 @@ module Steep
       WorkspaceSymbolJob = _ = Struct.new(:query, :id, keyword_init: true)
       StatsJob = _ = Struct.new(:id, keyword_init: true)
       QueryDefinitionJob = _ = Struct.new(:id, :name, keyword_init: true)
+      QueryDiagnosticsJob = _ = Struct.new(:id, keyword_init: true)
       StartTypeCheckJob = _ = Struct.new(:guid, :changes, keyword_init: true)
       TypeCheckCodeJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
       ValidateAppSignatureJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
@@ -112,6 +113,8 @@ module Steep
         when CustomMethods::Query__Definition::METHOD
           params = request[:params] #: CustomMethods::Query__Definition::params
           queue << QueryDefinitionJob.new(id: request[:id], name: params[:name])
+        when CustomMethods::Query__Diagnostics::METHOD
+          queue << QueryDiagnosticsJob.new(id: request[:id])
         when "textDocument/definition"
           queue << GotoJob.definition(id: request[:id], params: request[:params])
         when "textDocument/implementation"
@@ -307,6 +310,10 @@ module Steep
           writer.write(
             CustomMethods::Query__Definition.response(job.id, query_definition_result(job.name))
           )
+        when QueryDiagnosticsJob
+          writer.write(
+            CustomMethods::Query__Diagnostics.response(job.id, query_diagnostics_result())
+          )
         end
       end
 
@@ -356,6 +363,45 @@ module Steep
             stats << calculator.calc_stats(target, file: file)
           end
         end
+      end
+
+      # Returns the diagnostics of the files this worker has type checked so far
+      #
+      # An array of `Query__Diagnostics::entry`, with the LSP-formatted diagnostics per file URI.
+      # Files that are loaded but not type checked yet are not included.
+      #
+      def query_diagnostics_result
+        result = {} #: Hash[String, Array[untyped]]
+
+        service.source_files.each_value do |file|
+          next if file.typing.nil? && file.errors.nil?
+
+          absolute_path = project.absolute_path(file.path)
+
+          group_target =
+            project.group_for_source_path(absolute_path) ||
+            project.group_for_inline_source_path(absolute_path) ||
+            project.target_for_source_path(absolute_path) ||
+            project.target_for_inline_source_path(absolute_path)
+          next unless group_target
+
+          formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
+          uri = PathHelper.to_uri(absolute_path).to_s
+          array = result[uri] ||= []
+          array.concat(file.diagnostics.filter_map { formatter.format(_1) })
+        end
+
+        formatter = Diagnostic::LSPFormatter.new({}, **{})
+        service.signature_validation_diagnostics.each_value do |path_diagnostics|
+          path_diagnostics.each do |path, diagnostics|
+            absolute_path = path.absolute? ? path : project.absolute_path(path)
+            uri = PathHelper.to_uri(absolute_path).to_s
+            array = result[uri] ||= []
+            array.concat(diagnostics.filter_map { formatter.format(_1) })
+          end
+        end
+
+        result.map { { uri: _1, diagnostics: _2 } }
       end
 
       def query_definition_result(name_string)

--- a/sig/steep/drivers/query.rbs
+++ b/sig/steep/drivers/query.rbs
@@ -13,6 +13,11 @@ module Steep
 
       def run_definition: (names: Array[String]) -> Integer
 
+      # Prints the diagnostics the server has computed for `paths`, or for every file the
+      # server has diagnostics of when `paths` is empty
+      #
+      def run_diagnostics: (paths: Array[String]) -> Integer
+
       private
 
       def to_absolute_path: (String path) -> Pathname?

--- a/sig/steep/server/custom_methods.rbs
+++ b/sig/steep/server/custom_methods.rbs
@@ -170,6 +170,30 @@ module Steep
 
         def self.response: (String id, result) -> untyped
       end
+
+      module Query__Diagnostics
+        METHOD: String
+
+        type params = {
+          paths: Array[String]?
+        }
+
+        # Diagnostics of a file
+        #
+        # `diagnostics` is `nil` when the server has not type checked the file yet.
+        #
+        type entry = { uri: String, diagnostics: Array[untyped]? }
+
+        # The same shape flows on both hops: each typecheck worker answers with the
+        # entries it holds (`diagnostics` never `nil`), and the master merges them,
+        # adding `diagnostics: nil` entries for requested files no worker has checked.
+        #
+        type result = Array[entry]
+
+        def self.request: (String id, params) -> untyped
+
+        def self.response: (String id, result) -> untyped
+      end
     end
   end
 end

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -160,6 +160,9 @@ module Steep
 
       @need_to_refork: boolish
 
+      # Callbacks to be called when no type check is running anymore
+      attr_reader typecheck_quiescent_callbacks: Array[^() -> void]
+
       def initialize: (project: Project, reader: untyped, writer: untyped, interaction_worker: WorkerProcess?, typecheck_workers: Array[WorkerProcess], ?queue: Thread::Queue, ?refork: boolish) -> void
 
       # Start the Steep language server
@@ -224,6 +227,23 @@ module Steep
       def group_request: () { (GroupHandler) -> void } -> GroupHandler
 
       def enqueue_write_job: (SendMessageJob job) -> void
+
+      # Calls the block once no type check is running
+      #
+      # Starts a type check for dirty paths first, so that the block observes up-to-date results.
+      #
+      def run_when_typecheck_quiescent: () { () -> void } -> void
+
+      # Calls the waiting quiescent callbacks, once a type check for the paths that went dirty
+      # in the meantime finishes
+      #
+      def flush_typecheck_quiescent_callbacks: () -> void
+
+      # Collects the stored diagnostics from all typecheck workers and sends the response
+      #
+      # `paths` is an array of absolute path strings to filter the result, or `nil` to return everything.
+      #
+      def collect_query_diagnostics: (String id, Array[String]? paths) -> void
 
       def work_done_progress: (String) -> WorkDoneProgress
 

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -96,6 +96,12 @@ module Steep
         def initialize: (id: String, name: String) -> void
       end
 
+      class QueryDiagnosticsJob
+        attr_reader id: String
+
+        def initialize: (id: String) -> void
+      end
+
       class GotoJob
         type kind = :implementation | :definition | :type_definition
 
@@ -156,6 +162,7 @@ module Steep
                | GotoJob
                | StatsJob
                | QueryDefinitionJob
+               | QueryDiagnosticsJob
 
       def handle_job: (job) -> void
 
@@ -168,6 +175,13 @@ module Steep
       def goto: (GotoJob job) -> Array[untyped]
 
       def query_definition_result: (String name_string) -> CustomMethods::Query__Definition::result
+
+      # Returns the diagnostics of the files this worker has type checked so far
+      #
+      # An array of `Query__Diagnostics::entry`, with the LSP-formatted diagnostics per file URI.
+      # Files that are loaded but not type checked yet are not included.
+      #
+      def query_diagnostics_result: () -> CustomMethods::Query__Diagnostics::result
     end
   end
 end

--- a/sig/test/cli_test.rbs
+++ b/sig/test/cli_test.rbs
@@ -101,6 +101,8 @@ class CLITest < Minitest::Test
 
   def test_query_hover_multiple_locations: () -> untyped
 
+  def test_query_diagnostics_returns_result: () -> untyped
+
   def test_query_definition_missing_argument: () -> untyped
 
   def test_query_definition_help: () -> untyped

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1069,6 +1069,59 @@ end
     end
   end
 
+  def test_query_diagnostics_returns_result
+    skip "fork() is not available on this platform" unless Steep.can_fork?
+
+    in_tmpdir do
+      (current_dir + "Steepfile").write(<<-EOF)
+target :app do
+  check "foo.rb"
+  signature "foo.rbs"
+end
+      EOF
+
+      (current_dir + "foo.rbs").write(<<~RBS)
+        class Foo
+          def name: () -> String
+        end
+      RBS
+
+      (current_dir + "foo.rb").write(<<~RUBY)
+        class Foo
+          def name
+            42
+          end
+        end
+      RUBY
+
+      sh!(*steep, "server", "start", err: [:child, :out])
+
+      begin
+        # The first response has to wait for the warm-up of the server, which takes long on a loaded machine
+        finally_holds(timeout: 60) do
+          stdout, status = sh(*steep, "query", "diagnostics", "foo.rb")
+          assert_predicate status, :success?
+
+          result = JSON.parse(stdout.lines.first, symbolize_names: true)
+          assert_equal "foo.rb", result[:path]
+          refute_nil result[:diagnostics]
+          assert result[:diagnostics].any? {|d| d[:code] == "Ruby::MethodBodyTypeMismatch" }, result[:diagnostics].inspect
+        end
+
+        # Without arguments, every file the server has diagnostics for is printed
+        finally_holds(timeout: 30) do
+          stdout, status = sh(*steep, "query", "diagnostics")
+          assert_predicate status, :success?
+
+          paths = stdout.lines.map {|line| JSON.parse(line, symbolize_names: true).fetch(:path) }
+          assert_includes paths, "foo.rb"
+        end
+      ensure
+        sh(*steep, "server", "stop", err: [:child, :out])
+      end
+    end
+  end
+
   def test_query_definition_missing_argument
     in_tmpdir do
       _, stderr, status = sh3(*steep, "query", "definition")


### PR DESCRIPTION
`steep check` is the imperative "run the type check now" command; the new
`steep query diagnostics [FILE...]` asks the running server for the diagnostics it
has computed — designed for coding agents that edit files on disk and want fast
feedback without spawning a checker. Split out of #2273: it works against the
`steep server` daemon alone and does not need the command socket.

Typecheck workers return the diagnostics they have stored, LSP-formatted, including
signature validation results. The master waits until no type check is running —
starting one for the paths that went dirty first — then fans out to all workers and
merges. Requested files the server has not type checked are reported with
`"diagnostics": null`, as distinct from a file with no errors; the CLI prints JSONL,
one line per file.

Reading the stored results back surfaced a refork bug: reforked workers start from a
copy of the primary's state, so the results the replaced workers had computed were
discarded — everything but the primary's share of the project had no stored result.
The first commit makes the master type check everything again once the refork
finishes.
