### PR TITLE
Stop `steep query definition` from hanging on inline sources

### DIFF
--- a/lib/steep/server/base_worker.rb
+++ b/lib/steep/server/base_worker.rb
@@ -56,6 +56,21 @@ module Steep
                     handle_job(job)
                   rescue => exn
                     Steep.log_error exn
+
+                    # Jobs that carry an `id` answer a request. Reply with an error response, or the
+                    # client would wait for a response that never arrives.
+                    if job.respond_to?(:id) && (id = job.id)
+                      writer.write(
+                        {
+                          id: id,
+                          error: {
+                            code: LSP::Constant::ErrorCodes::INTERNAL_ERROR,
+                            message: "Unexpected error: #{exn.message} (#{exn.class})"
+                          }
+                        }
+                      )
+                    end
+
                     writer.write(
                       {
                         method: "window/showMessage",

--- a/lib/steep/services/goto_service.rb
+++ b/lib/steep/services/goto_service.rb
@@ -524,7 +524,9 @@ module Steep
       def constant_definition_in_ruby(name, locations:)
         type_check.source_files.each do |path, source|
           if typing = source.typing
-            target = project.target_for_source_path(path) or raise
+            # Inline sources are type checked too, but they don't have a Ruby definition to go to.
+            # Their declarations are found through the RBS lookup instead.
+            target = project.target_for_source_path(path) or next
             entry = typing.source_index.entry(constant: name)
             entry.definitions.each do |node|
               case node.type
@@ -551,7 +553,9 @@ module Steep
         if in_ruby
           type_check.source_files.each do |path, source|
             if typing = source.typing
-              target = project.target_for_source_path(path) or raise
+              # Inline sources are type checked too, but they don't have a Ruby definition to go to.
+              # Their declarations are found through the RBS lookup instead.
+              target = project.target_for_source_path(path) or next
               entry = typing.source_index.entry(method: name)
 
               if entry.definitions.empty?

--- a/sig/shims/language-server_protocol.rbs
+++ b/sig/shims/language-server_protocol.rbs
@@ -162,6 +162,7 @@ module LanguageServer
       module ErrorCodes
         INVALID_REQUEST: -32600
         SERVER_NOT_INITIALIZED: -32002
+        INTERNAL_ERROR: -32603
 
         type t = Integer
       end

--- a/sig/test/base_worker_test.rbs
+++ b/sig/test/base_worker_test.rbs
@@ -1,0 +1,55 @@
+# Generated from test/base_worker_test.rb with RBS::Inline
+
+use Steep::*
+
+class BaseWorkerTest < Minitest::Test
+  include TestHelper
+
+  include ShellHelper
+
+  include LSPTestHelper
+
+  include Steep
+
+  # A worker whose jobs always raise, to exercise `BaseWorker`'s error handling.
+  class RaisingWorker < Server::BaseWorker
+    class RequestJob < Struct[untyped]
+      attr_accessor id(): untyped
+
+      def self.new: (?id: untyped) -> instance
+                  | ({ ?id: untyped }) -> instance
+    end
+
+    class NotificationJob < Struct[untyped]
+      attr_accessor guid(): untyped
+
+      def self.new: (?guid: untyped) -> instance
+                  | ({ ?guid: untyped }) -> instance
+    end
+
+    attr_reader queue: untyped
+
+    def initialize: (project: untyped, reader: untyped, writer: untyped) -> untyped
+
+    def handle_request: (untyped request) -> untyped
+
+    def handle_job: (untyped job) -> untyped
+  end
+
+  def dirs: () -> untyped
+
+  def project: () -> untyped
+
+  # Runs a worker, and shuts it down after the block returns -- even when an assertion fails,
+  # so that a regression fails the test instead of hanging it.
+  #
+  # @rbs (Queue) { () -> void } -> void
+  def run_worker: (Queue) { () -> void } -> void
+
+  # @rbs (Queue) { (untyped) -> boolish } -> untyped
+  def pop_until: (Queue) { (untyped) -> boolish } -> untyped
+
+  def test_failed_request_job_returns_error_response: () -> untyped
+
+  def test_failed_notification_job_reports_message_only: () -> untyped
+end

--- a/sig/test/goto_service_test.rbs
+++ b/sig/test/goto_service_test.rbs
@@ -89,4 +89,8 @@ class GotoServiceTest < Minitest::Test
   def test_query_definition_method: () -> untyped
 
   def test_query_definition_constant: () -> untyped
+
+  def test_query_definition_method__inline: () -> untyped
+
+  def test_query_definition_constant__inline: () -> untyped
 end

--- a/test/base_worker_test.rb
+++ b/test/base_worker_test.rb
@@ -1,0 +1,115 @@
+require_relative "test_helper"
+
+# @rbs use Steep::*
+
+class BaseWorkerTest < Minitest::Test
+  include TestHelper
+  include ShellHelper
+  include LSPTestHelper
+
+  include Steep
+
+  # A worker whose jobs always raise, to exercise `BaseWorker`'s error handling.
+  class RaisingWorker < Server::BaseWorker
+    RequestJob = _ = Struct.new(:id, keyword_init: true)
+    NotificationJob = _ = Struct.new(:guid, keyword_init: true)
+
+    attr_reader :queue
+
+    def initialize(project:, reader:, writer:)
+      super
+      @queue = Queue.new
+    end
+
+    def handle_request(request)
+      case request[:method]
+      when "test/request"
+        queue << RequestJob.new(id: request[:id])
+      when "test/notification"
+        queue << NotificationJob.new(guid: "guid")
+      end
+    end
+
+    def handle_job(job)
+      raise "Boom"
+    end
+  end
+
+  def dirs
+    @dirs ||= []
+  end
+
+  def project
+    Project.new(steepfile_path: current_dir + "Steepfile").tap do |project|
+      Project::DSL.parse(project, <<~RUBY)
+        target :lib do
+          check "lib"
+          signature "sig"
+        end
+      RUBY
+    end
+  end
+
+  # Runs a worker, and shuts it down after the block returns -- even when an assertion fails,
+  # so that a regression fails the test instead of hanging it.
+  #
+  # @rbs (Queue) { () -> void } -> void
+  def run_worker(read_queue)
+    worker = RaisingWorker.new(project: project, reader: worker_reader, writer: worker_writer)
+
+    thread = Thread.new { worker.run() }
+
+    begin
+      yield
+    ensure
+      master_writer.write(id: -1, method: :shutdown, params: nil)
+      pop_until(read_queue) {|message| message[:id] == -1 }
+      master_writer.write(method: :exit)
+
+      thread.join
+      reader_pipe[1].close
+      writer_pipe[1].close
+    end
+  end
+
+  # @rbs (Queue) { (untyped) -> boolish } -> untyped
+  def pop_until(read_queue)
+    while message = read_queue.pop(timeout: 10)
+      return message if yield(message)
+    end
+
+    flunk "Timeout: the worker didn't send the expected message"
+  end
+
+  def test_failed_request_job_returns_error_response
+    in_tmpdir do
+      with_master_read_queue do |read_queue|
+        run_worker(read_queue) do
+          master_writer.write(id: 123, method: "test/request", params: nil)
+
+          response = pop_until(read_queue) {|message| message[:id] == 123 }
+
+          refute_operator response, :key?, :result
+          assert_equal LSP::Constant::ErrorCodes::INTERNAL_ERROR, response[:error][:code]
+          assert_match(/Boom/, response[:error][:message])
+        end
+      end
+    end
+  end
+
+  def test_failed_notification_job_reports_message_only
+    in_tmpdir do
+      with_master_read_queue do |read_queue|
+        run_worker(read_queue) do
+          master_writer.write(method: "test/notification", params: nil)
+
+          # The job carries no request id, so `window/showMessage` is the only message sent.
+          message = pop_until(read_queue) {|message| message[:method] == "window/showMessage" }
+
+          assert_equal LSP::Constant::MessageType::ERROR, message[:params][:type]
+          assert_match(/Boom/, message[:params][:message])
+        end
+      end
+    end
+  end
+end

--- a/test/goto_service_test.rb
+++ b/test/goto_service_test.rb
@@ -36,7 +36,8 @@ class GotoServiceTest < Minitest::Test
     type_check = Services::TypeCheckService.new(project: project)
     type_check.update(changes: changes)
     changes.each_key do |path|
-      if target = project.target_for_source_path(path)
+      # `TypeCheckWorker` type checks inline sources too, via `TypeCheckInlineCodeJob`.
+      if target = project.target_for_source_path(path) || project.target_for_inline_source_path(path)
         type_check.typecheck_source(path: path, target: target)
       end
     end
@@ -1185,6 +1186,53 @@ x = nil #: MyString?
       refute_empty locs
       assert locs.any? {|loc| loc.is_a?(RBS::Location) && loc.buffer.name.to_s.end_with?("customer.rbs") }
       assert locs.any? {|loc| !loc.is_a?(RBS::Location) && loc.source_buffer.name.to_s.end_with?("customer.rb") }
+    end
+  end
+
+  def test_query_definition_method__inline
+    type_check = type_check_service do |changes|
+      changes[Pathname("inline/a.rb")] = [ContentChange.string(<<~RUBY)]
+        class Customer
+          # @rbs () -> String
+          def greet
+            "hi"
+          end
+        end
+      RUBY
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("Customer#greet") or raise
+    service.query_definition(name).tap do |locs|
+      assert_any!(locs) do |loc|
+        assert_instance_of RBS::Location, loc
+        assert_equal "greet", loc.source
+        assert_equal Pathname("inline/a.rb"), loc.buffer.name
+      end
+    end
+  end
+
+  def test_query_definition_constant__inline
+    type_check = type_check_service do |changes|
+      changes[Pathname("inline/a.rb")] = [ContentChange.string(<<~RUBY)]
+        class Customer
+          # @rbs!
+          #   VERSION: String
+          VERSION = "0.1.0"
+        end
+      RUBY
+    end
+
+    service = Services::GotoService.new(type_check: type_check, assignment: assignment)
+
+    name = Services::GotoService.parse_name("Customer::VERSION") or raise
+    service.query_definition(name).tap do |locs|
+      assert_any!(locs) do |loc|
+        assert_instance_of RBS::Location, loc
+        assert_equal "VERSION", loc.source
+        assert_equal Pathname("inline/a.rb"), loc.buffer.name
+      end
     end
   end
 end


### PR DESCRIPTION
`steep query definition Foo#bar` never returned in a project with an inline
target, once anything had been type checked.

`GotoService#method_locations` and `#constant_definition_in_ruby` take the
target of every type checked source from `target_for_source_path` and raise
when there is none. Inline sources have no target there, but they do land in
`source_files` and do get a `typing`, so the lookup raised. They are skipped
now: an inline source has no Ruby definition to go to, and its declarations
are found through the RBS index anyway.

The second commit is why this was a hang rather than an error. `BaseWorker#run`
answered a raising job with `window/showMessage` alone; a job carrying an `id`
now gets an LSP error response too, so the client stops waiting.