### PR TITLE
Update RBS to 4.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,3 @@ group :development, optional: true do
 end
 
 # gem "rbs", path: "../rbs"
-gem "rbs", "4.2.0.pre.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       parser (>= 3.2)
       prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 4.0)
+      rbs (~> 4.2)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
@@ -63,7 +63,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (4.2.0.pre.1)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -97,7 +97,6 @@ DEPENDENCIES
   minitest-hooks
   minitest-slow_test
   rake
-  rbs (= 4.2.0.pre.1)
   stackprof
   steep!
   vernier (~> 1.5)

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -69,7 +69,7 @@ module Steep
         @io_socket = io_socket
         @service = service if service
         @child_pids = []
-        @need_to_warmup = defined?(Process.warmup)
+        @need_to_warmup = true
 
         if io_socket
           Signal.trap "SIGCHLD" do

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -134,7 +134,7 @@ module Steep
 
       attr_reader child_pids: Array[Integer]
 
-      attr_reader need_to_warmup: boolish
+      attr_reader need_to_warmup: bool
 
       include ChangeBuffer
 

--- a/steep.gemspec
+++ b/steep.gemspec
@@ -29,14 +29,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.3.0'
 
   spec.add_runtime_dependency "parser", ">= 3.2"
   spec.add_runtime_dependency "prism", ">= 0.25.0"
   spec.add_runtime_dependency "rainbow", ">= 2.2.2", "< 4.0"
   spec.add_runtime_dependency "listen", "~> 3.0"
   spec.add_runtime_dependency "language_server-protocol", ">= 3.17.0.4", "< 4.0"
-  spec.add_runtime_dependency "rbs", "~> 4.0"
+  spec.add_runtime_dependency "rbs", "~> 4.2"
   spec.add_runtime_dependency "concurrent-ruby", ">= 1.1.10"
   spec.add_runtime_dependency "terminal-table", ">= 2", "< 5"
   spec.add_runtime_dependency "securerandom", ">= 0.1"


### PR DESCRIPTION
The gem dependency moves from `rbs ~> 4.0` to `~> 4.2`. ruby/rbs#3067 fixes type param alignment for module self types, which Steep relies on when it validates mixin constraints, and it is not backported to the 4.1 series.

RBS 4.2 requires Ruby 3.3, so `required_ruby_version` moves up to match and the `defined?(Process.warmup)` check in `TypeCheckWorker` goes away -- `Process.warmup` landed in 3.3. Nothing else in `lib/` was gated on the Ruby version, and CI already runs 3.3, 3.4 and 4.0.