### PR TITLE
Remove the if false block from the gemspec

### DIFF
--- a/steep.gemspec
+++ b/steep.gemspec
@@ -29,12 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  if false
-    # This is to let dependabot use 3.3, instead of 3.1.x.
-    # They use `required_ruby_version=` method to detect the Ruby version they use.
-    spec.required_ruby_version = ">= 3.3.0"
-  end
-
   spec.required_ruby_version = '>= 3.2.0'
 
   spec.add_runtime_dependency "parser", ">= 3.2"


### PR DESCRIPTION
It existed to make dependabot read 3.3 rather than the declared `required_ruby_version`, but dependabot no longer updates the gems here: `.github/dependabot.yml` only covers GitHub Actions, and gem updates come from the `bundle update` workflow.