### PR TITLE
Narrow union types on `eql?` and `equal?`

### DIFF
--- a/lib/steep/ast/types/logic.rb
+++ b/lib/steep/ast/types/logic.rb
@@ -44,6 +44,13 @@ module Steep
         class ReceiverIsArg < Base
         end
 
+        # Same as `ReceiverIsArg`, but for identity comparison (`equal?`): a
+        # falsy result doesn't imply the receiver is not the argument value,
+        # because equal values may be distinct objects (String, non-fixnum
+        # Integer literals).
+        class ReceiverIdenticalToArg < Base
+        end
+
         class ArgIsReceiver < Base
         end
 

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -829,21 +829,30 @@ module Steep
                 )
               )
             end
-          when :==
+          when :==, :eql?, :equal?
             case defined_in
             when RBS::BuiltinNames::BasicObject.name,
               RBS::BuiltinNames::Object.name,
               RBS::BuiltinNames::Kernel.name,
+              RBS::BuiltinNames::Numeric.name,
               RBS::BuiltinNames::String.name,
               RBS::BuiltinNames::Integer.name,
               RBS::BuiltinNames::Symbol.name,
               RBS::BuiltinNames::TrueClass.name,
               RBS::BuiltinNames::FalseClass.name,
               RBS::TypeName.parse("::NilClass")
-              # For ==, we use ReceiverIsArg to narrow the receiver based on the argument
+              # For ==, eql?, and equal?, we narrow the receiver based on the argument.
+              # `equal?` is identity comparison, so a falsy result doesn't rule out value
+              # equality, and the else branch is narrowed more conservatively.
+              logic_type =
+                if method_name.method_name == :equal?
+                  AST::Types::Logic::ReceiverIdenticalToArg.instance()
+                else
+                  AST::Types::Logic::ReceiverIsArg.instance()
+                end
               return method_type.with(
                 type: method_type.type.with(
-                  return_type: AST::Types::Logic::ReceiverIsArg.instance()
+                  return_type: logic_type
                 )
               )
             end

--- a/lib/steep/type_inference/logic_type_interpreter.rb
+++ b/lib/steep/type_inference/logic_type_interpreter.rb
@@ -53,6 +53,10 @@ module Steep
       BOT = AST::Types::Bot.instance
       UNTYPED = AST::Types::Any.instance
 
+      # The fixnum range of 32 bit platforms, the conservative bound for integers
+      # that are guaranteed to be interned on any platform
+      FIXNUM_RANGE = (-(2**30)..(2**30 - 1)) #: Range[Integer]
+
       def eval(env:, node:)
         evaluate_node(env: env, node: node)
       end
@@ -324,12 +328,15 @@ module Steep
             [truthy_result, falsy_result]
           end
 
-        when AST::Types::Logic::ReceiverIsArg
+        when AST::Types::Logic::ReceiverIsArg, AST::Types::Logic::ReceiverIdenticalToArg
+          identity = type.is_a?(AST::Types::Logic::ReceiverIdenticalToArg)
+
           if receiver && (arg = arguments[0])
             receiver_type = typing.type_of(node: receiver)
             arg_type = factory.deep_expand_alias(typing.type_of(node: arg))
 
             if arg_type.is_a?(AST::Types::Name::Singleton)
+              return if identity
               truthy_type, falsy_type = type_case_select(receiver_type, arg_type.name)
               truthy_env, falsy_env = refine_node_type(
                 env: env,
@@ -345,7 +352,7 @@ module Steep
               falsy_result.unreachable! unless falsy_type
 
               [truthy_result, falsy_result]
-            elsif (truthy_types, falsy_types = literal_var_type_case_select(arg, receiver_type, for_receiver: true))
+            elsif (truthy_types, falsy_types = literal_var_type_case_select(arg, receiver_type, for_receiver: true, identity: identity))
               # Handle literal equality: receiver == literal_value
               truthy_env, falsy_env = refine_node_type(
                 env: env,
@@ -509,7 +516,7 @@ module Steep
         end
       end
 
-      def literal_var_type_case_select(value_node, arg_type, for_receiver: false)
+      def literal_var_type_case_select(value_node, arg_type, for_receiver: false, identity: false)
         case arg_type
         when AST::Types::Union
           # @type var truthy_types: Array[AST::Types::t]
@@ -518,7 +525,7 @@ module Steep
           falsy_types = []
 
           arg_type.types.each do |type|
-            if (ts, fs = literal_var_type_case_select(value_node, type, for_receiver: for_receiver))
+            if (ts, fs = literal_var_type_case_select(value_node, type, for_receiver: for_receiver, identity: identity))
               truthy_types.push(*ts)
               falsy_types.push(*fs)
             else
@@ -560,6 +567,10 @@ module Steep
               when type.is_a?(AST::Types::Literal)
                 if type.value == value_node.children[0]
                   true_types << type
+                  # For `equal?`, equal values may be distinct objects (String and
+                  # non-fixnum Integer literals aren't interned), so a falsy result
+                  # doesn't rule out the matched literal type.
+                  false_types << type if identity && !interned_literal?(value_node)
                 else
                   false_types << type
                 end
@@ -574,6 +585,21 @@ module Steep
               end
             end
           end
+        end
+      end
+
+      # Whether the literal node denotes a value for which Ruby guarantees that
+      # value equality implies object identity: Symbols, fixnum Integers, `true`,
+      # `false`, and `nil` are interned; Strings and non-fixnum Integers are not.
+      def interned_literal?(value_node)
+        case value_node.type
+        when :sym, :true, :false, :nil
+          true
+        when :int
+          int = value_node.children[0] #: Integer
+          FIXNUM_RANGE.include?(int)
+        else
+          false
         end
       end
 

--- a/sig/steep/ast/types.rbs
+++ b/sig/steep/ast/types.rbs
@@ -6,7 +6,7 @@ module Steep
            | Intersection  | Record | Tuple | Union
            | Name::Alias | Name::Instance | Name::Interface | Name::Singleton
            | Proc | Var
-           | Logic::Not | Logic::ReceiverIsNil | Logic::ReceiverIsNotNil | Logic::ReceiverIsArg | Logic::ArgIsReceiver | Logic::ArgEqualsReceiver | Logic::ArgIsAncestor | Logic::Env
+           | Logic::Not | Logic::ReceiverIsNil | Logic::ReceiverIsNotNil | Logic::ReceiverIsArg | Logic::ReceiverIdenticalToArg | Logic::ArgIsReceiver | Logic::ArgEqualsReceiver | Logic::ArgIsAncestor | Logic::Env
 
       # Variables and special types that is subject for substitution
       #

--- a/sig/steep/ast/types/logic.rbs
+++ b/sig/steep/ast/types/logic.rbs
@@ -38,6 +38,13 @@ module Steep
         class ReceiverIsArg < Base
         end
 
+        # Same as `ReceiverIsArg`, but for identity comparison (`equal?`): a
+        # falsy result doesn't imply the receiver is not the argument value,
+        # because equal values may be distinct objects (String, non-fixnum
+        # Integer literals).
+        class ReceiverIdenticalToArg < Base
+        end
+
         # A type for `Class#===` call results.
         class ArgIsReceiver < Base
         end

--- a/sig/steep/type_inference/logic_type_interpreter.rbs
+++ b/sig/steep/type_inference/logic_type_interpreter.rbs
@@ -29,6 +29,10 @@ module Steep
 
       UNTYPED: AST::Types::Any
 
+      # The fixnum range of 32 bit platforms, the conservative bound for integers
+      # that are guaranteed to be interned on any platform
+      FIXNUM_RANGE: Range[Integer]
+
       attr_reader subtyping: Subtyping::Check
 
       attr_reader typing: Typing
@@ -98,7 +102,12 @@ module Steep
       # end
       # ```
       #
-      def literal_var_type_case_select: (Parser::AST::Node value_node, AST::Types::t arg_type, ?for_receiver: bool) -> [Array[AST::Types::t], Array[AST::Types::t]]?
+      def literal_var_type_case_select: (Parser::AST::Node value_node, AST::Types::t arg_type, ?for_receiver: bool, ?identity: bool) -> [Array[AST::Types::t], Array[AST::Types::t]]?
+
+      # Whether the literal node denotes a value for which Ruby guarantees that
+      # value equality implies object identity: Symbols, fixnum Integers, `true`,
+      # `false`, and `nil` are interned; Strings and non-fixnum Integers are not.
+      def interned_literal?: (Parser::AST::Node value_node) -> bool
 
       def type_case_select: (AST::Types::t `type`, RBS::TypeName klass) -> [AST::Types::t?, AST::Types::t?]
 

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -108,6 +108,8 @@ class TypeCheckTest < Minitest::Test
   # values, so the truthy branch is reachable.
   def test_type_narrowing__literal_equality_with_supertype: () -> untyped
 
+  def test_type_narrowing__literal_equality_with_eql_and_equal: () -> untyped
+
   def test_argument_error__unexpected_unexpected_positional_argument: () -> untyped
 
   def test_type_assertion__type_error: () -> untyped

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1617,6 +1617,92 @@ class TypeCheckTest < Minitest::Test
     )
   end
 
+  def test_type_narrowing__literal_equality_with_eql_and_equal
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class A
+            def foo: () -> (String | :some_symbol)
+            def bar: () -> ("foo" | "bar")
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class A
+            def foo
+              "hello"
+            end
+
+            def bar
+              "foo"
+            end
+          end
+
+          a = A.new
+
+          x = a.foo
+          if x.eql?(:some_symbol)
+            # @type var sym: :some_symbol
+            sym = x
+          else
+            # @type var str: String
+            str = x
+          end
+
+          y = a.foo
+          if y.equal?(:some_symbol)
+            # @type var sym: :some_symbol
+            sym = y
+          else
+            # Symbols are interned, so the else branch is narrowed
+            # @type var str: String
+            str = y
+          end
+
+          z = a.bar
+          if z.eql?("foo")
+            # @type var foo: "foo"
+            foo = z
+          else
+            # @type var bar: "bar"
+            bar = z
+          end
+
+          w = a.bar
+          if w.equal?("foo")
+            # @type var foo: "foo"
+            foo = w
+          else
+            # Equal strings may be distinct objects, so the else branch is not narrowed
+            # @type var union: "foo" | "bar"
+            union = w
+            # @type var bar: "bar"
+            bar = w
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 50
+                character: 2
+              end:
+                line: 50
+                character: 9
+            severity: ERROR
+            message: |-
+              Cannot assign a value of type `("foo" | "bar")` to a variable of type `"bar"`
+                ("foo" | "bar") <: "bar"
+                  "foo" <: "bar"
+            code: Ruby::IncompatibleAssignment
+      YAML
+    )
+  end
+
   def test_argument_error__unexpected_unexpected_positional_argument
     run_type_check_test(
       signatures: {


### PR DESCRIPTION
Steep narrows the receiver's union type when compared to a literal with `==`, but not with `eql?` or `equal?`. This PR handles those methods too.

`eql?` is strictly stricter than `==` and both directions agree on every literal type RBS can express, so it narrows exactly like `==`:

```ruby
# x: String | :some_symbol
if x.eql?(:some_symbol)
  # x: :some_symbol
else
  # x: String
end
```

`equal?` (identity) implies equality but a falsy result doesn’t rule out value equality, because equal values may be distinct objects:

```ruby
"fo+".sub("+", "o").equal?("foo")  # => false, yet the value is "foo"
```

So `equal?` gets its own logic type, `ReceiverIdenticalToArg`, which narrows the truthy branch like `==` but subtracts the literal from the else branch only when Ruby guarantees the literal is interned, so that value equality implies identity: `true`, `false`, `nil`, `Symbols`, and `Fixnum` Integers (using the 32-bit `Fixnum` bound to stay platform-independent). String and non-fixnum `Integer` literals leave the `else` branch un-narrowed:

```ruby
# x: "foo" | "bar"
if x.equal?("foo")
  # x: "foo"
else
  # x: "foo" | "bar"
end
```

The identity path also skips the singleton-argument narrowing, so `o.equal?(SomeClass)` doesn’t narrow `o` to a `SomeClass` instance in the truthy branch, since the receiver would be the class object itself, not an instance.

`::Numeric` is added to the list of accepted `defined_in` classes because `Integer#eql?` is defined in `Numeric` in the RBS core signatures (`equal?` resolves to `BasicObject` and the other `eql?` definitions to `Kernel` or `String`, which were already covered).
