### PR TITLE
Speed up subtyping checks of literal types

### DIFF
--- a/lib/steep/ast/types/literal.rb
+++ b/lib/steep/ast/types/literal.rb
@@ -14,7 +14,7 @@ module Steep
         end
 
         def hash
-          self.class.hash
+          self.class.hash ^ value.hash
         end
 
         alias eql? ==

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -459,11 +459,21 @@ module Steep
           end
 
         when relation.super_type.is_a?(AST::Types::Union)
-          Any(relation) do |result|
-            relation.super_type.types.sort_by {|ty| (path = hole_path(ty)) ? -path.size : -Float::INFINITY }.each do |super_type|
-              rel = Relation.new(sub_type: relation.sub_type, super_type: super_type)
-              result.add(rel) do
-                check_type(rel)
+          sub_type = relation.sub_type
+          if sub_type.is_a?(AST::Types::Literal) &&
+              relation.super_type.free_variables.empty? &&
+              relation.super_type.types.any? {|ty| ty.is_a?(AST::Types::Literal) && ty == sub_type }
+            # A literal type is a member of a union of literals: no need to test the
+            # branches one by one. Only for unions without free variables, so that no
+            # constraint recording can be skipped.
+            success(relation)
+          else
+            Any(relation) do |result|
+              relation.super_type.types.sort_by {|ty| (path = hole_path(ty)) ? -path.size : -Float::INFINITY }.each do |super_type|
+                rel = Relation.new(sub_type: relation.sub_type, super_type: super_type)
+                result.add(rel) do
+                  check_type(rel)
+                end
               end
             end
           end

--- a/sig/test/subtyping_test.rbs
+++ b/sig/test/subtyping_test.rbs
@@ -107,6 +107,12 @@ class SubtypingTest < Minitest::Test
 
   def test_literal_alias_union: () -> untyped
 
+  def test_literal_union_membership: () -> untyped
+
+  def test_literal_union_with_unknown_variable: () -> untyped
+
+  def test_literal_hash: () -> untyped
+
   def test_logic_type: () -> untyped
 
   def test_proc_type: () -> untyped

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -951,6 +951,44 @@ type c = a | b
     end
   end
 
+  def test_literal_union_membership
+    with_checker <<-EOF do |checker|
+type enum_t = 1 | 2 | 3 | "a" | "b" | :c
+    EOF
+      assert_success_check checker, "1", "::enum_t"
+      assert_success_check checker, '"b"', "::enum_t"
+      assert_success_check checker, ":c", "::enum_t"
+
+      assert_fail_check checker, "4", "::enum_t"
+      assert_fail_check checker, '"c"', "::enum_t"
+      assert_fail_check checker, ":a", "::enum_t"
+    end
+  end
+
+  def test_literal_union_with_unknown_variable
+    with_checker do |checker|
+      constraints = Constraints.new(unknowns: [:X])
+
+      # The literal-membership fast path must not apply to unions with unknown
+      # type variables: the constraint has to be recorded.
+      assert_success_check(
+        checker,
+        "1",
+        parse_type("X | 2", checker: checker, variables: [:X]),
+        constraints: constraints
+      )
+
+      assert_operator constraints, :unknown?, :X
+      assert_equal parse_type("1", checker: checker), constraints.lower_bound(:X)
+    end
+  end
+
+  def test_literal_hash
+    assert_equal AST::Types::Literal.new(value: 1).hash, AST::Types::Literal.new(value: 1).hash
+    refute_equal AST::Types::Literal.new(value: 1).hash, AST::Types::Literal.new(value: 2).hash
+    refute_equal AST::Types::Literal.new(value: "a").hash, AST::Types::Literal.new(value: "b").hash
+  end
+
   def test_logic_type
     with_checker do |checker|
       type = AST::Types::Logic::ReceiverIsNil.new()


### PR DESCRIPTION
`Literal#hash` returned the same value for every literal while `#==` compares the values, so all literal relations landed in one bucket of the subtyping cache and every lookup among them scanned the whole chain. The hash now includes the value.

Checking a literal against a union tried the branches one by one, building an `Any` result with a failure branch for every literal that did not match. When the union has no free variables and contains an equal literal, `check_type0` now returns a plain `Success`: success derivations are never inspected, so the result is indistinguishable. Unions with unknown type variables keep the branching path so that constraint recording is not skipped, and failures keep it so that diagnostics do not change.