### PR TITLE
Add subtyping cache statistics to steep check

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -26,6 +26,8 @@ target :app do
   signature "sig"
   ignore_signature "sig/test"
 
+  library "objspace"
+
   implicitly_returns_nil!
 
   configure_code_diagnostics(D::Ruby.strict) do |hash|

--- a/lib/steep.rb
+++ b/lib/steep.rb
@@ -67,6 +67,7 @@ require "steep/interface/shape"
 require "steep/interface/builder"
 
 require "steep/subtyping/result"
+require "steep/subtyping/stats"
 require "steep/subtyping/check"
 require "steep/subtyping/cache"
 require "steep/subtyping/relation"

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -65,6 +65,16 @@ module Steep
       end
 
       def shape(type, config)
+        if stats = Subtyping::Stats.active
+          stats.measure_shape(type) do
+            shape0(type, config)
+          end
+        else
+          shape0(type, config)
+        end
+      end
+
+      def shape0(type, config)
         Steep.logger.tagged(-> { "shape(#{type})" }) do
           if shape = raw_shape(type, config)
             # Optimization that skips unnecessary substitution

--- a/lib/steep/subtyping/cache.rb
+++ b/lib/steep/subtyping/cache.rb
@@ -5,6 +5,7 @@ module Steep
 
       def initialize
         @subtypes = {}
+        Stats.active&.register_cache(self)
       end
 
       def subtype(relation, self_type, instance_type, class_type, bounds)

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -204,7 +204,7 @@ module Steep
               success(relation)
             else
               toplevel = assumptions.empty?
-              stats&.compute(relation, cached: cached ? true : false, toplevel: toplevel)
+              stats&.compute(relation, cached: cached ? true : false, toplevel: toplevel, ground: fvs.empty?)
               started = stats && toplevel ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : nil
               push_assumption(relation) do
                 check_type0(relation).tap do |result|

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -189,20 +189,30 @@ module Steep
 
         relation.type!
 
+        stats = Stats.active
+
         Steep.logger.tagged(-> { "#{relation.sub_type} <: #{relation.super_type}" }) do
           bounds = cache_bounds(relation)
           fvs = relation.sub_type.free_variables + relation.super_type.free_variables
           cached = cache[relation, @self_type, @instance_type, @class_type, bounds]
           if cached && fvs.none? {|var| var.is_a?(Symbol) && constraints.unknown?(var) }
+            stats&.hit(relation, toplevel: assumptions.empty?)
             cached
           else
             if assumptions.member?(relation)
+              stats&.assumption(relation)
               success(relation)
             else
+              toplevel = assumptions.empty?
+              stats&.compute(relation, cached: cached ? true : false, toplevel: toplevel)
+              started = stats && toplevel ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : nil
               push_assumption(relation) do
                 check_type0(relation).tap do |result|
                   Steep.logger.debug { "result=#{result.class}" }
                   cache[relation, @self_type, @instance_type, @class_type, bounds] = result
+                  if stats && started
+                    stats.compute_time(relation, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started)
+                  end
                 end
               end
             end

--- a/lib/steep/subtyping/stats.rb
+++ b/lib/steep/subtyping/stats.rb
@@ -43,6 +43,8 @@ module Steep
                   :computes, :toplevel_computes, :computes_with_unusable_cache,
                   :assumption_successes, :context_misses
       attr_reader :toplevel_compute_time
+      attr_reader :shapes, :shape_calls
+      attr_reader :shape_time
 
       def initialize
         @kinds = {}
@@ -61,6 +63,12 @@ module Steep
         @assumption_successes = 0
         @context_misses = 0
         @toplevel_compute_time = 0.0
+
+        # shape target type => [calls, time] of Interface::Builder#shape
+        @shapes = {}
+        @shape_calls = 0
+        @shape_time = 0.0
+        @shape_depth = 0
       end
 
       # Returns the process-wide collector, or `nil` unless enabled via environment
@@ -93,6 +101,33 @@ module Steep
       def assumption(relation)
         count_call(relation, hit: false)
         @assumption_successes += 1
+      end
+
+      # Measures Interface::Builder#shape: total wall-clock time of outermost
+      # calls (shape building recurses into itself), and the time per shape
+      # target. Includes time served from the shape caches.
+      def measure_shape(type)
+        @shape_depth += 1
+        if @shape_depth == 1
+          @shape_calls += 1
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          begin
+            yield
+          ensure
+            @shape_depth -= 1
+            time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+            @shape_time += time
+            counts = (shapes[type] ||= [0, 0.0])
+            counts[0] += 1
+            counts[1] += time
+          end
+        else
+          begin
+            yield
+          ensure
+            @shape_depth -= 1
+          end
+        end
       end
 
       # `ground` is whether the relation has no free variables, including the
@@ -256,6 +291,20 @@ module Steep
             kind, stats.calls, percent(stats.hits, stats.calls), stats.computes, stats.toplevel_compute_time
           ]
         end
+
+        if shape_calls > 0
+          io.puts "  shape calls: #{shape_calls} taking #{shape_time.round(2)}s (distinct targets: #{shapes.size}; overlaps with compute time above)"
+          by_kind = {} #: Hash[String, [Integer, Float]]
+          shapes.each do |type, (calls, time)|
+            entry = (by_kind[type_kind(type)] ||= [0, 0.0])
+            entry[0] += calls
+            entry[1] += time
+          end
+          io.puts "  shape time by target kind:"
+          by_kind.sort_by {|_, (_, time)| -time }.take(8).each do |kind, (calls, time)|
+            io.puts "    %-40s %8d calls %8.2fs" % [kind, calls, time]
+          end
+        end
       end
 
       def as_json(entry_stats, exclusive_memory)
@@ -299,6 +348,15 @@ module Steep
               calls: stats.calls,
               hits: stats.hits,
               toplevel_compute_time: stats.toplevel_compute_time.round(4),
+            }
+          end,
+          shape_calls: shape_calls,
+          shape_time: shape_time.round(4),
+          top_shapes_by_time: shapes.sort_by {|_, (_, time)| -time }.take(20).map do |type, (calls, time)|
+            {
+              type: type.to_s,
+              calls: calls,
+              time: time.round(4),
             }
           end,
         }

--- a/lib/steep/subtyping/stats.rb
+++ b/lib/steep/subtyping/stats.rb
@@ -40,13 +40,14 @@ module Steep
       attr_reader :kinds, :relations, :caches
       attr_reader :calls, :reflexive_calls, :hits, :toplevel_hits, :reflexive_hits,
                   :computes, :toplevel_computes, :computes_with_unusable_cache,
-                  :assumption_successes
+                  :assumption_successes, :context_misses
       attr_reader :toplevel_compute_time
 
       def initialize
         @kinds = {}
         @relations = {}
         @caches = []
+        @ground_relations = Set[]
 
         @calls = 0
         @reflexive_calls = 0
@@ -57,6 +58,7 @@ module Steep
         @toplevel_computes = 0
         @computes_with_unusable_cache = 0
         @assumption_successes = 0
+        @context_misses = 0
         @toplevel_compute_time = 0.0
       end
 
@@ -92,11 +94,24 @@ module Steep
         @assumption_successes += 1
       end
 
-      def compute(relation, cached:, toplevel:)
+      # `ground` is whether the relation has no free variables, including the
+      # `self`/`instance`/`class` placeholder types: the result of such a relation
+      # does not depend on the (self_type, instance_type, class_type, bounds)
+      # context in the cache key. Computing a ground relation that was already
+      # computed before is a miss caused by context keying.
+      def compute(relation, cached:, toplevel:, ground:)
         count_call(relation, hit: false)
         @computes += 1
         @toplevel_computes += 1 if toplevel
         @computes_with_unusable_cache += 1 if cached
+
+        if ground
+          if @ground_relations.include?(relation)
+            @context_misses += 1
+          else
+            @ground_relations << relation
+          end
+        end
 
         kind = kind_stats(relation)
         kind.computes += 1
@@ -227,6 +242,7 @@ module Steep
         io.puts "  check_type calls: #{calls} (reflexive: #{reflexive_calls}, distinct relations: #{relations.size})"
         io.puts "  cache hits: #{hits} (#{percent(hits, calls)}; top-level: #{toplevel_hits}, reflexive: #{reflexive_hits})"
         io.puts "  computed: #{computes} (top-level: #{toplevel_computes}, taking #{toplevel_compute_time.round(2)}s; cached but unusable: #{computes_with_unusable_cache})"
+        io.puts "  context-fragmented misses: #{context_misses} (#{percent(context_misses, computes)} of computes are ground relations already computed in another context)"
         io.puts "  assumption successes: #{assumption_successes}"
         io.puts "  cache entries: #{entry_stats[:entries]} (contexts: #{entry_stats[:distinct_contexts]}, reflexive: #{entry_stats[:reflexive_entries]}, successes: #{entry_stats[:success_values]})"
         if exclusive_memory
@@ -254,6 +270,7 @@ module Steep
           toplevel_computes: toplevel_computes,
           toplevel_compute_time: toplevel_compute_time.round(4),
           computes_with_unusable_cache: computes_with_unusable_cache,
+          context_misses: context_misses,
           assumption_successes: assumption_successes,
           cache: entry_stats,
           exclusive_memory_bytes: exclusive_memory,

--- a/lib/steep/subtyping/stats.rb
+++ b/lib/steep/subtyping/stats.rb
@@ -1,20 +1,5 @@
 module Steep
   module Subtyping
-    # Collects statistics of the subtyping cache in `Subtyping::Check#check_type`.
-    #
-    # Activated by environment variables, so that it works with a normal `steep check`
-    # (each worker process reports its own stats on exit):
-    #
-    # * `STEEP_SUBTYPING_STATS=1` prints a summary to stderr on exit.
-    #   The summary contains only counts and type *kinds* -- no type names from the
-    #   code base --, so it can be shared safely.
-    # * `STEEP_SUBTYPING_STATS_FILE=path` appends one JSON object per process to the
-    #   file. The JSON includes the most frequent relations, which contain type names
-    #   from the code base.
-    # * `STEEP_SUBTYPING_STATS_MEMORY=1` additionally measures the memory exclusively
-    #   retained by the cache, by clearing it on exit and comparing
-    #   `ObjectSpace.memsize_of_all`. This makes the process exit slower.
-    #
     class Stats
       class KindStats
         attr_accessor :calls, :hits, :computes, :toplevel_computes, :toplevel_compute_time
@@ -64,15 +49,12 @@ module Steep
         @context_misses = 0
         @toplevel_compute_time = 0.0
 
-        # shape target type => [calls, time] of Interface::Builder#shape
         @shapes = {}
         @shape_calls = 0
         @shape_time = 0.0
         @shape_depth = 0
       end
 
-      # Returns the process-wide collector, or `nil` unless enabled via environment
-      # variables. The decision is made once per process.
       def self.active
         return @active if defined?(@active)
 
@@ -103,9 +85,6 @@ module Steep
         @assumption_successes += 1
       end
 
-      # Measures Interface::Builder#shape: total wall-clock time of outermost
-      # calls (shape building recurses into itself), and the time per shape
-      # target. Includes time served from the shape caches.
       def measure_shape(type)
         @shape_depth += 1
         if @shape_depth == 1
@@ -130,11 +109,6 @@ module Steep
         end
       end
 
-      # `ground` is whether the relation has no free variables, including the
-      # `self`/`instance`/`class` placeholder types: the result of such a relation
-      # does not depend on the (self_type, instance_type, class_type, bounds)
-      # context in the cache key. Computing a ground relation that was already
-      # computed before is a miss caused by context keying.
       def compute(relation, cached:, toplevel:, ground:)
         count_call(relation, hit: false)
         @computes += 1
@@ -211,8 +185,6 @@ module Steep
         "#{type_kind(relation.sub_type)} <: #{type_kind(relation.super_type)}"
       end
 
-      # Composition of the current cache entries: total count, distinct contexts,
-      # reflexive relations, and successful results.
       def entry_stats
         entries = 0
         contexts = Set[]
@@ -237,8 +209,6 @@ module Steep
         }
       end
 
-      # Memory exclusively retained by the caches, in bytes, measured by clearing
-      # them. Destructive -- only use when the caches are no longer needed.
       def measure_exclusive_memory!
         require "objspace"
 

--- a/lib/steep/subtyping/stats.rb
+++ b/lib/steep/subtyping/stats.rb
@@ -1,0 +1,281 @@
+module Steep
+  module Subtyping
+    # Collects statistics of the subtyping cache in `Subtyping::Check#check_type`.
+    #
+    # Activated by environment variables, so that it works with a normal `steep check`
+    # (each worker process reports its own stats on exit):
+    #
+    # * `STEEP_SUBTYPING_STATS=1` prints a summary to stderr on exit.
+    #   The summary contains only counts and type *kinds* -- no type names from the
+    #   code base --, so it can be shared safely.
+    # * `STEEP_SUBTYPING_STATS_FILE=path` appends one JSON object per process to the
+    #   file. The JSON includes the most frequent relations, which contain type names
+    #   from the code base.
+    # * `STEEP_SUBTYPING_STATS_MEMORY=1` additionally measures the memory exclusively
+    #   retained by the cache, by clearing it on exit and comparing
+    #   `ObjectSpace.memsize_of_all`. This makes the process exit slower.
+    #
+    class Stats
+      class KindStats
+        attr_accessor :calls, :hits, :computes, :toplevel_computes, :toplevel_compute_time
+
+        def initialize
+          @calls = 0
+          @hits = 0
+          @computes = 0
+          @toplevel_computes = 0
+          @toplevel_compute_time = 0.0
+        end
+      end
+
+      class RelationStats
+        attr_accessor :calls, :hits
+
+        def initialize
+          @calls = 0
+          @hits = 0
+        end
+      end
+
+      attr_reader :kinds, :relations, :caches
+      attr_reader :calls, :reflexive_calls, :hits, :toplevel_hits, :reflexive_hits,
+                  :computes, :toplevel_computes, :computes_with_unusable_cache,
+                  :assumption_successes
+      attr_reader :toplevel_compute_time
+
+      def initialize
+        @kinds = {}
+        @relations = {}
+        @caches = []
+
+        @calls = 0
+        @reflexive_calls = 0
+        @hits = 0
+        @toplevel_hits = 0
+        @reflexive_hits = 0
+        @computes = 0
+        @toplevel_computes = 0
+        @computes_with_unusable_cache = 0
+        @assumption_successes = 0
+        @toplevel_compute_time = 0.0
+      end
+
+      # Returns the process-wide collector, or `nil` unless enabled via environment
+      # variables. The decision is made once per process.
+      def self.active
+        return @active if defined?(@active)
+
+        @active =
+          if ENV["STEEP_SUBTYPING_STATS"] || ENV["STEEP_SUBTYPING_STATS_FILE"]
+            stats = new()
+            at_exit { stats.report() }
+            stats
+          end
+      end
+
+      def self.active=(stats)
+        @active = stats
+      end
+
+      def register_cache(cache)
+        caches << cache
+      end
+
+      def hit(relation, toplevel:)
+        count_call(relation, hit: true)
+        @hits += 1
+        @toplevel_hits += 1 if toplevel
+      end
+
+      def assumption(relation)
+        count_call(relation, hit: false)
+        @assumption_successes += 1
+      end
+
+      def compute(relation, cached:, toplevel:)
+        count_call(relation, hit: false)
+        @computes += 1
+        @toplevel_computes += 1 if toplevel
+        @computes_with_unusable_cache += 1 if cached
+
+        kind = kind_stats(relation)
+        kind.computes += 1
+        kind.toplevel_computes += 1 if toplevel
+      end
+
+      def compute_time(relation, time)
+        @toplevel_compute_time += time
+        kind_stats(relation).toplevel_compute_time += time
+      end
+
+      def count_call(relation, hit:)
+        @calls += 1
+        reflexive = relation.sub_type == relation.super_type
+        @reflexive_calls += 1 if reflexive
+        @reflexive_hits += 1 if reflexive && hit
+
+        kind = kind_stats(relation)
+        kind.calls += 1
+        kind.hits += 1 if hit
+
+        rel = (relations[relation] ||= RelationStats.new)
+        rel.calls += 1
+        rel.hits += 1 if hit
+      end
+
+      def kind_stats(relation)
+        kinds[relation_kind(relation)] ||= KindStats.new
+      end
+
+      def type_kind(type)
+        case type
+        when AST::Types::Name::Instance then "Instance"
+        when AST::Types::Name::Singleton then "Singleton"
+        when AST::Types::Name::Interface then "Interface"
+        when AST::Types::Name::Alias then "Alias"
+        when AST::Types::Union then "Union"
+        when AST::Types::Intersection then "Intersection"
+        when AST::Types::Tuple then "Tuple"
+        when AST::Types::Record then "Record"
+        when AST::Types::Proc then "Proc"
+        when AST::Types::Literal then "Literal"
+        when AST::Types::Boolean then "bool"
+        when AST::Types::Var then "Var"
+        when AST::Types::Any then "untyped"
+        when AST::Types::Top then "top"
+        when AST::Types::Bot then "bot"
+        when AST::Types::Void then "void"
+        when AST::Types::Nil then "nil"
+        when AST::Types::Self then "self"
+        when AST::Types::Instance then "instance"
+        when AST::Types::Class then "class"
+        when AST::Types::Logic::Base then "logic"
+        else
+          type.class.name || "?"
+        end
+      end
+
+      def relation_kind(relation)
+        "#{type_kind(relation.sub_type)} <: #{type_kind(relation.super_type)}"
+      end
+
+      # Composition of the current cache entries: total count, distinct contexts,
+      # reflexive relations, and successful results.
+      def entry_stats
+        entries = 0
+        contexts = Set[]
+        reflexive = 0
+        successes = 0
+
+        caches.each do |cache|
+          cache.subtypes.each do |key, value|
+            relation, self_type, instance_type, class_type, bounds = key
+            entries += 1
+            contexts << [self_type, instance_type, class_type, bounds]
+            reflexive += 1 if relation.sub_type == relation.super_type
+            successes += 1 if value.success?
+          end
+        end
+
+        {
+          entries: entries,
+          distinct_contexts: contexts.size,
+          reflexive_entries: reflexive,
+          success_values: successes,
+        }
+      end
+
+      # Memory exclusively retained by the caches, in bytes, measured by clearing
+      # them. Destructive -- only use when the caches are no longer needed.
+      def measure_exclusive_memory!
+        require "objspace"
+
+        2.times { GC.start }
+        before = ObjectSpace.memsize_of_all
+        caches.each {|cache| cache.subtypes.clear }
+        2.times { GC.start }
+        after = ObjectSpace.memsize_of_all
+
+        before - after
+      end
+
+      def percent(count, total)
+        return "-" if total.zero?
+        "#{(count * 100.0 / total).round(1)}%"
+      end
+
+      def report
+        return if calls.zero?
+
+        entry_stats = entry_stats()
+        exclusive_memory = ENV["STEEP_SUBTYPING_STATS_MEMORY"] ? measure_exclusive_memory! : nil
+
+        if ENV["STEEP_SUBTYPING_STATS"]
+          report_text($stderr, entry_stats, exclusive_memory)
+        end
+
+        if path = ENV["STEEP_SUBTYPING_STATS_FILE"]
+          require "json"
+          File.open(path, "a") do |io|
+            io.puts(JSON.generate(as_json(entry_stats, exclusive_memory)))
+          end
+        end
+      end
+
+      def report_text(io, entry_stats, exclusive_memory)
+        io.puts "[steep #{VERSION}] subtyping cache stats (pid #{Process.pid})"
+        io.puts "  check_type calls: #{calls} (reflexive: #{reflexive_calls}, distinct relations: #{relations.size})"
+        io.puts "  cache hits: #{hits} (#{percent(hits, calls)}; top-level: #{toplevel_hits}, reflexive: #{reflexive_hits})"
+        io.puts "  computed: #{computes} (top-level: #{toplevel_computes}, taking #{toplevel_compute_time.round(2)}s; cached but unusable: #{computes_with_unusable_cache})"
+        io.puts "  assumption successes: #{assumption_successes}"
+        io.puts "  cache entries: #{entry_stats[:entries]} (contexts: #{entry_stats[:distinct_contexts]}, reflexive: #{entry_stats[:reflexive_entries]}, successes: #{entry_stats[:success_values]})"
+        if exclusive_memory
+          io.puts "  memory exclusively retained by cache: #{(exclusive_memory / 1024.0 / 1024).round(1)}MB"
+        end
+        io.puts "  top kinds by calls:"
+        kinds.sort_by {|_, stats| -stats.calls }.take(15).each do |kind, stats|
+          io.puts "    %-40s %8d calls %6s hit %8d computes %8.2fs top-level compute" % [
+            kind, stats.calls, percent(stats.hits, stats.calls), stats.computes, stats.toplevel_compute_time
+          ]
+        end
+      end
+
+      def as_json(entry_stats, exclusive_memory)
+        {
+          steep_version: VERSION,
+          pid: Process.pid,
+          calls: calls,
+          reflexive_calls: reflexive_calls,
+          distinct_relations: relations.size,
+          hits: hits,
+          toplevel_hits: toplevel_hits,
+          reflexive_hits: reflexive_hits,
+          computes: computes,
+          toplevel_computes: toplevel_computes,
+          toplevel_compute_time: toplevel_compute_time.round(4),
+          computes_with_unusable_cache: computes_with_unusable_cache,
+          assumption_successes: assumption_successes,
+          cache: entry_stats,
+          exclusive_memory_bytes: exclusive_memory,
+          kinds: kinds.sort_by {|_, stats| -stats.calls }.map do |kind, stats|
+            {
+              kind: kind,
+              calls: stats.calls,
+              hits: stats.hits,
+              computes: stats.computes,
+              toplevel_computes: stats.toplevel_computes,
+              toplevel_compute_time: stats.toplevel_compute_time.round(4),
+            }
+          end,
+          top_relations: relations.sort_by {|_, stats| -stats.calls }.take(25).map do |relation, stats|
+            {
+              relation: relation.to_s,
+              calls: stats.calls,
+              hits: stats.hits,
+            }
+          end,
+        }
+      end
+    end
+  end
+end

--- a/lib/steep/subtyping/stats.rb
+++ b/lib/steep/subtyping/stats.rb
@@ -29,11 +29,12 @@ module Steep
       end
 
       class RelationStats
-        attr_accessor :calls, :hits
+        attr_accessor :calls, :hits, :toplevel_compute_time
 
         def initialize
           @calls = 0
           @hits = 0
+          @toplevel_compute_time = 0.0
         end
       end
 
@@ -121,6 +122,7 @@ module Steep
       def compute_time(relation, time)
         @toplevel_compute_time += time
         kind_stats(relation).toplevel_compute_time += time
+        (relations[relation] ||= RelationStats.new).toplevel_compute_time += time
       end
 
       def count_call(relation, hit:)
@@ -289,6 +291,14 @@ module Steep
               relation: relation.to_s,
               calls: stats.calls,
               hits: stats.hits,
+            }
+          end,
+          top_relations_by_compute_time: relations.each.select {|_, stats| stats.toplevel_compute_time > 0 }.sort_by {|_, stats| -stats.toplevel_compute_time }.take(15).map do |relation, stats|
+            {
+              relation: relation.to_s,
+              calls: stats.calls,
+              hits: stats.hits,
+              toplevel_compute_time: stats.toplevel_compute_time.round(4),
             }
           end,
         }

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -62,6 +62,8 @@ module Steep
       #
       def shape: (AST::Types::t, Config) -> Shape?
 
+      def shape0: (AST::Types::t, Config) -> Shape?
+
       private
 
       def fetch_cache: [KEY < ::Hash::_Key] (Hash[KEY, Shape?], KEY) { () -> Shape? } -> Shape?

--- a/sig/steep/subtyping/stats.rbs
+++ b/sig/steep/subtyping/stats.rbs
@@ -1,0 +1,113 @@
+module Steep
+  module Subtyping
+    # Collects statistics of the subtyping cache in `Subtyping::Check#check_type`.
+    #
+    # Activated by environment variables, so that it works with a normal `steep check`
+    # (each worker process reports its own stats on exit):
+    #
+    # * `STEEP_SUBTYPING_STATS=1` prints a summary to stderr on exit.
+    # * `STEEP_SUBTYPING_STATS_FILE=path` appends one JSON object per process to the file.
+    # * `STEEP_SUBTYPING_STATS_MEMORY=1` additionally measures the memory exclusively
+    #   retained by the cache.
+    #
+    class Stats
+      class KindStats
+        attr_accessor calls: Integer
+
+        attr_accessor hits: Integer
+
+        attr_accessor computes: Integer
+
+        attr_accessor toplevel_computes: Integer
+
+        attr_accessor toplevel_compute_time: Float
+
+        def initialize: () -> void
+      end
+
+      class RelationStats
+        attr_accessor calls: Integer
+
+        attr_accessor hits: Integer
+
+        def initialize: () -> void
+      end
+
+      type entry_stats = {
+        entries: Integer,
+        distinct_contexts: Integer,
+        reflexive_entries: Integer,
+        success_values: Integer
+      }
+
+      attr_reader kinds: Hash[String, KindStats]
+
+      attr_reader relations: Hash[Relation[untyped], RelationStats]
+
+      attr_reader caches: Array[Cache]
+
+      attr_reader calls: Integer
+
+      attr_reader reflexive_calls: Integer
+
+      attr_reader hits: Integer
+
+      attr_reader toplevel_hits: Integer
+
+      attr_reader reflexive_hits: Integer
+
+      attr_reader computes: Integer
+
+      attr_reader toplevel_computes: Integer
+
+      attr_reader computes_with_unusable_cache: Integer
+
+      attr_reader assumption_successes: Integer
+
+      attr_reader toplevel_compute_time: Float
+
+      self.@active: Stats?
+
+      def initialize: () -> void
+
+      # Returns the process-wide collector, or `nil` unless enabled via environment
+      # variables. The decision is made once per process.
+      def self.active: () -> Stats?
+
+      def self.active=: (Stats?) -> Stats?
+
+      def register_cache: (Cache) -> void
+
+      def hit: (Relation[untyped] relation, toplevel: bool) -> void
+
+      def assumption: (Relation[untyped] relation) -> void
+
+      def compute: (Relation[untyped] relation, cached: bool, toplevel: bool) -> void
+
+      def compute_time: (Relation[untyped] relation, Float time) -> void
+
+      def count_call: (Relation[untyped] relation, hit: bool) -> void
+
+      def kind_stats: (Relation[untyped] relation) -> KindStats
+
+      def type_kind: (untyped `type`) -> String
+
+      def relation_kind: (Relation[untyped] relation) -> String
+
+      # Composition of the current cache entries.
+      def entry_stats: () -> entry_stats
+
+      # Memory exclusively retained by the caches, in bytes, measured by clearing
+      # them. Destructive -- only use when the caches are no longer needed.
+      def measure_exclusive_memory!: () -> Integer
+
+      def percent: (Integer count, Integer total) -> String
+
+      def report: () -> void
+
+      def report_text: (IO io, entry_stats stats, Integer? exclusive_memory) -> void
+
+      def as_json: (entry_stats stats, Integer? exclusive_memory) -> Hash[Symbol, untyped]
+    end
+  end
+end

--- a/sig/steep/subtyping/stats.rbs
+++ b/sig/steep/subtyping/stats.rbs
@@ -30,6 +30,8 @@ module Steep
 
         attr_accessor hits: Integer
 
+        attr_accessor toplevel_compute_time: Float
+
         def initialize: () -> void
       end
 

--- a/sig/steep/subtyping/stats.rbs
+++ b/sig/steep/subtyping/stats.rbs
@@ -70,6 +70,15 @@ module Steep
 
       attr_reader toplevel_compute_time: Float
 
+      # shape target type => [calls, time] of Interface::Builder#shape
+      attr_reader shapes: Hash[AST::Types::t, [Integer, Float]]
+
+      attr_reader shape_calls: Integer
+
+      attr_reader shape_time: Float
+
+      @shape_depth: Integer
+
       @ground_relations: Set[Relation[untyped]]
 
       self.@active: Stats?
@@ -87,6 +96,10 @@ module Steep
       def hit: (Relation[untyped] relation, toplevel: bool) -> void
 
       def assumption: (Relation[untyped] relation) -> void
+
+      # Measures Interface::Builder#shape: total wall-clock time of outermost
+      # calls, and the time per shape target.
+      def measure_shape: [A] (AST::Types::t `type`) { () -> A } -> A
 
       # `ground` is whether the relation has no free variables, including the
       # `self`/`instance`/`class` placeholder types. Computing a ground relation

--- a/sig/steep/subtyping/stats.rbs
+++ b/sig/steep/subtyping/stats.rbs
@@ -64,7 +64,11 @@ module Steep
 
       attr_reader assumption_successes: Integer
 
+      attr_reader context_misses: Integer
+
       attr_reader toplevel_compute_time: Float
+
+      @ground_relations: Set[Relation[untyped]]
 
       self.@active: Stats?
 
@@ -82,7 +86,10 @@ module Steep
 
       def assumption: (Relation[untyped] relation) -> void
 
-      def compute: (Relation[untyped] relation, cached: bool, toplevel: bool) -> void
+      # `ground` is whether the relation has no free variables, including the
+      # `self`/`instance`/`class` placeholder types. Computing a ground relation
+      # that was already computed before is a miss caused by context keying.
+      def compute: (Relation[untyped] relation, cached: bool, toplevel: bool, ground: bool) -> void
 
       def compute_time: (Relation[untyped] relation, Float time) -> void
 

--- a/sig/test/subtyping_stats_test.rbs
+++ b/sig/test/subtyping_stats_test.rbs
@@ -1,0 +1,27 @@
+# Generated from test/subtyping_stats_test.rb with RBS::Inline
+
+class SubtypingStatsTest < Minitest::Test
+  include TestHelper
+
+  include Steep
+
+  include FactoryHelper
+
+  Relation: untyped
+
+  Constraints: untyped
+
+  Stats: untyped
+
+  def with_checker: () ?{ (?) -> untyped } -> untyped
+
+  def parse_type: (untyped string, checker: untyped) -> untyped
+
+  def test_stats_counts_hits_and_computes: () -> untyped
+
+  def test_stats_context_fragmentation: () -> untyped
+
+  def test_stats_measure_shape: () -> untyped
+
+  def test_stats_inactive_by_default: () -> untyped
+end

--- a/test/subtyping_stats_test.rb
+++ b/test/subtyping_stats_test.rb
@@ -1,0 +1,101 @@
+require_relative "test_helper"
+
+class SubtypingStatsTest < Minitest::Test
+  include TestHelper
+  include Steep
+
+  include FactoryHelper
+
+  Relation = Subtyping::Relation
+  Constraints = Subtyping::Constraints
+  Stats = Subtyping::Stats
+
+  def with_checker(&block)
+    with_factory({ "a.rbs" => <<-EOS }, nostdlib: false) do |factory|
+class Foo
+end
+    EOS
+      builder = Interface::Builder.new(factory, implicitly_returns_nil: true)
+      yield Subtyping::Check.new(builder: builder)
+    end
+  end
+
+  def parse_type(string, checker:)
+    checker.factory.type(RBS::Parser.parse_type(string))
+  end
+
+  def test_stats_counts_hits_and_computes
+    Stats.active = Stats.new()
+
+    with_checker do |checker|
+      # Cache#initialize registers itself to the active Stats
+      stats = Stats.active or raise
+
+      relation = Relation.new(
+        sub_type: parse_type("::Foo", checker: checker),
+        super_type: parse_type("::Object", checker: checker)
+      )
+
+      2.times do
+        checker.check(
+          relation,
+          self_type: parse_type("self", checker: checker),
+          instance_type: AST::Types::Instance.new,
+          class_type: AST::Types::Class.new,
+          constraints: Constraints.empty
+        )
+      end
+
+      assert_operator stats.calls, :>, 0
+      assert_operator stats.computes, :>, 0
+      # The second check must hit the cache
+      assert_operator stats.hits, :>, 0
+      assert_operator stats.toplevel_hits, :>, 0
+      assert_operator stats.toplevel_compute_time, :>, 0.0
+
+      assert_operator stats.kinds, :key?, "Instance <: Instance"
+      kind = stats.kinds.fetch("Instance <: Instance")
+      assert_operator kind.calls, :>, 0
+      assert_operator kind.hits, :>, 0
+
+      assert_equal stats.calls, stats.hits + stats.computes + stats.assumption_successes
+
+      entry_stats = stats.entry_stats
+      assert_operator entry_stats[:entries], :>, 0
+      assert_operator entry_stats[:distinct_contexts], :>, 0
+
+      json = stats.as_json(entry_stats, nil)
+      assert_equal stats.calls, json[:calls]
+      refute_empty json[:kinds]
+      refute_empty json[:top_relations]
+
+      io = StringIO.new
+      stats.report_text(io, entry_stats, nil)
+      assert_includes io.string, "subtyping cache stats"
+      assert_includes io.string, "Instance <: Instance"
+    end
+  ensure
+    Stats.active = nil
+  end
+
+  def test_stats_inactive_by_default
+    Stats.active = nil
+
+    with_checker do |checker|
+      relation = Relation.new(
+        sub_type: parse_type("::Foo", checker: checker),
+        super_type: parse_type("::Object", checker: checker)
+      )
+
+      result = checker.check(
+        relation,
+        self_type: parse_type("self", checker: checker),
+        instance_type: AST::Types::Instance.new,
+        class_type: AST::Types::Class.new,
+        constraints: Constraints.empty
+      )
+
+      assert_predicate result, :success?
+    end
+  end
+end

--- a/test/subtyping_stats_test.rb
+++ b/test/subtyping_stats_test.rb
@@ -108,6 +108,26 @@ end
     Stats.active = nil
   end
 
+  def test_stats_measure_shape
+    Stats.active = Stats.new()
+
+    with_checker do |checker|
+      stats = Stats.active or raise
+
+      type = parse_type("::Foo", checker: checker)
+      config = Interface::Builder::Config.new(self_type: type, variable_bounds: {})
+      checker.builder.shape(type, config)
+
+      assert_operator stats.shape_calls, :>, 0
+      assert_operator stats.shape_time, :>, 0.0
+
+      json = stats.as_json(stats.entry_stats, nil)
+      refute_empty json[:top_shapes_by_time]
+    end
+  ensure
+    Stats.active = nil
+  end
+
   def test_stats_inactive_by_default
     Stats.active = nil
 

--- a/test/subtyping_stats_test.rb
+++ b/test/subtyping_stats_test.rb
@@ -68,6 +68,7 @@ end
       assert_equal stats.calls, json[:calls]
       refute_empty json[:kinds]
       refute_empty json[:top_relations]
+      refute_empty json[:top_relations_by_compute_time]
 
       io = StringIO.new
       stats.report_text(io, entry_stats, nil)

--- a/test/subtyping_stats_test.rb
+++ b/test/subtyping_stats_test.rb
@@ -78,6 +78,35 @@ end
     Stats.active = nil
   end
 
+  def test_stats_context_fragmentation
+    Stats.active = Stats.new()
+
+    with_checker do |checker|
+      stats = Stats.active or raise
+
+      relation = Relation.new(
+        sub_type: parse_type("::Foo", checker: checker),
+        super_type: parse_type("::Object", checker: checker)
+      )
+
+      # The same ground relation in two different contexts: the second check
+      # misses the cache only because of the context in the cache key.
+      [parse_type("::Foo", checker: checker), parse_type("::Object", checker: checker)].each do |self_type|
+        checker.check(
+          relation,
+          self_type: self_type,
+          instance_type: AST::Types::Instance.new,
+          class_type: AST::Types::Class.new,
+          constraints: Constraints.empty
+        )
+      end
+
+      assert_operator stats.context_misses, :>, 0
+    end
+  ensure
+    Stats.active = nil
+  end
+
   def test_stats_inactive_by_default
     Stats.active = nil
 


### PR DESCRIPTION
Setting `STEEP_SUBTYPING_STATS=1` makes each worker process print a summary of the subtyping cache on exit: `check_type` calls, hits and computes with a per-kind breakdown (`Instance <: Union`, ...), the compute time of top-level checks, the cache entries by kind, and the time spent in `Interface::Builder#shape`. The summary contains only counts and type kinds, no type names, so it can be shared from a private codebase. `STEEP_SUBTYPING_STATS_FILE=path` appends a JSON report per process that additionally lists the most frequent relations, the relations with the highest compute time and the most expensive shape targets — those do contain type names. `STEEP_SUBTYPING_STATS_MEMORY=1` measures the memory exclusively retained by the cache by clearing it on exit, which is why the `app` target now loads the `objspace` library.

With the variables unset the cost is a nil check per `check_type` call and per `shape` call.