### PR TITLE
Cache ground subtype relations without the context

### DIFF
--- a/lib/steep/subtyping/cache.rb
+++ b/lib/steep/subtyping/cache.rb
@@ -1,10 +1,20 @@
 module Steep
   module Subtyping
     class Cache
+      # Results of relations that have free variables, keyed by the relation and the
+      # context the check ran in
       attr_reader :subtypes
+
+      # Results of relations without free variables, keyed by the relation alone
+      #
+      # The `self`/`instance`/`class` types count as free variables, so the result of
+      # such a relation doesn't depend on the context of the check.
+      #
+      attr_reader :ground_subtypes
 
       def initialize
         @subtypes = {}
+        @ground_subtypes = {}
         Stats.active&.register_cache(self)
       end
 
@@ -23,8 +33,16 @@ module Steep
         subtypes[key] = value
       end
 
+      def ground(relation)
+        ground_subtypes[relation]
+      end
+
+      def store_ground(relation, value)
+        ground_subtypes[relation] = value
+      end
+
       def no_subtype_cache?
-        @subtypes.empty?
+        @subtypes.empty? && @ground_subtypes.empty?
       end
     end
   end

--- a/lib/steep/subtyping/cache.rb
+++ b/lib/steep/subtyping/cache.rb
@@ -1,15 +1,8 @@
 module Steep
   module Subtyping
     class Cache
-      # Results of relations that have free variables, keyed by the relation and the
-      # context the check ran in
       attr_reader :subtypes
 
-      # Results of relations without free variables, keyed by the relation alone
-      #
-      # The `self`/`instance`/`class` types count as free variables, so the result of
-      # such a relation doesn't depend on the context of the check.
-      #
       attr_reader :ground_subtypes
 
       def initialize
@@ -19,17 +12,17 @@ module Steep
       end
 
       def subtype(relation, self_type, instance_type, class_type, bounds)
-        key = [relation, self_type, instance_type, class_type, bounds]
+        key = [relation, self_type, instance_type, class_type, bounds] #: context_key
         subtypes[key]
       end
 
       def [](relation, self_type, instance_type, class_type, bounds)
-        key = [relation, self_type, instance_type, class_type, bounds]
+        key = [relation, self_type, instance_type, class_type, bounds] #: context_key
         subtypes[key]
       end
 
       def []=(relation, self_type, instance_type, class_type, bounds, value)
-        key = [relation, self_type, instance_type, class_type, bounds]
+        key = [relation, self_type, instance_type, class_type, bounds] #: context_key
         subtypes[key] = value
       end
 

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -191,32 +191,81 @@ module Steep
 
         stats = Stats.active
 
+        case
+        when relation.sub_type == relation.super_type,
+             relation.sub_type.is_a?(AST::Types::Any) || relation.super_type.is_a?(AST::Types::Any),
+             relation.super_type.is_a?(AST::Types::Void),
+             relation.super_type.is_a?(AST::Types::Top),
+             relation.sub_type.is_a?(AST::Types::Bot)
+          # Trivially holds, by the first branches of `check_type0`; not worth caching.
+          stats&.shortcut(relation)
+          return success(relation)
+        end
+
         Steep.logger.tagged(-> { "#{relation.sub_type} <: #{relation.super_type}" }) do
-          bounds = cache_bounds(relation)
-          fvs = relation.sub_type.free_variables + relation.super_type.free_variables
-          cached = cache[relation, @self_type, @instance_type, @class_type, bounds]
-          if cached && fvs.none? {|var| var.is_a?(Symbol) && constraints.unknown?(var) }
-            stats&.hit(relation, toplevel: assumptions.empty?)
-            cached
-          else
-            if assumptions.member?(relation)
+          if cacheable?(relation)
+            # The relation has no free variables -- including the `self`, `instance`, and
+            # `class` types --, so its result doesn't depend on the context of the check.
+            if cached = cache.ground(relation)
+              stats&.hit(relation, toplevel: assumptions.empty?)
+              cached
+            elsif assumptions.member?(relation)
               stats&.assumption(relation)
               success(relation)
             else
               toplevel = assumptions.empty?
-              stats&.compute(relation, cached: cached ? true : false, toplevel: toplevel, ground: fvs.empty?)
+              stats&.compute(relation, cached: false, toplevel: toplevel, ground: true)
               started = stats && toplevel ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : nil
               push_assumption(relation) do
                 check_type0(relation).tap do |result|
                   Steep.logger.debug { "result=#{result.class}" }
-                  cache[relation, @self_type, @instance_type, @class_type, bounds] = result
+                  cache.store_ground(relation, cache_value(relation, result))
                   if stats && started
                     stats.compute_time(relation, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started)
                   end
                 end
               end
             end
+          else
+            bounds = cache_bounds(relation)
+            fvs = relation.sub_type.free_variables + relation.super_type.free_variables
+            cached = cache[relation, @self_type, @instance_type, @class_type, bounds]
+            if cached && fvs.none? {|var| var.is_a?(Symbol) && constraints.unknown?(var) }
+              stats&.hit(relation, toplevel: assumptions.empty?)
+              cached
+            else
+              if assumptions.member?(relation)
+                stats&.assumption(relation)
+                success(relation)
+              else
+                toplevel = assumptions.empty?
+                stats&.compute(relation, cached: cached ? true : false, toplevel: toplevel, ground: false)
+                started = stats && toplevel ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : nil
+                push_assumption(relation) do
+                  check_type0(relation).tap do |result|
+                    Steep.logger.debug { "result=#{result.class}" }
+                    cache[relation, @self_type, @instance_type, @class_type, bounds] = cache_value(relation, result)
+                    if stats && started
+                      stats.compute_time(relation, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started)
+                    end
+                  end
+                end
+              end
+            end
           end
+        end
+      end
+
+      # Returns the result to store in the cache
+      #
+      # A successful result is stored without its derivation tree, which is only read
+      # through `Result::Base#failure_path` to explain a failure.
+      #
+      def cache_value(relation, result)
+        if result.success? && !result.is_a?(Result::Success)
+          Success(relation)
+        else
+          result
         end
       end
 

--- a/lib/steep/subtyping/check.rb
+++ b/lib/steep/subtyping/check.rb
@@ -256,11 +256,6 @@ module Steep
         end
       end
 
-      # Returns the result to store in the cache
-      #
-      # A successful result is stored without its derivation tree, which is only read
-      # through `Result::Base#failure_path` to explain a failure.
-      #
       def cache_value(relation, result)
         if result.success? && !result.is_a?(Result::Success)
           Success(relation)

--- a/lib/steep/subtyping/stats.rb
+++ b/lib/steep/subtyping/stats.rb
@@ -26,7 +26,7 @@ module Steep
       attr_reader :kinds, :relations, :caches
       attr_reader :calls, :reflexive_calls, :hits, :toplevel_hits, :reflexive_hits,
                   :computes, :toplevel_computes, :computes_with_unusable_cache,
-                  :assumption_successes, :context_misses
+                  :assumption_successes, :context_misses, :shortcuts
       attr_reader :toplevel_compute_time
       attr_reader :shapes, :shape_calls
       attr_reader :shape_time
@@ -47,6 +47,7 @@ module Steep
         @computes_with_unusable_cache = 0
         @assumption_successes = 0
         @context_misses = 0
+        @shortcuts = 0
         @toplevel_compute_time = 0.0
 
         @shapes = {}
@@ -83,6 +84,11 @@ module Steep
       def assumption(relation)
         count_call(relation, hit: false)
         @assumption_successes += 1
+      end
+
+      def shortcut(relation)
+        count_call(relation, hit: false)
+        @shortcuts += 1
       end
 
       def measure_shape(type)
@@ -187,6 +193,7 @@ module Steep
 
       def entry_stats
         entries = 0
+        ground_entries = 0
         contexts = Set[]
         reflexive = 0
         successes = 0
@@ -199,10 +206,18 @@ module Steep
             reflexive += 1 if relation.sub_type == relation.super_type
             successes += 1 if value.success?
           end
+
+          cache.ground_subtypes.each do |relation, value|
+            entries += 1
+            ground_entries += 1
+            reflexive += 1 if relation.sub_type == relation.super_type
+            successes += 1 if value.success?
+          end
         end
 
         {
           entries: entries,
+          ground_entries: ground_entries,
           distinct_contexts: contexts.size,
           reflexive_entries: reflexive,
           success_values: successes,
@@ -214,7 +229,10 @@ module Steep
 
         2.times { GC.start }
         before = ObjectSpace.memsize_of_all
-        caches.each {|cache| cache.subtypes.clear }
+        caches.each do |cache|
+          cache.subtypes.clear
+          cache.ground_subtypes.clear
+        end
         2.times { GC.start }
         after = ObjectSpace.memsize_of_all
 
@@ -249,9 +267,10 @@ module Steep
         io.puts "  check_type calls: #{calls} (reflexive: #{reflexive_calls}, distinct relations: #{relations.size})"
         io.puts "  cache hits: #{hits} (#{percent(hits, calls)}; top-level: #{toplevel_hits}, reflexive: #{reflexive_hits})"
         io.puts "  computed: #{computes} (top-level: #{toplevel_computes}, taking #{toplevel_compute_time.round(2)}s; cached but unusable: #{computes_with_unusable_cache})"
+        io.puts "  trivial shortcuts (uncached): #{shortcuts}"
         io.puts "  context-fragmented misses: #{context_misses} (#{percent(context_misses, computes)} of computes are ground relations already computed in another context)"
         io.puts "  assumption successes: #{assumption_successes}"
-        io.puts "  cache entries: #{entry_stats[:entries]} (contexts: #{entry_stats[:distinct_contexts]}, reflexive: #{entry_stats[:reflexive_entries]}, successes: #{entry_stats[:success_values]})"
+        io.puts "  cache entries: #{entry_stats[:entries]} (ground: #{entry_stats[:ground_entries]}, contexts: #{entry_stats[:distinct_contexts]}, reflexive: #{entry_stats[:reflexive_entries]}, successes: #{entry_stats[:success_values]})"
         if exclusive_memory
           io.puts "  memory exclusively retained by cache: #{(exclusive_memory / 1024.0 / 1024).round(1)}MB"
         end
@@ -292,6 +311,7 @@ module Steep
           toplevel_compute_time: toplevel_compute_time.round(4),
           computes_with_unusable_cache: computes_with_unusable_cache,
           context_misses: context_misses,
+          shortcuts: shortcuts,
           assumption_successes: assumption_successes,
           cache: entry_stats,
           exclusive_memory_bytes: exclusive_memory,

--- a/sig/steep/subtyping/cache.rbs
+++ b/sig/steep/subtyping/cache.rbs
@@ -1,28 +1,33 @@
 module Steep
   module Subtyping
     class Cache
+      # Key of `subtypes`: the relation and the context the check ran in -- the
+      # `self`, `instance`, and `class` types given to `Check#check`, and the upper
+      # bounds of the free type variables of the relation
+      type context_key = [Relation[AST::Types::t], AST::Types::t?, AST::Types::t?, AST::Types::t?, Hash[Symbol, AST::Types::t?]]
+
       # Results of relations that have free variables, keyed by the relation and the
       # context the check ran in
-      attr_reader subtypes: untyped
+      attr_reader subtypes: Hash[context_key, Result::t]
 
       # Results of relations without free variables, keyed by the relation alone
       #
       # The `self`/`instance`/`class` types count as free variables, so the result of
       # such a relation doesn't depend on the context of the check.
       #
-      attr_reader ground_subtypes: Hash[Relation[untyped], Result::t]
+      attr_reader ground_subtypes: Hash[Relation[AST::Types::t], Result::t]
 
       def initialize: () -> void
 
-      def subtype: (untyped relation, untyped self_type, untyped instance_type, untyped class_type, untyped bounds) -> untyped
+      def subtype: (Relation[AST::Types::t] relation, AST::Types::t? self_type, AST::Types::t? instance_type, AST::Types::t? class_type, Hash[Symbol, AST::Types::t?] bounds) -> Result::t?
 
-      def []: (untyped relation, untyped self_type, untyped instance_type, untyped class_type, untyped bounds) -> untyped
+      def []: (Relation[AST::Types::t] relation, AST::Types::t? self_type, AST::Types::t? instance_type, AST::Types::t? class_type, Hash[Symbol, AST::Types::t?] bounds) -> Result::t?
 
-      def []=: (untyped relation, untyped self_type, untyped instance_type, untyped class_type, untyped bounds, untyped value) -> untyped
+      def []=: (Relation[AST::Types::t] relation, AST::Types::t? self_type, AST::Types::t? instance_type, AST::Types::t? class_type, Hash[Symbol, AST::Types::t?] bounds, Result::t value) -> Result::t
 
-      def ground: (Relation[untyped] relation) -> Result::t?
+      def ground: (Relation[AST::Types::t] relation) -> Result::t?
 
-      def store_ground: (Relation[untyped] relation, Result::t value) -> Result::t
+      def store_ground: (Relation[AST::Types::t] relation, Result::t value) -> Result::t
 
       def no_subtype_cache?: () -> bool
     end

--- a/sig/steep/subtyping/cache.rbs
+++ b/sig/steep/subtyping/cache.rbs
@@ -1,7 +1,16 @@
 module Steep
   module Subtyping
     class Cache
+      # Results of relations that have free variables, keyed by the relation and the
+      # context the check ran in
       attr_reader subtypes: untyped
+
+      # Results of relations without free variables, keyed by the relation alone
+      #
+      # The `self`/`instance`/`class` types count as free variables, so the result of
+      # such a relation doesn't depend on the context of the check.
+      #
+      attr_reader ground_subtypes: Hash[Relation[untyped], Result::t]
 
       def initialize: () -> void
 
@@ -11,7 +20,11 @@ module Steep
 
       def []=: (untyped relation, untyped self_type, untyped instance_type, untyped class_type, untyped bounds, untyped value) -> untyped
 
-      def no_subtype_cache?: () -> untyped
+      def ground: (Relation[untyped] relation) -> Result::t?
+
+      def store_ground: (Relation[untyped] relation, Result::t value) -> Result::t
+
+      def no_subtype_cache?: () -> bool
     end
   end
 end

--- a/sig/steep/subtyping/cache.rbs
+++ b/sig/steep/subtyping/cache.rbs
@@ -1,9 +1,16 @@
 module Steep
   module Subtyping
     class Cache
-      # Key of `subtypes`: the relation and the context the check ran in -- the
-      # `self`, `instance`, and `class` types given to `Check#check`, and the upper
-      # bounds of the free type variables of the relation
+      # Key of `subtypes`: the relation and the context the check ran in
+      #
+      # 1. The relation that was checked
+      # 2. The `self_type` given to `Check#check`, the type that `self` resolves to
+      # 3. The `instance_type` given to `Check#check`, the type that `instance` resolves to
+      # 4. The `class_type` given to `Check#check`, the type that `class` resolves to
+      # 5. The upper bounds of the type variables free in the relation, taken from the
+      #    enclosing `Check#push_variable_bounds` calls
+      #
+      # The result of a relation with free variables depends on all of them.
       type context_key = [Relation[AST::Types::t], AST::Types::t?, AST::Types::t?, AST::Types::t?, Hash[Symbol, AST::Types::t?]]
 
       # Results of relations that have free variables, keyed by the relation and the

--- a/sig/steep/subtyping/check.rbs
+++ b/sig/steep/subtyping/check.rbs
@@ -56,6 +56,13 @@ module Steep
 
       def check_type: (Relation[AST::Types::t] relation) -> Result::t
 
+      # Returns the result to store in the cache
+      #
+      # A successful result is stored without its derivation tree, which is only read
+      # through `Result::Base#failure_path` to explain a failure.
+      #
+      def cache_value: (Relation[AST::Types::t] relation, Result::t result) -> Result::t
+
       def cache_bounds: (Relation[AST::Types::t] relation) -> Hash[Symbol, AST::Types::t?]
 
       def alias?: (AST::Types::t `type`) -> bool

--- a/sig/steep/subtyping/stats.rbs
+++ b/sig/steep/subtyping/stats.rbs
@@ -37,6 +37,7 @@ module Steep
 
       type entry_stats = {
         entries: Integer,
+        ground_entries: Integer,
         distinct_contexts: Integer,
         reflexive_entries: Integer,
         success_values: Integer
@@ -68,6 +69,8 @@ module Steep
 
       attr_reader context_misses: Integer
 
+      attr_reader shortcuts: Integer
+
       attr_reader toplevel_compute_time: Float
 
       # shape target type => [calls, time] of Interface::Builder#shape
@@ -96,6 +99,9 @@ module Steep
       def hit: (Relation[untyped] relation, toplevel: bool) -> void
 
       def assumption: (Relation[untyped] relation) -> void
+
+      # A trivially successful relation resolved in check_type without consulting the cache
+      def shortcut: (Relation[untyped] relation) -> void
 
       # Measures Interface::Builder#shape: total wall-clock time of outermost
       # calls, and the time per shape target.

--- a/sig/test/subtyping_stats_test.rbs
+++ b/sig/test/subtyping_stats_test.rbs
@@ -19,7 +19,11 @@ class SubtypingStatsTest < Minitest::Test
 
   def test_stats_counts_hits_and_computes: () -> untyped
 
-  def test_stats_context_fragmentation: () -> untyped
+  def test_ground_relations_cached_across_contexts: () -> untyped
+
+  def test_trivial_relations_not_cached: () -> untyped
+
+  def test_cached_success_has_no_derivation_tree: () -> untyped
 
   def test_stats_measure_shape: () -> untyped
 

--- a/test/subtyping_stats_test.rb
+++ b/test/subtyping_stats_test.rb
@@ -58,11 +58,11 @@ end
       assert_operator kind.calls, :>, 0
       assert_operator kind.hits, :>, 0
 
-      assert_equal stats.calls, stats.hits + stats.computes + stats.assumption_successes
+      assert_equal stats.calls, stats.hits + stats.computes + stats.assumption_successes + stats.shortcuts
 
       entry_stats = stats.entry_stats
       assert_operator entry_stats[:entries], :>, 0
-      assert_operator entry_stats[:distinct_contexts], :>, 0
+      assert_operator entry_stats[:ground_entries], :>, 0
 
       json = stats.as_json(entry_stats, nil)
       assert_equal stats.calls, json[:calls]
@@ -79,7 +79,7 @@ end
     Stats.active = nil
   end
 
-  def test_stats_context_fragmentation
+  def test_ground_relations_cached_across_contexts
     Stats.active = Stats.new()
 
     with_checker do |checker|
@@ -90,8 +90,8 @@ end
         super_type: parse_type("::Object", checker: checker)
       )
 
-      # The same ground relation in two different contexts: the second check
-      # misses the cache only because of the context in the cache key.
+      # The same ground relation in two different contexts: the context is not part
+      # of the cache key for ground relations, so the second check hits.
       [parse_type("::Foo", checker: checker), parse_type("::Object", checker: checker)].each do |self_type|
         checker.check(
           relation,
@@ -102,10 +102,65 @@ end
         )
       end
 
-      assert_operator stats.context_misses, :>, 0
+      assert_operator stats.hits, :>, 0
+      assert_equal 0, stats.context_misses
+      assert_operator checker.cache.ground_subtypes, :key?, relation
     end
   ensure
     Stats.active = nil
+  end
+
+  def test_trivial_relations_not_cached
+    Stats.active = Stats.new()
+
+    with_checker do |checker|
+      stats = Stats.active or raise
+
+      foo = parse_type("::Foo", checker: checker)
+
+      [
+        Relation.new(sub_type: foo, super_type: foo),
+        Relation.new(sub_type: foo, super_type: parse_type("untyped", checker: checker)),
+        Relation.new(sub_type: foo, super_type: parse_type("void", checker: checker)),
+        Relation.new(sub_type: foo, super_type: parse_type("top", checker: checker)),
+        Relation.new(sub_type: parse_type("bot", checker: checker), super_type: foo),
+      ].each do |relation|
+        result = checker.check(
+          relation,
+          self_type: parse_type("self", checker: checker),
+          instance_type: AST::Types::Instance.new,
+          class_type: AST::Types::Class.new,
+          constraints: Constraints.empty
+        )
+        assert_predicate result, :success?
+      end
+
+      assert_equal 5, stats.shortcuts
+      assert_equal 0, stats.computes
+      assert_predicate checker.cache, :no_subtype_cache?
+    end
+  ensure
+    Stats.active = nil
+  end
+
+  def test_cached_success_has_no_derivation_tree
+    with_checker do |checker|
+      relation = Relation.new(
+        sub_type: parse_type("::Foo", checker: checker),
+        super_type: parse_type("::Object", checker: checker)
+      )
+
+      result = checker.check(
+        relation,
+        self_type: parse_type("self", checker: checker),
+        instance_type: AST::Types::Instance.new,
+        class_type: AST::Types::Class.new,
+        constraints: Constraints.empty
+      )
+
+      assert_predicate result, :success?
+      assert_instance_of Subtyping::Result::Success, checker.cache.ground(relation)
+    end
   end
 
   def test_stats_measure_shape

--- a/test/subtyping_test.rb
+++ b/test/subtyping_test.rb
@@ -600,17 +600,11 @@ end
         constraints: Subtyping::Constraints.empty
       )
 
-      # Cached because the relation does not have free variables
+      # Cached without the context because the relation does not have free variables
       assert_operator(
-        checker.cache.subtypes,
+        checker.cache.ground_subtypes,
         :key?,
-        [
-          parse_relation("::Integer", "::Object", checker: checker),
-          AST::Types::Self.new,
-          AST::Types::Instance.new,
-          AST::Types::Class.new,
-          {}
-        ]
+        parse_relation("::Integer", "::Object", checker: checker)
       )
     end
   end


### PR DESCRIPTION
The subtyping cache key included the `(self_type, instance_type, class_type, bounds)` context, which changes with the class being type checked. The context only affects a relation whose types mention `self`, `instance`, `class` or a type variable; for a ground relation the result is the same in every context, yet it was cached per context. Measured on Steep itself, 55–70% of all computes per worker were ground relations that had already been computed under another context, and the app target stored 80,286 entries for 25,303 distinct relations.

Ground relations (`cacheable?`, previously unused) now go to a table keyed by the relation alone; relations with free variables keep the context key. Two smaller changes ride along: relations that `check_type0` resolves in its first branches (`T <: T`, `untyped` on either side, `void`/`top` supertypes, `bot` subtypes) skip the cache entirely, and successful results are stored as a plain `Success` — derivation trees are only consumed through `failure_path` on failures.

On Steep's app target this cuts computes by 71%, cache entries by 73% and the memory retained by the cache from 70 MB to 24 MB; the top-level compute time roughly halves. Diagnostics are byte-identical. Widening the reuse of cached results does not change the character of the known issue where constraint side effects are not replayed on a hit: the context never captured constraints either.