### PR TITLE
Share method overloads and entries between shapes

### DIFF
--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -341,11 +341,41 @@ module Steep
             shared_method_overload(name, type_def)
           end
 
-          # Methods rebuilt for each definition convert to the same overloads when their type
-          # defs are shared, and share one entry through this index.
-          index = (@method_entry_index[name] ||= {})
-          index[[private_method, overloads]] ||= Interface::Shape::Entry.new(method_name: name, private_method: private_method, overloads: overloads)
+          indexed_method_entry(name, private_method, overloads)
         end
+      end
+
+      def indexed_method_entry(name, private_method, overloads)
+        # Methods rebuilt for each definition convert to the same overloads when their type defs
+        # are shared, and share one entry through this index. The overloads are shared objects,
+        # so the identity of the first one discriminates almost all of the entries.
+        index = @method_entry_index[name] ||= {}
+        key = overloads[0]&.object_id || 0
+
+        case bucket = index[key]
+        when nil
+          index[key] = Interface::Shape::Entry.new(method_name: name, private_method: private_method, overloads: overloads)
+        when Array
+          bucket.find {|entry| same_overloads?(entry, private_method, overloads) } ||
+            Interface::Shape::Entry.new(method_name: name, private_method: private_method, overloads: overloads).tap {|entry| bucket << entry }
+        else
+          if same_overloads?(bucket, private_method, overloads)
+            bucket
+          else
+            Interface::Shape::Entry.new(method_name: name, private_method: private_method, overloads: overloads).tap do |entry|
+              index[key] = [bucket, entry]
+            end
+          end
+        end
+      end
+
+      def same_overloads?(entry, private_method, overloads)
+        return false unless entry.private_method? == private_method
+
+        entry_overloads = entry.overloads
+        return false unless entry_overloads.size == overloads.size
+
+        entry_overloads.each_with_index.all? {|overload, index| overload.equal?(overloads[index]) }
       end
 
       def shared_method_overload(name, type_def)
@@ -353,14 +383,38 @@ module Steep
           hash = {} #: Hash[RBS::Definition::Method::TypeDef, Shape::MethodOverload]
           hash.compare_by_identity
         end
-        cache[type_def] ||= begin
-          # Value-equal type defs may be different objects between definitions.
-          # They are indexed here by the identities of their components, which the definition
-          # builder preserves while flattening ancestor methods into definitions.
-          index = (@method_overload_index[name] ||= {})
-          key = [type_def.member.object_id, type_def.type.object_id, type_def.defined_in, type_def.implemented_in] #: [Integer, Integer, RBS::TypeName, RBS::TypeName?]
-          index[key] ||= build_method_overload(name, type_def, nil)
+        cache[type_def] ||= indexed_method_overload(name, type_def)
+      end
+
+      def indexed_method_overload(name, type_def)
+        # Value-equal type defs may be different objects between definitions. They are indexed
+        # here by the identity of their type, which discriminates almost all of them, and the
+        # remaining components are compared in the bucket.
+        index = @method_overload_index[name] ||= {}
+        key = type_def.type.object_id
+
+        case bucket = index[key]
+        when nil
+          index[key] = build_method_overload(name, type_def, nil)
+        when Array
+          bucket.find {|overload| same_type_def?(overload, type_def) } ||
+            build_method_overload(name, type_def, nil).tap {|overload| bucket << overload }
+        else
+          if same_type_def?(bucket, type_def)
+            bucket
+          else
+            build_method_overload(name, type_def, nil).tap do |overload|
+              index[key] = [bucket, overload]
+            end
+          end
         end
+      end
+
+      def same_type_def?(overload, type_def)
+        defn = overload.method_defs[0] or return false
+        defn.member.equal?(type_def.member) &&
+          defn.defined_in == type_def.defined_in &&
+          defn.implemented_in == type_def.implemented_in
       end
 
       def build_method_overload(name, type_def, kernel_class_type)

--- a/lib/steep/interface/builder.rb
+++ b/lib/steep/interface/builder.rb
@@ -61,6 +61,10 @@ module Steep
         @object_shape_cache = {}
         @union_shape_cache = {}
         @singleton_shape_cache = {}
+        @method_overload_cache = {}
+        @method_overload_index = {}
+        @method_entry_cache = {}
+        @method_entry_index = {}
         @implicitly_returns_nil = implicitly_returns_nil
       end
 
@@ -277,17 +281,16 @@ module Steep
           definition = factory.definition_builder.build_singleton(type_name)
 
           definition.methods.each do |name, method|
-            Steep.logger.tagged(-> { "method = #{type_name}.#{name}" }) do
-              overloads = method.defs.map do |type_def|
-                method_name = method_name_for(type_def, name)
-                method_type = factory.method_type(type_def.type)
-                method_type = replace_primitive_method(method_name, type_def, method_type)
-                method_type = replace_kernel_class(method_name, type_def, method_type) { AST::Builtin::Class.instance_type }
-                method_type = add_implicitly_returns_nil(type_def.each_annotation, method_type)
-                Shape::MethodOverload.new(method_type, [type_def])
-              end
+            if name == :class
+              Steep.logger.tagged(-> { "method = #{type_name}.#{name}" }) do
+                overloads = method.defs.map do |type_def|
+                  build_method_overload(name, type_def, AST::Builtin::Class.instance_type)
+                end
 
-              shape.methods[name] = Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
+                shape.methods[name] = Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
+              end
+            else
+              shape.methods[name] = shared_method_entry(name, method)
             end
           end
 
@@ -309,24 +312,66 @@ module Steep
           definition or raise
 
           definition.methods.each do |name, method|
-            Steep.logger.tagged(-> { "method = #{type_name}##{name}" }) do
-              overloads = method.defs.map do |type_def|
-                method_name = method_name_for(type_def, name)
-                method_type = factory.method_type(type_def.type)
-                method_type = replace_primitive_method(method_name, type_def, method_type)
-                if type_name.class?
-                  method_type = replace_kernel_class(method_name, type_def, method_type) { AST::Types::Name::Singleton.new(name: type_name) }
+            if name == :class && type_name.class?
+              Steep.logger.tagged(-> { "method = #{type_name}##{name}" }) do
+                singleton_type = AST::Types::Name::Singleton.new(name: type_name)
+                overloads = method.defs.map do |type_def|
+                  build_method_overload(name, type_def, singleton_type)
                 end
-                method_type = add_implicitly_returns_nil(type_def.each_annotation, method_type)
-                Shape::MethodOverload.new(method_type, [type_def])
-              end
 
-              shape.methods[name] = Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
+                shape.methods[name] = Interface::Shape::Entry.new(method_name: name, private_method: method.private?, overloads: overloads)
+              end
+            else
+              shape.methods[name] = shared_method_entry(name, method)
             end
           end
 
           shape
         end
+      end
+
+      def shared_method_entry(name, method)
+        cache = @method_entry_cache[name] ||= begin
+          hash = {} #: Hash[RBS::Definition::Method, Shape::Entry]
+          hash.compare_by_identity
+        end
+        cache[method] ||= begin
+          private_method = method.private?
+          overloads = method.defs.map do |type_def|
+            shared_method_overload(name, type_def)
+          end
+
+          # Methods rebuilt for each definition convert to the same overloads when their type
+          # defs are shared, and share one entry through this index.
+          index = (@method_entry_index[name] ||= {})
+          index[[private_method, overloads]] ||= Interface::Shape::Entry.new(method_name: name, private_method: private_method, overloads: overloads)
+        end
+      end
+
+      def shared_method_overload(name, type_def)
+        cache = @method_overload_cache[name] ||= begin
+          hash = {} #: Hash[RBS::Definition::Method::TypeDef, Shape::MethodOverload]
+          hash.compare_by_identity
+        end
+        cache[type_def] ||= begin
+          # Value-equal type defs may be different objects between definitions.
+          # They are indexed here by the identities of their components, which the definition
+          # builder preserves while flattening ancestor methods into definitions.
+          index = (@method_overload_index[name] ||= {})
+          key = [type_def.member.object_id, type_def.type.object_id, type_def.defined_in, type_def.implemented_in] #: [Integer, Integer, RBS::TypeName, RBS::TypeName?]
+          index[key] ||= build_method_overload(name, type_def, nil)
+        end
+      end
+
+      def build_method_overload(name, type_def, kernel_class_type)
+        method_name = method_name_for(type_def, name)
+        method_type = factory.method_type(type_def.type)
+        method_type = replace_primitive_method(method_name, type_def, method_type)
+        if kernel_class_type
+          method_type = replace_kernel_class(method_name, type_def, method_type) { kernel_class_type }
+        end
+        method_type = add_implicitly_returns_nil(type_def.each_annotation, method_type)
+        Shape::MethodOverload.new(method_type, [type_def])
       end
 
       def union_shape(shape_type, shapes)

--- a/lib/steep/interface/shape.rb
+++ b/lib/steep/interface/shape.rb
@@ -157,8 +157,10 @@ module Steep
 
         def each_name(&block)
           if block
-            each do |name, _|
-              yield name
+            # `key?` decides if the method exists without applying the substitutions,
+            # unlike `each` that resolves every entry
+            methods.each_key do |name|
+              yield name if key?(name)
             end
           else
             enum_for :each_name

--- a/lib/steep/interface/shape.rb
+++ b/lib/steep/interface/shape.rb
@@ -180,7 +180,16 @@ module Steep
         end
 
         def merge!(other, &block)
-          other.each do |name, entry|
+          other.methods.each_key do |name|
+            # `key?` skips the entries without method types, like `each` did, but doesn't
+            # resolve the others -- applying the substitutions of `other` is deferred to a
+            # lazy entry, and the visibility is copied from the unresolved entry
+            next unless other.key?(name)
+
+            entry = Entry.new(method_name: name, private_method: other.methods.fetch(name).private_method?) do
+              other[name]&.overloads
+            end
+
             if block && (old_entry = methods[name])
               methods[name] = yield(name, old_entry, entry)
             else

--- a/lib/steep/interface/shape.rb
+++ b/lib/steep/interface/shape.rb
@@ -8,18 +8,18 @@ module Steep
 
         def initialize(method_type, defs)
           @method_type = method_type
-          @method_defs = defs.sort_by do |defn|
-            buf = +""
-
-            if loc = defn.type.location
-              buf << loc.buffer.name.to_s
-              buf << ":"
-              buf << loc.start_pos.to_s
+          if defs.size > 1
+            @method_defs = defs.sort_by do |defn|
+              if loc = defn.type.location
+                [loc.buffer.name.to_s, loc.start_pos]
+              else
+                ["", -1]
+              end
             end
-
-            buf
+            @method_defs.uniq!
+          else
+            @method_defs = defs.dup
           end
-          @method_defs.uniq!
         end
 
         def subst(s)

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -108,6 +108,48 @@ module Steep
       # Substitution for type application of class instance, type alias, or interface types
       def app_subst: (AST::Types::Name::Instance | AST::Types::Name::Alias | AST::Types::Name::Interface) -> Substitution
 
+      # Cache of shared method entries, keyed by the method name and the identity of the method
+      @method_entry_cache: Hash[Symbol, Hash[RBS::Definition::Method, Shape::Entry]]
+
+      # Index of shared method entries, keyed by the method name, the visibility, and the identities of the overloads
+      @method_entry_index: Hash[Symbol, Hash[[bool, Array[Shape::MethodOverload]], Shape::Entry]]
+
+      # Returns a `Shape::Entry` of the method, shared with the shapes of other types
+      #
+      # RBS definitions are flat, and inherited/mixed-in methods appear in the definition of
+      # every type. The entry of a method is a pure function of the method name and the method,
+      # so one shared, immutable entry works for all of them.
+      #
+      # The only exception is `Kernel#class`, whose return type is replaced with the type being
+      # built -- the callers must build an entry with `build_method_overload` directly for
+      # methods named `class` of classes and modules.
+      #
+      def shared_method_entry: (Symbol name, RBS::Definition::Method) -> Shape::Entry
+
+      # Cache of shared method overloads, keyed by the method name and the identity of the type def
+      @method_overload_cache: Hash[Symbol, Hash[RBS::Definition::Method::TypeDef, Shape::MethodOverload]]
+
+      # Index of shared method overloads, keyed by the method name and the identities of the type def components
+      @method_overload_index: Hash[Symbol, Hash[[Integer, Integer, TypeName, TypeName?], Shape::MethodOverload]]
+
+      # Returns a `Shape::MethodOverload` of the `type_def`, shared with the shapes of other types
+      #
+      # RBS definitions are flat, and the type defs of inherited/mixed-in methods are converted
+      # to equivalent overloads in the shape of every type. The conversion is a pure function of
+      # the method name and the type def, so one shared, immutable overload works for all of them.
+      #
+      # The only exception is `Kernel#class`, whose return type is replaced with the type being
+      # built -- the callers must use `build_method_overload` directly for methods named `class`
+      # of classes and modules.
+      #
+      def shared_method_overload: (Symbol name, RBS::Definition::Method::TypeDef) -> Shape::MethodOverload
+
+      # Converts a type def to a fresh `Shape::MethodOverload`
+      #
+      # `kernel_class_type` replaces the return type of `Kernel#class` when given.
+      #
+      def build_method_overload: (Symbol name, RBS::Definition::Method::TypeDef, AST::Types::t? kernel_class_type) -> Shape::MethodOverload
+
       def method_name_for: (RBS::Definition::Method::TypeDef, Symbol name) -> method_name
 
       def replace_primitive_method: (method_name, RBS::Definition::Method::TypeDef, MethodType) -> MethodType

--- a/sig/steep/interface/builder.rbs
+++ b/sig/steep/interface/builder.rbs
@@ -111,8 +111,17 @@ module Steep
       # Cache of shared method entries, keyed by the method name and the identity of the method
       @method_entry_cache: Hash[Symbol, Hash[RBS::Definition::Method, Shape::Entry]]
 
-      # Index of shared method entries, keyed by the method name, the visibility, and the identities of the overloads
-      @method_entry_index: Hash[Symbol, Hash[[bool, Array[Shape::MethodOverload]], Shape::Entry]]
+      # Index of shared method entries, keyed by the method name and the identity of the first overload
+      #
+      # The buckets hold an array only when different entries start with one overload.
+      #
+      @method_entry_index: Hash[Symbol, Hash[Integer, Shape::Entry | Array[Shape::Entry]]]
+
+      # Returns a shared `Shape::Entry` through the index, building one if it is new
+      def indexed_method_entry: (Symbol name, bool private_method, Array[Shape::MethodOverload]) -> Shape::Entry
+
+      # Returns `true` if the entry has the given visibility and exactly the given overloads
+      def same_overloads?: (Shape::Entry, bool private_method, Array[Shape::MethodOverload]) -> bool
 
       # Returns a `Shape::Entry` of the method, shared with the shapes of other types
       #
@@ -129,8 +138,20 @@ module Steep
       # Cache of shared method overloads, keyed by the method name and the identity of the type def
       @method_overload_cache: Hash[Symbol, Hash[RBS::Definition::Method::TypeDef, Shape::MethodOverload]]
 
-      # Index of shared method overloads, keyed by the method name and the identities of the type def components
-      @method_overload_index: Hash[Symbol, Hash[[Integer, Integer, TypeName, TypeName?], Shape::MethodOverload]]
+      # Index of shared method overloads, keyed by the method name and the identity of the type
+      #
+      # The buckets hold an array only when different type defs share one type object.
+      #
+      @method_overload_index: Hash[Symbol, Hash[Integer, Shape::MethodOverload | Array[Shape::MethodOverload]]]
+
+      # Returns a shared `Shape::MethodOverload` through the index, building one if it is new
+      def indexed_method_overload: (Symbol name, RBS::Definition::Method::TypeDef) -> Shape::MethodOverload
+
+      # Returns `true` if the overload was built from a type def equal to the given one
+      #
+      # The type is not compared, because it is the key of the bucket the overload is in.
+      #
+      def same_type_def?: (Shape::MethodOverload, RBS::Definition::Method::TypeDef) -> bool
 
       # Returns a `Shape::MethodOverload` of the `type_def`, shared with the shapes of other types
       #

--- a/sig/steep/interface/shape.rbs
+++ b/sig/steep/interface/shape.rbs
@@ -52,6 +52,8 @@ module Steep
         def each: () { ([Symbol, Entry]) -> void } -> void
                 | () -> Enumerator[[Symbol, Entry], void]
 
+        # Yields the name of each method that has an entry, without resolving the entries
+        #
         def each_name: () { (Symbol) -> void } -> void
                      | () -> Enumerator[Symbol, void]
 

--- a/sig/steep/interface/shape.rbs
+++ b/sig/steep/interface/shape.rbs
@@ -71,6 +71,12 @@ module Steep
 
         def push_substitution: (Substitution) -> Methods
 
+        # Copies the entries of `other` into `self`
+        #
+        # The copied entries are lazy -- the substitutions of `other` are applied when the
+        # entry is used. The block, if given, decides which entry survives when `self`
+        # already has an entry of the method, and receives the new entry unresolved.
+        #
         def merge!: (Methods other) ?{ (Symbol name, Entry old_entry, Entry new_entry) -> Entry } -> void
 
         def public_methods: () -> Methods


### PR DESCRIPTION
RBS definitions are flat -- every type carries the methods it inherits
and mixes in -- so `Interface::Builder` converted the same type defs to
`Shape::MethodOverload`s and `Shape::Entry`s once per type, and each
shape held its own copies of the methods of `Object` and `Kernel`.

The conversion is a pure function of the method name and the type def,
so the builder now keeps one immutable overload per (name, type def)
and one entry per (name, method), shared by all the shapes. They are
looked up by identity, with a fallback index for the value-equal type
defs that different definitions rebuild (mixins, generics, and
interfaces), so no method type is hashed. `Kernel#class` is still built
per type, because its return type is the type being built.

The other commits stop work the sharing made visible: `MethodOverload`
sorted the defs of every overload although almost all have one, unions
resolved every entry of every member just to list the common method
names, and `Methods#merge!` copied the entries of intersections and
tuples eagerly.

Building the shapes of all 1,806 types of Steep's own environment goes
from 9.9s to 1.4s and from 197MB to 75MB of heap. The diagnostics of
`steep check` on Steep itself are unchanged.