### PR TITLE
Handle a singleton method definition on an untyped receiver

### DIFF
--- a/lib/steep/type_construction.rb
+++ b/lib/steep/type_construction.rb
@@ -278,7 +278,8 @@ module Steep
                          method_name: InstanceMethodName.new(type_name: module_context.class_name, method_name: method_name)
                        )
                      else
-                       raise "Unexpected self_type: #{self_type}"
+                       # `def obj.foo` where the type of `obj` doesn't name a class or module, `untyped` included
+                       TypeInference::MethodCall::UnknownContext.new()
                      end
 
       self.class.new(

--- a/sig/test/type_check_test.rbs
+++ b/sig/test/type_check_test.rbs
@@ -311,4 +311,6 @@ class TypeCheckTest < Minitest::Test
   def test_array_literal_with_pair_interface_hint_two_params_block: () -> untyped
 
   def test_array_literal_with_pair_interface_hint_mismatch: () -> untyped
+
+  def test_defs_on_untyped_receiver: () -> untyped
 end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -4861,4 +4861,40 @@ class TypeCheckTest < Minitest::Test
       YAML
     )
   end
+
+  def test_defs_on_untyped_receiver
+    run_type_check_test(
+      signatures: {
+        "a.rbs" => <<~RBS
+          class DefsOnUntypedReceiver
+            def foo: (untyped) -> void
+          end
+        RBS
+      },
+      code: {
+        "a.rb" => <<~RUBY
+          class DefsOnUntypedReceiver
+            def foo(object)
+              def object.bar = 1
+            end
+          end
+        RUBY
+      },
+      expectations: <<~YAML
+        ---
+        - file: a.rb
+          diagnostics:
+          - range:
+              start:
+                line: 3
+                character: 15
+              end:
+                line: 3
+                character: 18
+            severity: ERROR
+            message: Method `bar` is defined in undeclared module
+            code: Ruby::MethodDefinitionInUndeclaredModule
+      YAML
+    )
+  end
 end


### PR DESCRIPTION
`for_new_method` derived the call context from `self_type`, which for `def obj.foo` is the type of the receiver and can be any type, but only `nil`, an instance, a singleton and an intersection were handled. Fall back to `UnknownContext` instead of raising, so that a definition on an `untyped` receiver no longer ends as a `Ruby::UnexpectedError`.