### PR TITLE
Report definitions and references through typecheck progress

### DIFF
--- a/lib/steep/server/master.rb
+++ b/lib/steep/server/master.rb
@@ -186,6 +186,8 @@ module Steep
       attr_accessor :typecheck_automatically
       attr_reader :start_type_checking_queue
 
+      attr_reader :type_check_database
+
       # Type check requests waiting for the current type check to finish
       attr_reader :pending_typecheck_requests
 
@@ -214,6 +216,7 @@ module Steep
         @controller = TypeCheckController.new(project: project)
         @result_controller = ResultController.new()
         @start_type_checking_queue = DelayQueue.new(delay: 0.3)
+        @type_check_database = TypeCheckDatabase.new()
       end
 
       def start
@@ -790,7 +793,8 @@ module Steep
                 guid: params[:guid],
                 path: Pathname(params[:path]),
                 target: target,
-                diagnostics: params[:diagnostics]
+                source: params[:source],
+                signature: params[:signature]
               )
             else
               # Forward other notifications
@@ -902,10 +906,37 @@ module Steep
         end
       end
 
-      def on_type_check_update(guid:, path:, target:, diagnostics:)
+      def on_type_check_update(guid:, path:, target:, source: nil, signature: nil)
         if current = current_type_check_request()
           if current.guid == guid
             current.checked(path, target)
+
+            if source
+              type_check_database.update_source(
+                path: path,
+                target: target.name,
+                diagnostics: source[:diagnostics],
+                entries: source[:entries]&.map { TypeCheckDatabase::Entry.from_wire(_1) }
+              )
+            end
+
+            if signature
+              type_check_database.update_signature(
+                path: path,
+                target: target.name,
+                diagnostics: signature[:diagnostics],
+                entries: signature[:entries]&.map { TypeCheckDatabase::Entry.from_wire(_1) }
+              )
+            end
+
+            source_diagnostics = source && source[:diagnostics]
+            signature_diagnostics = signature && signature[:diagnostics]
+            diagnostics =
+              if source_diagnostics && signature_diagnostics
+                source_diagnostics + signature_diagnostics
+              else
+                source_diagnostics || signature_diagnostics
+              end
 
             Steep.logger.info { "Request updated: checked=#{path}, unchecked=#{current.each_unchecked_code_target_path.size}, diagnostics=#{diagnostics&.size}" }
 

--- a/lib/steep/server/type_check_database.rb
+++ b/lib/steep/server/type_check_database.rb
@@ -1,7 +1,25 @@
 module Steep
   module Server
     class TypeCheckDatabase
-      Entry = _ = Struct.new(:name, :role, :start_line, :start_character, :end_line, :end_character, keyword_init: true)
+      Entry =
+        _ = Struct.new(:name, :role, :start_line, :start_character, :end_line, :end_character, keyword_init: true) do
+          # @implements Entry
+
+          def to_wire
+            [name, ROLE_CODES.fetch(role), start_line, start_character, end_line, end_character]
+          end
+
+          def self.from_wire(array)
+            Entry.new(
+              name: array[0],
+              role: ROLES.fetch(array[1]),
+              start_line: array[2],
+              start_character: array[3],
+              end_line: array[4],
+              end_character: array[5]
+            )
+          end
+        end
 
       Location =
         _ = Struct.new(:path, :source, :start_line, :start_character, :end_line, :end_character, keyword_init: true) do
@@ -67,6 +85,155 @@ module Steep
       ROLES = ROLE_CODES.invert #: Hash[Integer, Entry::role]
 
       ENTRY_SIZE = 6
+
+      def self.entries_from(typing)
+        entries = [] #: Array[Entry]
+        seen = Set[] #: Set[Array[untyped]]
+
+        index = typing.source_index
+
+        index.constant_index.each do |name, entry|
+          entry.definitions.each do |node|
+            if location = constant_definition_location(node)
+              push_entry(entries, seen, name: name.to_s, role: :definition, location: location)
+            end
+          end
+          entry.references.each do |node|
+            push_entry(entries, seen, name: name.to_s, role: :reference, location: node.location.expression)
+          end
+        end
+
+        index.method_index.each do |name, entry|
+          entry.definitions.each do |node|
+            location = (_ = node.location).name #: Parser::Source::Range
+            push_entry(entries, seen, name: name.to_s, role: :definition, location: location)
+          end
+        end
+
+        typing.method_calls.each do |node, call|
+          decls =
+            case call
+            when TypeInference::MethodCall::Typed, TypeInference::MethodCall::Error
+              call.method_decls
+            end
+          next unless decls
+
+          location = method_call_location(node) or next
+          decls.each do |decl|
+            push_entry(entries, seen, name: decl.method_name.to_s, role: :reference, location: location)
+          end
+        end
+
+        entries
+      end
+
+      def self.constant_definition_location(node)
+        case node.type
+        when :const
+          node.location.expression #: Parser::Source::Range
+        when :casgn
+          name_location = (_ = node.location).name #: Parser::Source::Range
+          if parent = node.children[0]
+            parent_location = parent.location.expression #: Parser::Source::Range
+            parent_location.join(name_location)
+          else
+            name_location
+          end
+        end
+      end
+
+      def self.method_call_location(node)
+        case node.type
+        when :block, :numblock, :itblock
+          method_call_location(node.children.fetch(0))
+        else
+          location = node.location
+          selector = location.respond_to?(:selector) ? (_ = location).selector : nil #: Parser::Source::Range?
+          selector || location.expression
+        end
+      end
+
+      def self.push_entry(entries, seen, name:, role:, location:)
+        key = [name, role, location.line, location.column, location.last_line, location.last_column] #: Array[untyped]
+        return if seen.include?(key)
+        seen << key
+
+        entries << Entry.new(
+          name: name,
+          role: role,
+          start_line: location.line - 1,
+          start_character: location.column,
+          end_line: location.last_line - 1,
+          end_character: location.last_column
+        )
+      end
+
+      def self.rbs_entries_by_path(index)
+        entries = {} #: Hash[Pathname, Array[Entry]]
+        paths = {} #: Hash[String, Pathname]
+
+        index.type_index.each do |type_name, entry|
+          entry.declarations.each do |decl|
+            location = rbs_declaration_location(decl) or next
+            push_rbs_entry(entries, paths, name: type_name.to_s, location: location)
+          end
+        end
+
+        index.method_index.each do |method_name, entry|
+          entry.declarations.each do |decl|
+            location = rbs_declaration_location(decl) or next
+            push_rbs_entry(entries, paths, name: method_name.to_s, location: location)
+          end
+        end
+
+        index.const_index.each do |const_name, entry|
+          entry.declarations.each do |decl|
+            location = rbs_declaration_location(decl) or next
+            push_rbs_entry(entries, paths, name: const_name.to_s, location: location)
+          end
+        end
+
+        index.global_index.each do |global_name, entry|
+          entry.declarations.each do |decl|
+            location = rbs_declaration_location(decl) or next
+            push_rbs_entry(entries, paths, name: global_name.to_s, location: location)
+          end
+        end
+
+        entries
+      end
+
+      def self.rbs_declaration_location(decl)
+        case decl
+        when RBS::AST::Declarations::Class, RBS::AST::Declarations::Module, RBS::AST::Declarations::Interface, RBS::AST::Declarations::TypeAlias,
+             RBS::AST::Declarations::Constant, RBS::AST::Declarations::Global,
+             RBS::AST::Members::MethodDefinition, RBS::AST::Members::AttrAccessor, RBS::AST::Members::AttrReader, RBS::AST::Members::AttrWriter
+          if (location = decl.location) && location.key?(:name)
+            location[:name]
+          end
+        when RBS::AST::Declarations::ClassAlias, RBS::AST::Declarations::ModuleAlias, RBS::AST::Members::Alias
+          if (location = decl.location) && location.key?(:new_name)
+            location[:new_name]
+          end
+        when RBS::AST::Ruby::Declarations::ClassDecl, RBS::AST::Ruby::Declarations::ModuleDecl, RBS::AST::Ruby::Declarations::ClassModuleAliasDecl,
+             RBS::AST::Ruby::Declarations::ConstantDecl, RBS::AST::Ruby::Members::DefMember
+          decl.name_location
+        end
+      end
+
+      def self.push_rbs_entry(entries, paths, name:, location:)
+        buffer_name = location.buffer.name.to_s
+        path = (paths[buffer_name] ||= Pathname(buffer_name))
+
+        (entries[path] ||= []) << Entry.new(
+          name: name,
+          role: :definition,
+          start_line: location.start_line - 1,
+          start_character: location.start_column,
+          end_line: location.end_line - 1,
+          end_character: location.end_column
+        )
+      end
 
       attr_reader :pool
 

--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -71,6 +71,7 @@ module Steep
         @service = service if service
         @child_pids = []
         @need_to_warmup = true
+        @rbs_entries_cache = {}
 
         if io_socket
           Signal.trap "SIGCHLD" do
@@ -257,13 +258,14 @@ module Steep
 
             formatter = Diagnostic::LSPFormatter.new({}, **{})
 
-            diagnostics = service.validate_signature(path: project.relative_path(job.path), target: job.target)
+            relative_path = project.relative_path(job.path)
+            diagnostics = service.validate_signature(path: relative_path, target: job.target)
 
             typecheck_progress(
               path: job.path,
               guid: job.guid,
               target: job.target,
-              diagnostics: diagnostics.filter_map { formatter.format(_1) }
+              signature: { diagnostics: diagnostics.filter_map { formatter.format(_1) }, entries: signature_entries(job.target, relative_path) }
             )
           end
 
@@ -274,7 +276,12 @@ module Steep
             formatter = Diagnostic::LSPFormatter.new({}, **{})
             diagnostics = service.validate_signature(path: job.path, target: job.target)
 
-            typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics.filter_map { formatter.format(_1) })
+            typecheck_progress(
+              path: job.path,
+              guid: job.guid,
+              target: job.target,
+              signature: { diagnostics: diagnostics.filter_map { formatter.format(_1) }, entries: signature_entries(job.target, job.path) }
+            )
           end
 
         when TypeCheckCodeJob
@@ -284,7 +291,12 @@ module Steep
             formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
             relative_path = project.relative_path(job.path)
             diagnostics = service.typecheck_source(path: relative_path, target: job.target)
-            typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics&.filter_map { formatter.format(_1) })
+            typecheck_progress(
+              path: job.path,
+              guid: job.guid,
+              target: job.target,
+              source: { diagnostics: diagnostics&.filter_map { formatter.format(_1) }, entries: source_file_entries(relative_path) }
+            )
           end
 
         when TypeCheckInlineCodeJob
@@ -293,17 +305,21 @@ module Steep
             group_target = project.group_for_inline_source_path(job.path) || job.target
             formatter = Diagnostic::LSPFormatter.new(group_target.code_diagnostics_config)
             relative_path = project.relative_path(job.path)
-            diagnostics = service.typecheck_source(path: relative_path, target: job.target) #: Array[Diagnostic::Ruby::Base | Diagnostic::Signature::Base] | nil
-            signature_diagnostics = service.validate_signature(path: relative_path, target: job.target)
-            if diagnostics
-              diagnostics.concat(signature_diagnostics)
-            else
-              unless signature_diagnostics.empty?
-                diagnostics = signature_diagnostics
-              end
+            source_diagnostics = service.typecheck_source(path: relative_path, target: job.target)&.filter_map { formatter.format(_1) }
+            signature_diagnostics = service.validate_signature(path: relative_path, target: job.target).filter_map { formatter.format(_1) } #: Array[LanguageServer::Protocol::Interface::Diagnostic::json]?
+
+            # Keep the diagnostics of the last type checking, as the plain Ruby files do, when the type checking is skipped and the validation finds nothing
+            if source_diagnostics.nil? && signature_diagnostics&.empty?
+              signature_diagnostics = nil
             end
 
-            typecheck_progress(path: job.path, guid: job.guid, target: job.target, diagnostics: diagnostics&.filter_map { formatter.format(_1) })
+            typecheck_progress(
+              path: job.path,
+              guid: job.guid,
+              target: job.target,
+              source: { diagnostics: source_diagnostics, entries: source_file_entries(relative_path) },
+              signature: { diagnostics: signature_diagnostics, entries: signature_entries(job.target, relative_path) }
+            )
           end
 
         when WorkspaceSymbolJob
@@ -332,8 +348,41 @@ module Steep
         end
       end
 
-      def typecheck_progress(guid:, path:, target:, diagnostics:)
-        writer.write(CustomMethods::TypeCheck__Progress.notification({ guid: guid, path: path.to_s, target: target.name.to_s, diagnostics: diagnostics }))
+      def typecheck_progress(guid:, path:, target:, source: nil, signature: nil)
+        writer.write(
+          CustomMethods::TypeCheck__Progress.notification({
+            guid: guid,
+            path: path.to_s,
+            target: target.name.to_s,
+            source: source && wire_result(source),
+            signature: signature && wire_result(signature)
+          })
+        )
+      end
+
+      def wire_result(result)
+        { diagnostics: result[:diagnostics], entries: result[:entries]&.map { _1.to_wire } }
+      end
+
+      def source_file_entries(relative_path)
+        if file = service.source_files[relative_path]
+          if typing = file.typing
+            TypeCheckDatabase.entries_from(typing)
+          end
+        end
+      end
+
+      def signature_entries(target, path)
+        signature_service = service.signature_services.fetch(target.name)
+        return unless signature_service.status.is_a?(Services::SignatureService::LoadedStatus)
+
+        index = signature_service.latest_rbs_index
+        cached = @rbs_entries_cache[target.name]
+        unless cached && cached[0].equal?(index)
+          cached = @rbs_entries_cache[target.name] = [index, TypeCheckDatabase.rbs_entries_by_path(index)]
+        end
+
+        cached[1][path] || []
       end
 
       def workspace_symbol_result(query)

--- a/sig/steep/server/custom_methods.rbs
+++ b/sig/steep/server/custom_methods.rbs
@@ -89,11 +89,22 @@ module Steep
       module TypeCheck__Progress
         METHOD: String
 
+        # The result of type checking Ruby code or validating RBS declarations in the file
+        #
+        # `diagnostics` is `nil` when the type checking is skipped, and `entries` is `nil` when no entries
+        # are available. The master keeps the ones of the last result in either case.
+        #
+        type result = { diagnostics: Array[LSPDiagnostic::json]?, entries: Array[TypeCheckDatabase::Entry::wire]? }
+
+        # `source` is the result of type checking Ruby code, and `signature` is the result of validating RBS declarations.
+        # A Ruby file with inline RBS declarations has both.
+        #
         type params = {
           guid: String,
           path: String,
           target: String,
-          diagnostics: Array[LSPDiagnostic::json]?
+          source: result?,
+          signature: result?
         }
 
         def self.notification: (params) -> untyped

--- a/sig/steep/server/master.rbs
+++ b/sig/steep/server/master.rbs
@@ -158,6 +158,9 @@ module Steep
 
       attr_reader start_type_checking_queue: DelayQueue
 
+      # The type check results reported by the typecheck workers
+      attr_reader type_check_database: TypeCheckDatabase
+
       @need_to_refork: boolish
 
       # Type check requests waiting for the current type check to finish
@@ -225,7 +228,12 @@ module Steep
 
       def finish_type_check: (TypeCheckController::Request) -> void
 
-      def on_type_check_update: (guid: String, path: Pathname, target: Project::Target, diagnostics: Array[LSPDiagnostic::json]?) -> void
+      # Stores the results reported by a worker in the database and publishes the diagnostics of the file
+      #
+      # Results of a guid other than the current request are dropped. The diagnostics published are the ones of
+      # `source` and `signature` concatenated, or nothing when both are skipped.
+      #
+      def on_type_check_update: (guid: String, path: Pathname, target: Project::Target, ?source: CustomMethods::TypeCheck__Progress::result?, ?signature: CustomMethods::TypeCheck__Progress::result?) -> void
 
       def refork_workers: () -> void
 

--- a/sig/steep/server/type_check_database.rbs
+++ b/sig/steep/server/type_check_database.rbs
@@ -58,7 +58,17 @@ module Steep
 
         attr_reader end_character: Integer
 
+        # Array representation of an entry for `$/steep/typecheck/progress` notifications
+        #
+        # `[name, role code, start_line, start_character, end_line, end_character]`
+        #
+        type wire = Array[untyped]
+
         def initialize: (name: String, role: role, start_line: Integer, start_character: Integer, end_line: Integer, end_character: Integer) -> void
+
+        def to_wire: () -> wire
+
+        def self.from_wire: (wire array) -> Entry
       end
 
       # Location of a definition or reference, returned by the queries
@@ -152,6 +162,33 @@ module Steep
 
       # Reference counts of names per path in `@signatures` -- `name id => (path => count)`
       @signature_paths: Hash[Integer, Hash[Pathname, Integer]]
+
+      # Extracts the entries of a type checked Ruby file from its `Typing`
+      #
+      # The constant definitions/references and method definitions come from the `SourceIndex`,
+      # and the method references come from the method calls, resolved to the names of the
+      # declarations of each call.
+      #
+      def self.entries_from: (Typing typing) -> Array[Entry]
+
+      def self.constant_definition_location: (Parser::AST::Node node) -> Parser::Source::Range?
+
+      def self.method_call_location: (Parser::AST::Node node) -> Parser::Source::Range?
+
+      def self.push_entry: (Array[Entry] entries, Set[Array[untyped]] seen, name: String, role: Entry::role, location: Parser::Source::Range) -> void
+
+      # Extracts the declarations in RBS files (and inline RBS in Ruby files) from an `RBSIndex`, grouped by the path of the file
+      #
+      # Only the declarations are extracted. The references the index records point at the member or declaration
+      # that contains a type, not at the type itself, which is too coarse to store as a reference.
+      #
+      def self.rbs_entries_by_path: (Index::RBSIndex index) -> Hash[Pathname, Array[Entry]]
+
+      # Returns the location of the name of a declaration or member, or `nil` if it has no location
+      def self.rbs_declaration_location: (untyped decl) -> RBS::Location[untyped, untyped]?
+
+      # `paths` caches the `Pathname` of each buffer name, which is shared by every declaration in the file
+      def self.push_rbs_entry: (Hash[Pathname, Array[Entry]] entries, Hash[String, Pathname] paths, name: String, location: RBS::Location[untyped, untyped]) -> void
 
       attr_reader pool: NamePool
 

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -146,6 +146,12 @@ module Steep
 
       attr_reader need_to_warmup: bool
 
+      # The declarations extracted from the latest `RBSIndex` of each target, grouped by path
+      #
+      # The index is kept with the entries to detect a newer index of the target.
+      #
+      @rbs_entries_cache: Hash[Symbol, [Index::RBSIndex, Hash[Pathname, Array[TypeCheckDatabase::Entry]]]]
+
       include ChangeBuffer
 
       def initialize: (
@@ -183,7 +189,33 @@ module Steep
       #
       def refork: (ReforkJob job) -> void
 
-      def typecheck_progress: (guid: String, path: Pathname, target: Project::Target, diagnostics: Array[LSPDiagnostic::json]?) -> void
+      # The result of type checking Ruby code or validating RBS declarations in a file, to be reported to the master
+      #
+      # `diagnostics` is `nil` when the type checking is skipped, and `entries` is `nil` when no entries are available.
+      #
+      type result = { diagnostics: Array[LSPDiagnostic::json]?, entries: Array[TypeCheckDatabase::Entry]? }
+
+      # Sends `$/steep/typecheck/progress` with the results of the file
+      #
+      # `source` is the result of type checking Ruby code, and `signature` is the result of validating RBS declarations.
+      # A Ruby file with inline RBS declarations reports both.
+      #
+      def typecheck_progress: (guid: String, path: Pathname, target: Project::Target, ?source: result?, ?signature: result?) -> void
+
+      def wire_result: (result) -> CustomMethods::TypeCheck__Progress::result
+
+      # Returns the entries extracted from the last type checking of the file, or `nil` if no `Typing` is available
+      def source_file_entries: (Pathname relative_path) -> Array[TypeCheckDatabase::Entry]?
+
+      # Returns the declarations in the RBS file (or the inline RBS in the Ruby file) of the target
+      #
+      # `path` is the relative path of a project file, or the absolute path of a library file, which is the
+      # name of the buffer of the declarations.
+      #
+      # Returns `nil` when the signatures of the target failed to load, because the index would be of the last
+      # successfully loaded signatures, and its locations may be stale.
+      #
+      def signature_entries: (Project::Target target, Pathname path) -> Array[TypeCheckDatabase::Entry]?
 
       def workspace_symbol_result: (untyped query) -> untyped
 

--- a/sig/test/master_test.rbs
+++ b/sig/test/master_test.rbs
@@ -31,6 +31,8 @@ class MasterTest < Minitest::Test
 
   def test_on_type_check_update_with_progress: () -> untyped
 
+  def test_on_type_check_update_stores_results_in_database: () -> untyped
+
   def test_on_type_check_update_without_progress: () -> untyped
 
   def test_client_message_initialize_work_done_supported_no: () -> untyped

--- a/sig/test/server/type_check_database_test.rbs
+++ b/sig/test/server/type_check_database_test.rbs
@@ -36,5 +36,7 @@ class Steep::Server::TypeCheckDatabaseTest < Minitest::Test
 
   def test_name_shared_between_files_survives_removal_of_one: () -> untyped
 
+  def test_entry_wire_round_trip: () -> untyped
+
   def test_rbs_declarations: () -> untyped
 end

--- a/sig/test/type_check_worker_test.rbs
+++ b/sig/test/type_check_worker_test.rbs
@@ -40,6 +40,10 @@ class TypeCheckWorkerTest < Minitest::Test
 
   def test_handle_job_validate_app_signature: () -> untyped
 
+  def test_handle_job_validate_app_signature_entries: () -> untyped
+
+  def test_handle_job_validate_app_signature_entries_on_syntax_error: () -> untyped
+
   def test_handle_job_validate_app_signature_skip: () -> untyped
 
   def test_handle_job_validate_lib_signature: () -> untyped
@@ -47,6 +51,8 @@ class TypeCheckWorkerTest < Minitest::Test
   def test_handle_job_validate_lib_signature_skip: () -> untyped
 
   def test_handle_job_typecheck_code: () -> untyped
+
+  def test_handle_job_typecheck_code_entries: () -> untyped
 
   def test_handle_job_typecheck_code_diagnostics: () -> untyped
 

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -226,7 +226,7 @@ end
 
       flush_queue(master.write_queue)
 
-      master.on_type_check_update(guid: "guid", path: current_dir + "lib/customer.rb", target: project.targets[0], diagnostics: nil)
+      master.on_type_check_update(guid: "guid", path: current_dir + "lib/customer.rb", target: project.targets[0], source: { diagnostics: nil, entries: nil })
 
       jobs = flush_queue(master.write_queue)
 
@@ -244,7 +244,7 @@ end
         end
       end
 
-      master.on_type_check_update(guid: "guid", path: current_dir + "lib/account.rb", target: project.targets[0], diagnostics: [])
+      master.on_type_check_update(guid: "guid", path: current_dir + "lib/account.rb", target: project.targets[0], source: { diagnostics: [], entries: [] })
 
       jobs = flush_queue(master.write_queue)
 
@@ -278,6 +278,76 @@ end
       end
 
       assert_nil master.current_type_check_request
+    end
+  end
+
+  def test_on_type_check_update_stores_results_in_database
+    in_tmpdir do
+      steepfile = current_dir + "Steepfile"
+      steepfile.write(<<-EOF)
+target :lib do
+  check "lib"
+  signature "sig"
+end
+      EOF
+
+      project = Project.new(steepfile_path: steepfile)
+      Project::DSL.parse(project, steepfile.read)
+
+      worker = Server::WorkerProcess.new(reader: nil, writer: nil, stderr: nil, wait_thread: nil, name: "test", index: 0)
+
+      master = Server::Master.new(
+        project: project,
+        reader: worker_reader,
+        writer: worker_writer,
+        interaction_worker: nil,
+        typecheck_workers: [worker]
+      )
+      master.assign_initialize_params(DEFAULT_CLI_LSP_INITIALIZE_PARAMS.merge(capabilities: { window: { workDoneProgress: true } }))
+
+      master.controller.add_dirty_code_path current_dir + "lib/customer.rb"
+
+      progress = master.work_done_progress("guid")
+      master.start_type_check(last_request: nil, progress: progress, report_progress_threshold: 0, needs_response: true)
+
+      flush_queue(master.write_queue)
+
+      master.on_type_check_update(
+        guid: "guid",
+        path: current_dir + "lib/customer.rb",
+        target: project.targets[0],
+        source: {
+          diagnostics: [],
+          entries: [
+            ["::Customer", 0, 0, 6, 0, 14],
+            ["::Customer#name", 0, 1, 6, 1, 10]
+          ]
+        },
+        signature: {
+          diagnostics: [],
+          entries: [
+            ["::Customer#name", 0, 1, 6, 1, 10]
+          ]
+        }
+      )
+
+      database = master.type_check_database
+
+      assert_equal [], database.diagnostics(current_dir + "lib/customer.rb")
+
+      # The Ruby code and the inline declarations are stored in both tables
+      definitions = database.definitions("::Customer#name")
+      assert_equal [current_dir + "lib/customer.rb"], definitions.map(&:path).uniq
+      assert_equal [[:ruby, 1], [:rbs, 1]], definitions.map { [_1.source, _1.start_line] }
+
+      # Results of unknown guids are not stored
+      master.on_type_check_update(
+        guid: "different-guid",
+        path: current_dir + "lib/customer.rb",
+        target: project.targets[0],
+        source: { diagnostics: nil, entries: [["::Other", 0, 0, 0, 0, 5]] }
+      )
+      assert_equal [], database.definitions("::Other")
     end
   end
 
@@ -315,8 +385,8 @@ end
 
       flush_queue(master.write_queue)
 
-      master.on_type_check_update(guid: "guid", path: current_dir + "lib/customer.rb", target: project.targets[0], diagnostics: [])
-      master.on_type_check_update(guid: "guid", path: current_dir + "lib/account.rb", target: project.targets[0], diagnostics: nil)
+      master.on_type_check_update(guid: "guid", path: current_dir + "lib/customer.rb", target: project.targets[0], source: { diagnostics: [], entries: [] })
+      master.on_type_check_update(guid: "guid", path: current_dir + "lib/account.rb", target: project.targets[0], source: { diagnostics: nil, entries: nil })
 
       jobs = flush_queue(master.write_queue)
 

--- a/test/server/type_check_database_test.rb
+++ b/test/server/type_check_database_test.rb
@@ -274,6 +274,13 @@ class Steep::Server::TypeCheckDatabaseTest < Minitest::Test
     assert_equal 1, database.pool.size
   end
 
+  def test_entry_wire_round_trip
+    e = entry("::Foo#bar", role: :reference, at: [1, 2, 3, 4])
+
+    assert_equal ["::Foo#bar", 1, 1, 2, 3, 4], e.to_wire
+    assert_equal e, TypeCheckDatabase::Entry.from_wire(e.to_wire)
+  end
+
   def test_rbs_declarations
     database = TypeCheckDatabase.new()
 

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -323,7 +323,121 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal TypeCheck__Progress::METHOD, message[:method]
           assert_equal "guid", message[:params][:guid]
           assert_equal (current_dir + "sig/hello.rbs").to_s, message[:params][:path]
-          assert_empty message[:params][:diagnostics]
+          assert_empty message[:params][:signature][:diagnostics]
+        end
+      end
+    end
+  end
+
+  def test_handle_job_validate_app_signature_entries
+    in_tmpdir do
+      with_master_read_queue do |master_read_queue|
+        project = Project.new(steepfile_path: current_dir + "Steepfile")
+        Project::DSL.parse(project, <<~RUBY)
+          target :lib do
+            check "lib"
+            signature "sig"
+          end
+        RUBY
+
+        worker = Server::TypeCheckWorker.new(
+          project: project,
+          assignment: assignment,
+          commandline_args: [],
+          reader: worker_reader,
+          writer: worker_writer
+        )
+
+        worker.instance_variable_set(:@current_type_check_guid, "guid")
+
+        {}.tap do |changes|
+          changes[Pathname("sig/hello.rbs")] = [Services::ContentChange.string(<<~RBS)]
+            class Hello
+              def world: () -> void
+              attr_reader name: String
+              alias greet world
+            end
+
+            interface _Greeter
+              def greet: () -> void
+            end
+
+            type greeting = String
+
+            VERSION: String
+
+            $hello: Hello
+          RBS
+          worker.handle_job(TypeCheckWorker::StartTypeCheckJob.new(guid: "guid", changes: changes))
+        end
+
+        job = TypeCheckWorker::ValidateAppSignatureJob.new(guid: "guid", path: current_dir + "sig/hello.rbs", target: project.targets[0])
+        worker.handle_job(job)
+
+        master_read_queue.pop.tap do |message|
+          assert_equal TypeCheck__Progress::METHOD, message[:method]
+          assert_empty message[:params][:signature][:diagnostics]
+
+          entries = message[:params][:signature][:entries]
+
+          # Class, methods (`def`, `attr_reader`, and `alias`)
+          assert_includes entries, ["::Hello", 0, 0, 6, 0, 11]
+          assert_includes entries, ["::Hello#world", 0, 1, 6, 1, 11]
+          assert_includes entries, ["::Hello#name", 0, 2, 14, 2, 18]
+          assert_includes entries, ["::Hello#greet", 0, 3, 8, 3, 13]
+
+          # Interface, type alias, constant, and global
+          assert_includes entries, ["::_Greeter", 0, 6, 10, 6, 18]
+          assert_includes entries, ["::_Greeter#greet", 0, 7, 6, 7, 11]
+          assert_includes entries, ["::greeting", 0, 10, 5, 10, 13]
+          assert_includes entries, ["::VERSION", 0, 12, 0, 12, 7]
+          assert_includes entries, ["$hello", 0, 14, 0, 14, 6]
+
+          # Declarations of other files are not included
+          refute entries.any? {|name, *| name == "::String" }
+        end
+      end
+    end
+  end
+
+  def test_handle_job_validate_app_signature_entries_on_syntax_error
+    in_tmpdir do
+      with_master_read_queue do |master_read_queue|
+        project = Project.new(steepfile_path: current_dir + "Steepfile")
+        Project::DSL.parse(project, <<~RUBY)
+          target :lib do
+            check "lib"
+            signature "sig"
+          end
+        RUBY
+
+        worker = Server::TypeCheckWorker.new(
+          project: project,
+          assignment: assignment,
+          commandline_args: [],
+          reader: worker_reader,
+          writer: worker_writer
+        )
+
+        worker.instance_variable_set(:@current_type_check_guid, "guid")
+
+        {}.tap do |changes|
+          changes[Pathname("sig/hello.rbs")] = [Services::ContentChange.string(<<~RBS)]
+            class Hello
+              def world: () ->
+          RBS
+          worker.handle_job(TypeCheckWorker::StartTypeCheckJob.new(guid: "guid", changes: changes))
+        end
+
+        job = TypeCheckWorker::ValidateAppSignatureJob.new(guid: "guid", path: current_dir + "sig/hello.rbs", target: project.targets[0])
+        worker.handle_job(job)
+
+        master_read_queue.pop.tap do |message|
+          assert_equal TypeCheck__Progress::METHOD, message[:method]
+          refute_empty message[:params][:signature][:diagnostics]
+
+          # No entries are reported while the signatures fail to load
+          assert_nil message[:params][:signature][:entries]
         end
       end
     end
@@ -419,7 +533,7 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal TypeCheck__Progress::METHOD, message[:method]
           assert_equal "guid", message[:params][:guid]
           assert_equal (RBS::EnvironmentLoader::DEFAULT_CORE_ROOT + "object.rbs").to_s, message[:params][:path]
-          assert_empty message[:params][:diagnostics]
+          assert_empty message[:params][:signature][:diagnostics]
         end
       end
     end
@@ -513,7 +627,68 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal TypeCheck__Progress::METHOD, message[:method]
           assert_equal "guid", message[:params][:guid]
           assert_equal (current_dir + "lib/hello.rb").to_s, message[:params][:path]
-          assert_equal 1, message[:params][:diagnostics].size
+          assert_equal 1, message[:params][:source][:diagnostics].size
+        end
+      end
+    end
+  end
+
+  def test_handle_job_typecheck_code_entries
+    in_tmpdir do
+      with_master_read_queue do |master_read_queue|
+        project = Project.new(steepfile_path: current_dir + "Steepfile")
+        Project::DSL.parse(project, <<~RUBY)
+          target :lib do
+            check "lib"
+            signature "sig"
+          end
+        RUBY
+
+        worker = Server::TypeCheckWorker.new(
+          project: project,
+          assignment: assignment,
+          commandline_args: [],
+          reader: worker_reader,
+          writer: worker_writer
+        )
+
+        worker.instance_variable_set(:@current_type_check_guid, "guid")
+
+        {}.tap do |changes|
+          changes[Pathname("lib/hello.rb")] = [Services::ContentChange.string(<<~RUBY)]
+            class Hello
+              def world
+              end
+            end
+
+            Hello.new.world()
+          RUBY
+          changes[Pathname("sig/hello.rbs")] = [Services::ContentChange.string(<<~RUBY)]
+            class Hello
+              def world: () -> void
+            end
+          RUBY
+          worker.handle_job(TypeCheckWorker::StartTypeCheckJob.new(guid: "guid", changes: changes))
+        end
+
+        job = TypeCheckWorker::TypeCheckCodeJob.new(guid: "guid", path: current_dir + "lib/hello.rb", target: project.targets[0])
+        worker.handle_job(job)
+
+        master_read_queue.pop.tap do |message|
+          assert_equal TypeCheck__Progress::METHOD, message[:method]
+
+          entries = message[:params][:source][:entries]
+
+          # Constant definition and reference of ::Hello
+          assert_includes entries, ["::Hello", 0, 0, 6, 0, 11]
+          assert_includes entries, ["::Hello", 1, 5, 0, 5, 5]
+
+          # Method definition and reference of ::Hello#world
+          assert_includes entries, ["::Hello#world", 0, 1, 6, 1, 11]
+          assert_includes entries, ["::Hello#world", 1, 5, 10, 5, 15]
+
+          # The reference of `.new` points at the selector
+          assert(entries.any? {|_, role, line, character, _, _| role == 1 && line == 5 && character == 6 })
         end
       end
     end
@@ -570,12 +745,12 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal "guid", message[:params][:guid]
           assert_equal (current_dir + "lib/hello.rb").to_s, message[:params][:path]
 
-          assert_any!(message[:params][:diagnostics], size: 2) do |diagnostic|
+          assert_any!(message[:params][:source][:diagnostics], size: 2) do |diagnostic|
             assert_equal "Ruby::UnexpectedPositionalArgument", diagnostic[:code]
             assert_equal 1, diagnostic[:severity]
           end
 
-          assert_any!(message[:params][:diagnostics], size: 2) do |diagnostic|
+          assert_any!(message[:params][:source][:diagnostics], size: 2) do |diagnostic|
             assert_equal "Ruby::UnknownConstant", diagnostic[:code]
             assert_equal 3, diagnostic[:severity]
           end
@@ -670,7 +845,7 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal TypeCheck__Progress::METHOD, message[:method]
           assert_equal "guid", message[:params][:guid]
           assert_equal (current_dir + "lib/hello.rb").to_s, message[:params][:path]
-          assert_equal 0, message[:params][:diagnostics].size
+          assert_equal 0, message[:params][:source][:diagnostics].size
         end
       end
     end
@@ -717,8 +892,8 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal TypeCheck__Progress::METHOD, message[:method]
           assert_equal "guid", message[:params][:guid]
           assert_equal (current_dir + "lib/hello.rb").to_s, message[:params][:path]
-          assert_equal 1, message[:params][:diagnostics].size
-          assert_equal "Ruby::ArgumentTypeMismatch", message[:params][:diagnostics][0][:code]
+          assert_equal 1, message[:params][:source][:diagnostics].size
+          assert_equal "Ruby::ArgumentTypeMismatch", message[:params][:source][:diagnostics][0][:code]
         end
       end
     end
@@ -765,9 +940,9 @@ class TypeCheckWorkerTest < Minitest::Test
           assert_equal TypeCheck__Progress::METHOD, message[:method]
           assert_equal "guid", message[:params][:guid]
           assert_equal (current_dir + "lib/hello.rb").to_s, message[:params][:path]
-          assert_equal 1, message[:params][:diagnostics].size
-          pp message[:params][:diagnostics][0]
-          assert_equal "RBS::InlineDiagnostic", message[:params][:diagnostics][0][:code]
+          assert_equal 1, message[:params][:signature][:diagnostics].size
+          pp message[:params][:signature][:diagnostics][0]
+          assert_equal "RBS::InlineDiagnostic", message[:params][:signature][:diagnostics][0][:code]
         end
       end
     end
@@ -1011,7 +1186,7 @@ RUBY
         refute_nil progress
         assert_equal "guid2", progress[:params][:guid]
         assert_equal (current_dir + "lib/hello.rb").to_s, progress[:params][:path]
-        assert_equal [], progress[:params][:diagnostics]
+        assert_equal [], progress[:params][:source][:diagnostics]
 
         child_writer.write({ method: "shutdown", id: "shutdown" })
         child_writer.write({ method: "exit" })


### PR DESCRIPTION
Stacked on #2290.

The typecheck workers now extract the definitions and references of methods and constants from the `Typing` of each type checked file, and attach them to `$/steep/typecheck/progress` notifications, which the master stores in its `TypeCheckDatabase` together with the diagnostics of the file. A notification carries up to two results, matching the two tables of the database: `source` for the type checking of Ruby code and `signature` for the validation of RBS declarations. A Ruby file with inline RBS declarations reports both. The diagnostics published to the client are the two concatenated, as they were.

Constants and method definitions come from the `SourceIndex`. Method references are new -- `SourceIndex` never recorded them -- and come from the method calls, resolved through `method_decls` to the name each call is declared as, so that the master can answer a lookup without knowing anything about types. They are roughly 70% of the entries, and the reason the master can serve goto without the workers keeping their `Typing` objects.

The declarations in RBS files (and inline RBS in Ruby files) are reported too: classes, modules, interfaces, type aliases, constants, globals, and methods including `alias` and `attr_*`, extracted from the `RBSIndex` of the target and grouped by file once per index, and reported by the signature validation of each file under the target that owns it. Only declarations are reported, since the type-name references the index records point at the whole member containing the type, which is too coarse to store. Nothing is reported for an RBS file while the signatures of its target fail to load, because the index would be of the last good load and its locations may be stale; the master keeps the entries of the last result then.

Library RBS files are never validated in the language server, so their declarations do not reach the database yet, and goto into a gem finds nothing for now. They will be indexed by the master once it loads the environment itself.

Entries travel as `[name, role, start line, start character, end line, end character]` tuples rather than one object per entry, which measured 6x smaller and 6x faster to parse than a hash per entry, with 125x fewer allocations on the master.

The workers still keep their `Typing` objects, and every query still reads from them, so nothing changes behaviourally yet. Keeping both sides live is deliberate: it makes the entries the master receives checkable against the answers the workers still produce, before the queries move over.