### PR TITLE
Fork reforked workers after the jobs queued in the primary

### DIFF
--- a/lib/steep/server/type_check_worker.rb
+++ b/lib/steep/server/type_check_worker.rb
@@ -14,6 +14,7 @@ module Steep
       ValidateAppSignatureJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
       ValidateLibrarySignatureJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
       TypeCheckInlineCodeJob = _ = Struct.new(:guid, :path, :target, keyword_init: true)
+      ReforkJob = _ = Struct.new(:id, :params, keyword_init: true)
       class GotoJob < Struct.new(:id, :kind, :params, keyword_init: true)
         def self.implementation(id:, params:)
           new(
@@ -124,43 +125,54 @@ module Steep
         when CustomMethods::Refork::METHOD
           io_socket or raise
 
-          # Receive IOs before fork to avoid receiving them from multiple processes
-          stdin = io_socket.recv_io
-          stdout = io_socket.recv_io
+          # The job thread forks, after the jobs queued so far are done. `service` is updated only
+          # by that thread, and the changes a `StartTypeCheckJob` applies are already popped from
+          # the buffer: a fork before the job finishes gives the new worker neither the changes
+          # nor the files they add.
+          queue << ReforkJob.new(id: request[:id], params: request[:params])
+        end
+      end
 
-          if need_to_warmup
-            Process.warmup
-            @need_to_warmup = false
+      def refork(job)
+        io_socket = self.io_socket or raise
+
+        # Receive IOs before fork to avoid receiving them from multiple processes
+        stdin = io_socket.recv_io
+        stdout = io_socket.recv_io
+
+        if need_to_warmup
+          Process.warmup
+          @need_to_warmup = false
+        end
+
+        if pid = fork
+          stdin.close
+          stdout.close
+          @child_pids << pid
+          writer.write(CustomMethods::Refork.response(job.id, { pid: }))
+        else
+          io_socket.close
+
+          reader.close
+          writer.close
+
+          reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdin)
+          writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdout)
+          Steep.logger.info("Reforked worker: #{Process.pid}, params: #{job.params}")
+          index = job.params[:index]
+          assignment = Services::PathAssignment.new(max_index: job.params[:max_index], index: index)
+
+          worker = self.class.new(project: project, reader: reader, writer: writer, assignment: assignment, commandline_args: commandline_args, io_socket: nil, buffered_changes: buffered_changes, service: service)
+
+          # The forking thread is the job thread of the primary worker, and becomes the main thread of the new worker
+          tags = Steep.logger.current_tags
+          tags.delete("background")
+          if (tag_index = tags.find_index("typecheck:typecheck@0"))
+            tags[tag_index] = "typecheck:typecheck@#{index}-reforked"
           end
+          worker.run()
 
-          if pid = fork
-            stdin.close
-            stdout.close
-            @child_pids << pid
-            writer.write(CustomMethods::Refork.response(request[:id], { pid: }))
-          else
-            io_socket.close
-
-            reader.close
-            writer.close
-
-            reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdin)
-            writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdout)
-            Steep.logger.info("Reforked worker: #{Process.pid}, params: #{request[:params]}")
-            index = request[:params][:index]
-            assignment = Services::PathAssignment.new(max_index: request[:params][:max_index], index: index)
-
-            worker = self.class.new(project: project, reader: reader, writer: writer, assignment: assignment, commandline_args: commandline_args, io_socket: nil, buffered_changes: buffered_changes, service: service)
-
-            tags = Steep.logger.current_tags.dup
-            if (index = tags.find_index("typecheck:typecheck@0"))
-              tags[index] = "typecheck:typecheck@#{index}-reforked"
-            end
-            Steep.logger.push_tags(*tags)
-            worker.run()
-
-            raise "unreachable"
-          end
+          exit 0
         end
       end
 
@@ -235,6 +247,9 @@ module Steep
         when StartTypeCheckJob
           Steep.logger.info { "Processing StartTypeCheckJob for guid=#{job.guid}" }
           service.update(changes: job.changes)
+
+        when ReforkJob
+          refork(job)
 
         when ValidateAppSignatureJob
           if job.guid == current_type_check_guid

--- a/sig/steep/server/type_check_worker.rbs
+++ b/sig/steep/server/type_check_worker.rbs
@@ -88,6 +88,16 @@ module Steep
         def initialize: (guid: String, path: Pathname, target: Project::Target) -> void
       end
 
+      # Forks a new worker, that starts from a copy of this worker
+      #
+      class ReforkJob
+        attr_reader id: String
+
+        attr_reader params: CustomMethods::Refork::params
+
+        def initialize: (id: String, params: CustomMethods::Refork::params) -> void
+      end
+
       class QueryDefinitionJob
         attr_reader id: String
 
@@ -163,8 +173,15 @@ module Steep
                | StatsJob
                | QueryDefinitionJob
                | QueryDiagnosticsJob
+               | ReforkJob
 
       def handle_job: (job) -> void
+
+      # Forks a new worker from the job thread, so that it starts with the jobs queued before the request done
+      #
+      # The new worker takes over the IOs the master sends through `io_socket`. The method returns only in the primary worker.
+      #
+      def refork: (ReforkJob job) -> void
 
       def typecheck_progress: (guid: String, path: Pathname, target: Project::Target, diagnostics: Array[LSPDiagnostic::json]?) -> void
 

--- a/sig/test/type_check_worker_test.rbs
+++ b/sig/test/type_check_worker_test.rbs
@@ -63,4 +63,6 @@ class TypeCheckWorkerTest < Minitest::Test
   def test_job_stats: () -> untyped
 
   def test_goto_definition_from_ruby: () -> untyped
+
+  def test_refork_after_pending_jobs: () -> untyped
 end

--- a/test/type_check_worker_test.rb
+++ b/test/type_check_worker_test.rb
@@ -922,4 +922,106 @@ RUBY
       end
     end
   end
+  def test_refork_after_pending_jobs
+    skip "fork() is not available on this platform" unless Steep.can_fork?
+
+    in_tmpdir do
+      with_master_read_queue do |master_read_queue|
+        project = Project.new(steepfile_path: current_dir + "Steepfile")
+        Project::DSL.parse(project, <<~RUBY)
+          target :lib do
+            check "lib"
+            signature "sig"
+          end
+        RUBY
+
+        sock_master, sock_worker = UNIXSocket.pair
+        child_stdin, stdin_writer = IO.pipe
+        stdout_reader, child_stdout = IO.pipe
+
+        # The worker traps SIGCHLD to watch its reforked workers, which would report the exit of the child below as an error
+        sigchld = Signal.trap("SIGCHLD", "DEFAULT")
+
+        worker = Server::TypeCheckWorker.new(
+          project: project,
+          assignment: assignment,
+          commandline_args: [],
+          reader: worker_reader,
+          writer: worker_writer,
+          io_socket: sock_worker
+        )
+
+        typecheck_start = ->(guid) do
+          {
+            method: TypeCheck__Start::METHOD,
+            params: {
+              guid: guid,
+              priority_uris: [],
+              signature_uris: [],
+              code_uris: [["lib", "#{file_scheme}#{current_dir}/lib/hello.rb"]],
+              library_uris: [],
+              inline_uris: []
+            }
+          }
+        end
+
+        worker.handle_request({ method: FileLoad::METHOD, params: { content: { "lib/hello.rb" => "1 + 2\n" } } })
+        worker.handle_request(typecheck_start["guid1"])
+
+        sock_master.send_io(child_stdin)
+        sock_master.send_io(child_stdout)
+        worker.handle_request({ method: Refork::METHOD, id: "refork", params: { index: 1, max_index: 2 } })
+
+        # The fork waits for the jobs queued before the request, which apply the changes popped from the buffer
+        jobs = flush_queue(worker.queue)
+        assert_equal [TypeCheckWorker::StartTypeCheckJob, TypeCheckWorker::TypeCheckCodeJob, TypeCheckWorker::ReforkJob], jobs.map(&:class)
+
+        # Fork from another thread, as the job thread does, so that the child exits without unwinding this test
+        Thread.new { jobs.each { worker.handle_job(_1) } }.join
+
+        Signal.trap("SIGCHLD", sigchld)
+        sigchld = nil
+        child_stdin.close
+        child_stdout.close
+
+        master_read_queue.pop.tap do |message|
+          assert_equal TypeCheck__Progress::METHOD, message[:method]
+          assert_equal "guid1", message[:params][:guid]
+        end
+
+        pid = master_read_queue.pop.tap do |response|
+          assert_equal "refork", response[:id]
+        end[:result][:pid]
+
+        child_writer = LanguageServer::Protocol::Transport::Io::Writer.new(stdin_writer)
+        child_reader = LanguageServer::Protocol::Transport::Io::Reader.new(stdout_reader)
+
+        # The new worker type checks the file it inherited from the primary, which the master never sends again
+        child_writer.write(typecheck_start["guid2"])
+
+        progress = Timeout.timeout(TestHelper.timeout) do
+          child_reader.read do |message|
+            if message[:method] == "window/showMessage"
+              flunk "The reforked worker failed: #{message[:params][:message]}"
+            end
+            break message if message[:method] == TypeCheck__Progress::METHOD
+          end
+        end
+
+        refute_nil progress
+        assert_equal "guid2", progress[:params][:guid]
+        assert_equal (current_dir + "lib/hello.rb").to_s, progress[:params][:path]
+        assert_equal [], progress[:params][:diagnostics]
+
+        child_writer.write({ method: "shutdown", id: "shutdown" })
+        child_writer.write({ method: "exit" })
+        Process.waitpid(pid)
+      ensure
+        Signal.trap("SIGCHLD", sigchld) if sigchld
+        [sock_master, sock_worker, child_stdin, stdin_writer, stdout_reader, child_stdout].each do |io|
+          io&.close unless io&.closed?
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The daemon reforks the typecheck workers from the primary once the warm-up type check finishes, and the primary forked as soon as `$/steep/refork` arrived, from the thread reading the requests. The type check finishes when the worker the file is assigned to reports it, not when the primary has applied the changes, so the job thread of the primary could still be in the `StartTypeCheckJob` of that type check, loading the RBS environment or not yet putting the file into `service`. The changes are popped from the buffer when the job is queued, so the new worker started from a `service` without the file, or built an empty one, and had no buffered changes to recover it from. Type checking the file in the new worker then raised `KeyError` in `typecheck_source`, no progress was reported for it, and `steep check` waited for the response forever: the 120-second timeouts of `DaemonTest` on CI, each with `key not found: #<Pathname:foo.rb>` from a reforked worker in the daemon log. Delaying the `StartTypeCheckJob` of the primary reproduces it every time.

The request now queues a `ReforkJob`, and the job thread forks after the jobs queued before it. The master sends nothing to the primary until the refork finishes, so no change is popped between the request and the fork. The forking thread becomes the main thread of the new worker, which exits when its `run` returns instead of raising, and the log tag of the new worker names the index it received, where it used the position of the tag before. The added test reforks a worker with a file loaded and a type check queued, and checks that the new worker type checks the file without receiving it again.