### PR TITLE
Keep only the content of type checked files in the workers

### DIFF
--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -146,24 +146,6 @@ module Steep
         signature_diagnostics
       end
 
-      def diagnostics
-        each_diagnostics.to_h
-      end
-
-      def each_diagnostics(&block)
-        if block
-          signature_diagnostics.each do |path, diagnostics|
-            yield [path, diagnostics]
-          end
-
-          source_files.each_value do |file|
-            yield [file.path, file.diagnostics]
-          end
-        else
-          enum_for :each_diagnostics
-        end
-      end
-
       def update(changes:)
         Steep.measure "#update_signature" do
           update_signature(changes: changes)
@@ -271,13 +253,8 @@ module Steep
               text = source_files.fetch(path).content
               file = type_check_file(target: target, subtyping: subtyping, path: path, text: text) { signature_service.latest_constant_resolver }
 
-              # Keep the content and the diagnostics only: the Typing goes to the master through the worker, and is dropped with the file
-              source_files[path] =
-                if file.typing || file.errors
-                  SourceFile.with_diagnostics(path: path, content: file.content, diagnostics: file.diagnostics)
-                else
-                  SourceFile.no_data(path: path, content: file.content)
-                end
+              # Keep the content only: the diagnostics and the Typing go to the master through the worker, and are dropped with the file
+              source_files[path] = SourceFile.no_data(path: path, content: file.content)
 
               file
             else

--- a/sig/steep/services/type_check_service.rbs
+++ b/sig/steep/services/type_check_service.rbs
@@ -35,7 +35,7 @@ module Steep
 
         def self.with_syntax_error: (path: Pathname, content: String, error: Diagnostic::Ruby::SyntaxError | Diagnostic::Ruby::AnnotationSyntaxError) -> SourceFile
 
-        # A file with its diagnostics only -- the ones of a type checking that is done, or the errors that stopped it
+        # A file with the errors that stopped its type check
         def self.with_diagnostics: (path: Pathname, content: String, diagnostics: Array[Diagnostic::Ruby::Base]) -> SourceFile
 
         def self.with_typing: (path: Pathname, content: String, typing: Typing, ignores: Source::IgnoreRanges, node: Parser::AST::Node?) -> SourceFile
@@ -57,15 +57,6 @@ module Steep
       #
       def signature_diagnostics: () -> Hash[Pathname, Array[Diagnostic::Signature::Base]]
 
-      def diagnostics: () -> Hash[Pathname, Array[Diagnostic::Ruby::Base | Diagnostic::Signature::Base]]
-
-      # Yields diagnostics reported on each path
-      #
-      # * Signature diagnostics contains everything reported to each target
-      #
-      def each_diagnostics: () { ([Pathname, Array[Diagnostic::Ruby::Base] | Array[Diagnostic::Signature::Base]]) -> void } -> void
-                          | () -> Enumerator[[Pathname, Array[Diagnostic::Ruby::Base] | Array[Diagnostic::Signature::Base]], void]
-
       # Record the changes to the files managed by the service
       #
       # Note that the diagnostics are not updated by this method.
@@ -83,8 +74,8 @@ module Steep
       # * Returns `nil` if the type check doesn't complete.
       # * Returns the `SourceFile` with the `Typing` and the diagnostics otherwise, or with the errors that stopped the type check.
       #
-      # The returned file is not kept: `#source_files` keeps the content and the diagnostics of the file only, so that
-      # the workers hold no `Typing` after reporting the results to the master.
+      # The returned file is not kept: `#source_files` keeps the content of the file only, so that the workers hold
+      # neither the `Typing` nor the diagnostics after reporting the results to the master.
       #
       def typecheck_source: (path: Pathname, target: Project::Target?) -> SourceFile?
 

--- a/test/type_check_service_test.rb
+++ b/test/type_check_service_test.rb
@@ -106,17 +106,18 @@ RUBY
     }.tap do |changes|
       service.update(changes: changes)
 
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      file = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
 
-      service.source_files[Pathname("lib/core.rb")].tap do |file|
-        assert_any!(file.errors, size: 1) do |error|
-          assert_instance_of Diagnostic::Ruby::SyntaxError, error
-          assert_equal 1, error.location.line
-          assert_equal 13, error.location.column
-          assert_equal 2, error.location.last_line
-          assert_equal 0, error.location.last_column
-        end
+      assert_any!(file.errors, size: 1) do |error|
+        assert_instance_of Diagnostic::Ruby::SyntaxError, error
+        assert_equal 1, error.location.line
+        assert_equal 13, error.location.column
+        assert_equal 2, error.location.last_line
+        assert_equal 0, error.location.last_column
       end
+
+      # The service keeps the content of the file only
+      assert_nil service.source_files[Pathname("lib/core.rb")].errors
     end
   end
 
@@ -153,14 +154,12 @@ end
 RUBY
     }.tap do |changes|
       service.update(changes: changes)
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      file = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
 
-      service.source_files[Pathname("lib/core.rb")].tap do |file|
-        assert_any!(file.errors, size: 1) do |error|
-          assert_instance_of Diagnostic::Ruby::AnnotationSyntaxError, error
-          assert_equal "Array[", error.location.source
-          assert_equal "Syntax error caused by token `pEOF`", error.message
-        end
+      assert_any!(file.errors, size: 1) do |error|
+        assert_instance_of Diagnostic::Ruby::AnnotationSyntaxError, error
+        assert_equal "Array[", error.location.source
+        assert_equal "Syntax error caused by token `pEOF`", error.message
       end
     end
   end
@@ -184,12 +183,12 @@ RUBY
     }.tap do |changes|
       service.update(changes: changes)
 
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
-      service.typecheck_source(path: Pathname("lib/main.rb"), target: project.targets.find { _1.name == :main })
+      core = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
+      main = service.typecheck_source(path: Pathname("lib/main.rb"), target: project.targets.find { _1.name == :main }) or raise
 
-      assert_equal [], service.diagnostics.dig(Pathname("lib/core.rb"))
+      assert_equal [], core.diagnostics
 
-      service.diagnostics[Pathname("lib/main.rb")].tap do |errors|
+      main.diagnostics.tap do |errors|
         assert_equal 1, errors.size
         assert_instance_of Diagnostic::Ruby::UnresolvedOverloading, errors[0]
       end
@@ -224,13 +223,13 @@ RUBY
     }.tap do |changes|
       service.update(changes: changes)
 
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
-      service.typecheck_source(path: Pathname("lib/main.rb"), target: project.targets.find { _1.name == :main })
-      service.typecheck_source(path: Pathname("test/core_test.rb"), target: project.targets.find { _1.name == :test })
+      core = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
+      main = service.typecheck_source(path: Pathname("lib/main.rb"), target: project.targets.find { _1.name == :main }) or raise
+      core_test = service.typecheck_source(path: Pathname("test/core_test.rb"), target: project.targets.find { _1.name == :test }) or raise
 
-      assert_equal [], service.diagnostics.dig(Pathname("lib/core.rb"))
-      assert_equal [], service.diagnostics.dig(Pathname("lib/main.rb"))
-      assert_equal [], service.diagnostics.dig(Pathname("test/core_test.rb"))
+      assert_equal [], core.diagnostics
+      assert_equal [], main.diagnostics
+      assert_equal [], core_test.diagnostics
     end
   end
 
@@ -255,23 +254,23 @@ RUBY
     }.tap do |changes|
       service.update(changes: changes)
 
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
-      service.typecheck_source(path: Pathname("lib/main.rb"), target: project.targets.find { _1.name == :main })
-      service.typecheck_source(path: Pathname("test/core_test.rb"), target: project.targets.find { _1.name == :test })
+      core = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
+      main = service.typecheck_source(path: Pathname("lib/main.rb"), target: project.targets.find { _1.name == :main }) or raise
+      core_test = service.typecheck_source(path: Pathname("test/core_test.rb"), target: project.targets.find { _1.name == :test }) or raise
 
-      service.diagnostics[Pathname("lib/core.rb")].tap do |errors|
+      core.diagnostics.tap do |errors|
         assert_any!(errors, size: 1) do |error|
           assert_instance_of Diagnostic::Ruby::UnknownConstant, errors[0]
           assert_equal :CoreTest, error.name
         end
       end
-      service.diagnostics[Pathname("lib/main.rb")].tap do |errors|
+      main.diagnostics.tap do |errors|
         assert_any!(errors, size: 1) do |error|
           assert_instance_of Diagnostic::Ruby::UnknownConstant, errors[0]
           assert_equal :CoreTest, error.name
         end
       end
-      assert_equal [], service.diagnostics.dig(Pathname("test/core_test.rb"))
+      assert_equal [], core_test.diagnostics
     end
   end
 
@@ -291,13 +290,13 @@ RUBY
       service.validate_signature(path: Pathname("sig/core.rbs"), target: project.targets.find { _1.name == :core })
       service.validate_signature(path: Pathname("sig/main.rbs"), target: project.targets.find { _1.name == :main })
 
-      service.diagnostics[Pathname("sig/core.rbs")].tap do |errors|
+      service.signature_diagnostics[Pathname("sig/core.rbs")].tap do |errors|
         assert_any!(errors, size: 1) do |error|
           assert_instance_of Diagnostic::Signature::InvalidTypeApplication, error
         end
       end
 
-      assert_empty service.diagnostics[Pathname("sig/main.rbs")]
+      assert_empty service.signature_diagnostics[Pathname("sig/main.rbs")]
     end
   end
 
@@ -321,8 +320,8 @@ RBS
       service.validate_signature(path: Pathname("sig/core.rbs"), target: project.targets.find { _1.name == :core })
       service.validate_signature(path: Pathname("sig/main.rbs"), target: project.targets.find { _1.name == :main })
 
-      assert_empty service.diagnostics[Pathname("sig/core.rbs")]
-      assert_empty service.diagnostics[Pathname("sig/main.rbs")]
+      assert_empty service.signature_diagnostics[Pathname("sig/core.rbs")]
+      assert_empty service.signature_diagnostics[Pathname("sig/main.rbs")]
     end
   end
 
@@ -347,17 +346,17 @@ RBS
       service.validate_signature(path: Pathname("sig/main.rbs"), target: project.targets.find { _1.name == :main })
       service.validate_signature(path: Pathname("sig/core_test.rbs"), target: project.targets.find { _1.name == :test })
 
-      service.diagnostics[Pathname("sig/core.rbs")].tap do |errors|
+      service.signature_diagnostics[Pathname("sig/core.rbs")].tap do |errors|
         assert_any!(errors, size: 1) do |error|
           assert_instance_of Diagnostic::Signature::UnknownTypeName, error
         end
       end
-      service.diagnostics[Pathname("sig/main.rbs")].tap do |errors|
+      service.signature_diagnostics[Pathname("sig/main.rbs")].tap do |errors|
         assert_any!(errors, size: 1) do |error|
           assert_instance_of Diagnostic::Signature::UnknownTypeName, error
         end
       end
-      assert_empty service.diagnostics[Pathname("sig/core_test.rbs")]
+      assert_empty service.signature_diagnostics[Pathname("sig/core_test.rbs")]
     end
   end
 
@@ -377,7 +376,7 @@ RBS
       service.validate_signature(path: Pathname("sig/core.rbs"), target: project.targets.find { _1.name == :core })
 
       # SyntaxError is reported to all of the targets
-      service.diagnostics[Pathname("sig/core.rbs")].tap do |errors|
+      service.signature_diagnostics[Pathname("sig/core.rbs")].tap do |errors|
         assert_equal 4, errors.size
         errors.each do |error|
           assert_instance_of Diagnostic::Signature::SyntaxError, error
@@ -400,7 +399,7 @@ RBS
 
       service.validate_signature(path: Pathname("sig/core.rbs"), target: project.targets.find { _1.name == :core })
 
-      service.diagnostics[Pathname("sig/core.rbs")].tap do |errors|
+      service.signature_diagnostics[Pathname("sig/core.rbs")].tap do |errors|
         assert_any!(errors, size: 1) do |error|
           assert_instance_of Diagnostic::Signature::UnknownTypeName, errors[0]
           assert_equal "Cannot find type `::Foo::Bar`", error.header_line
@@ -425,9 +424,9 @@ RBS
       RUBY
     }.tap do |changes|
       service.update(changes: changes)
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      file = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
 
-      assert_equal [], service.diagnostics[Pathname("lib/core.rb")]
+      assert_equal [], file.diagnostics
     end
   end
 
@@ -448,11 +447,11 @@ RBS
     }.tap do |changes|
       service.update(changes: changes)
 
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      file = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
 
       assert_equal(
         [Diagnostic::Ruby::NoMethod, Diagnostic::Ruby::InvalidIgnoreComment, Diagnostic::Ruby::InvalidIgnoreComment],
-        service.diagnostics[Pathname("lib/core.rb")].map {|d| d.class }
+        file.diagnostics.map {|d| d.class }
       )
     end
   end
@@ -482,14 +481,14 @@ RUBY
     }.tap do |changes|
       service.update(changes: changes)
 
-      service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core })
+      file = service.typecheck_source(path: Pathname("lib/core.rb"), target: project.targets.find { _1.name == :core }) or raise
 
-      assert_any!(service.diagnostics[Pathname("lib/core.rb")]) do |error|
+      assert_any!(file.diagnostics) do |error|
         assert_instance_of Diagnostic::Ruby::RedundantIgnoreComment, error
         assert_equal "steep:ignore", error.location.source
       end
 
-      assert_any!(service.diagnostics[Pathname("lib/core.rb")]) do |error|
+      assert_any!(file.diagnostics) do |error|
         assert_instance_of Diagnostic::Ruby::RedundantIgnoreComment, error
         assert_equal "steep:ignore:start\n1+2\n# steep:ignore:end", error.location.source
       end


### PR DESCRIPTION
After reporting the diagnostics of a file to the master, the typecheck worker kept the `Diagnostic` objects in its `TypeCheckService`, and they retain the AST nodes and the types they mention. Nothing reads them after the report, so the service now keeps the content of the file only, as it already does for the `Typing` since #2298. For steep itself, this is about 35 MB in a worker that checks every file.

`TypeCheckService#diagnostics` and `#each_diagnostics` go with it. The tests were the only callers, and they read the diagnostics from the file `#typecheck_source` returns, or from `#signature_diagnostics` for RBS files.